### PR TITLE
fix: remove empty space created for response_type param in authz url created by admin ui #55

### DIFF
--- a/admin-ui/app/utils/AppAuthProvider.js
+++ b/admin-ui/app/utils/AppAuthProvider.js
@@ -41,8 +41,7 @@ class AppAuthProvider extends Component {
       console.warn('Parameters to process authz code flow are missing.')
       return
     }
-    return `${authzBaseUrl}?response_type=${responseType}
-     &redirect_uri=${redirectUrl}&client_id=${clientId}&scope=${scope}&state=${state}&nonce=${nonce}`
+    return `${authzBaseUrl}?response_type=${responseType}&redirect_uri=${redirectUrl}&client_id=${clientId}&scope=${scope}&state=${state}&nonce=${nonce}`
   }
   constructor() {
     super()


### PR DESCRIPTION
[…](https://github.com/GluuFederation/flex/issues/55)