### PR TITLE
ci: fix sonarcloud project id for casa

### DIFF
--- a/casa/pom.xml
+++ b/casa/pom.xml
@@ -32,7 +32,7 @@
         <resteasy.version>4.7.2.Final</resteasy.version>
         <tika.version>2.1.0</tika.version>
         <!-- SonarCloud integration properties -->
-        <sonar.projectKey>GluuFederation_casa</sonar.projectKey>
+        <sonar.projectKey>GluuFederation_flex_casa</sonar.projectKey>
         <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
         <sonar.organization>gluufederation</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
Sonarcloud project ID needed to be in correct case. Camel case. 
I also added `flex` as it would otherwise clash with existing casa project id in sonarcloud.