### PR TITLE
ci: add codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,5 @@
 /flex-cn-setup/ @moabu @iromli
 /.github/ @moabu @iromli
 /docker-*/ @moabu @iromli
-/admin-ui/ @syntrydy @duttarnab
+/admin-ui/ @syntrydy @duttarnab @mjatin-dev
 /casa/ @jgomer2001 @maduvena


### PR DESCRIPTION
Upon a request from @duttarnab , @mjatin-dev has been added to the codeowners of admin-ui