### PR TITLE
chore: sync casa image

### DIFF
--- a/docker-casa/Dockerfile
+++ b/docker-casa/Dockerfile
@@ -7,7 +7,7 @@ FROM bellsoft/liberica-openjre-alpine:11.0.13-8
 RUN apk update \
     && apk add --no-cache py3-pip openssl tini py3-cryptography py3-lxml py3-psycopg2 \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
-    && apk add --no-cache --virtual build-deps git wget \
+    && apk add --no-cache --virtual build-deps git wget zip \
     && mkdir -p /usr/java/latest \
     && ln -sf /usr/lib/jvm/jre /usr/java/latest/jre
 
@@ -35,16 +35,19 @@ EXPOSE 8080
 # ====
 
 ENV GLUU_VERSION=5.0.0-SNAPSHOT
-ENV GLUU_BUILD_DATE='2022-03-02 11:52'
+ENV GLUU_BUILD_DATE='2022-03-08 12:42'
 ENV GLUU_SOURCE_URL=https://jenkins.gluu.org/maven/org/gluu/casa/${GLUU_VERSION}/casa-${GLUU_VERSION}.war
 
 # Install Casa
-RUN wget -q ${GLUU_SOURCE_URL} -O /tmp/casa.war \
-    && mkdir -p ${JETTY_BASE}/casa/webapps/casa \
-    && unzip -qq /tmp/casa.war -d ${JETTY_BASE}/casa/webapps/casa \
+COPY jetty/jetty-env.xml /tmp/WEB-INF/jetty-env.xml
+RUN mkdir -p ${JETTY_BASE}/casa/webapps \
+    && wget -q ${GLUU_SOURCE_URL} -O /tmp/casa.war \
+    && cd /tmp \
+    && zip -d casa.war WEB-INF/jetty-web.xml \
+    && zip -r casa.war WEB-INF/jetty-env.xml \
+    && cp casa.war ${JETTY_BASE}/casa/webapps/casa.war \
     && java -jar ${JETTY_HOME}/start.jar jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}/casa --add-module=server,deploy,resources,http,jsp,cdi-decorate \
-    && rm -f /tmp/casa.war \
-    && rm -f ${JETTY_BASE}/casa/webapps/casa/WEB-INF/jetty-web.xml
+    && rm -rf /tmp/casa.war /tmp/WEB-INF
 
 # ======
 # Python
@@ -65,8 +68,7 @@ RUN apk del build-deps \
 # License
 # =======
 
-RUN mkdir -p /licenses
-COPY LICENSE /licenses/
+COPY LICENSE /licenses/LICENSE
 
 # ==========
 # Config ENV
@@ -166,10 +168,9 @@ RUN mkdir -p /etc/certs \
     /opt/jans/python/libs \
     /opt/jans/jetty/casa/static \
     /opt/jans/jetty/casa/plugins \
-    /app/templates \
-    /app/tmp
+    /opt/jetty/temp
 
-COPY jetty/jetty-env.xml ${JETTY_BASE}/casa/webapps/casa/WEB-INF/
+COPY jetty/casa.xml ${JETTY_BASE}/casa/webapps/
 COPY jetty/log4j2.xml ${JETTY_BASE}/casa/resources/
 COPY jetty/casa_web_resources.xml ${JETTY_BASE}/casa/webapps/
 COPY templates /app/templates/

--- a/docker-casa/Dockerfile
+++ b/docker-casa/Dockerfile
@@ -35,7 +35,7 @@ EXPOSE 8080
 # ====
 
 ENV GLUU_VERSION=5.0.0-SNAPSHOT
-ENV GLUU_BUILD_DATE='2022-03-08 12:42'
+ENV GLUU_BUILD_DATE='2022-03-09 20:14'
 ENV GLUU_SOURCE_URL=https://jenkins.gluu.org/maven/org/gluu/casa/${GLUU_VERSION}/casa-${GLUU_VERSION}.war
 
 # Install Casa

--- a/docker-casa/jetty/casa.xml
+++ b/docker-casa/jetty/casa.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"  encoding="ISO-8859-1"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_10_0.dtd">
+
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+    <Set name="contextPath">/casa</Set>
+    <Set name="war">
+        <Property name="jetty.webapps" default="." />/casa.war
+    </Set>
+    <Set name="extractWAR">true</Set>
+    <!-- <Set name="extraClasspath">%(extra_classpath)s</Set> -->
+</Configure>

--- a/docker-casa/jetty/log4j2.xml
+++ b/docker-casa/jetty/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="ERROR">
     <Appenders>
-        <Console name="STDOUT" target="SYSTEM_OUT">
+        <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{dd-MM HH:mm:ss.SSS} %-5p %C{4} %F:%L- %m%n" />
         </Console>
         <RollingFile name="LOG_FILE" fileName="${sys:log.base}/logs/casa.log" filePattern="${sys:log.base}/logs/casa-%d{yyyy-MM-dd}-%i.log">
@@ -24,12 +24,12 @@
         <Logger name="org.gluu.casa.timer" level="$timer_log_level" additivity="false">
             <AppenderRef ref="$timer_log_target" />
         </Logger>
-        <Logger name="org.gluu.casa" level="$casa_log_level">
+        <Logger name="org.gluu.casa" level="$casa_log_level" additivity="false">
             <!-- Configuration of this logger is tightly coupled with class org.gluu.casa.core.LogService -->
             <AppenderRef ref="$casa_log_target" />
         </Logger>
         <Root level="ERROR">
-            <AppenderRef ref="STDOUT" />
+            <AppenderRef ref="Console" />
         </Root>
     </Loggers>
 

--- a/docker-casa/scripts/bootstrap.py
+++ b/docker-casa/scripts/bootstrap.py
@@ -114,9 +114,14 @@ def configure_logging():
         "casa_log_target": "LOG_FILE",
         "timer_log_target": "TIMERS_FILE",
     }
-    for key, value in file_aliases.items():
-        if config[key] == "FILE":
-            config[key] = value
+    for key, value in config.items():
+        if not key.endswith("_target"):
+            continue
+
+        if value == "STDOUT":
+            config[key] = "Console"
+        else:
+            config[key] = file_aliases[key]
 
     logfile = "/opt/jans/jetty/casa/resources/log4j2.xml"
     with open(logfile) as f:

--- a/docker-casa/scripts/entrypoint.sh
+++ b/docker-casa/scripts/entrypoint.sh
@@ -42,6 +42,7 @@ exec java \
     -Dserver.base=/opt/jans/jetty/casa \
     -Dlog.base=/opt/jans/jetty/casa \
     -Dpython.home=/opt/jython \
+    -Djava.io.tmpdir=/opt/jetty/temp \
     -Dlog4j2.configurationFile=resources/log4j2.xml \
     ${CN_JAVA_OPTIONS} \
     -jar /opt/jetty/start.jar


### PR DESCRIPTION
Overview:

- use `casa.war` instead of exploded war to avoid hot-deployment issue
- update `casa.war` source (contains fix with logging)
- sync `log4j2.xml`