### PR TITLE
refactor: set arguments for jetty via command-line

### DIFF
--- a/docker-casa/scripts/bootstrap.py
+++ b/docker-casa/scripts/bootstrap.py
@@ -58,15 +58,6 @@ def modify_jetty_xml():
         f.write(updates)
 
 
-def modify_server_ini():
-    with open("/opt/jans/jetty/casa/start.d/server.ini", "a") as f:
-        updates = "\n".join([
-            # disable server version info
-            "jetty.httpConfig.sendServerVersion=false",
-        ])
-        f.write(updates)
-
-
 def configure_logging():
     # default config
     config = {
@@ -183,7 +174,6 @@ def main():
 
     modify_jetty_xml()
     modify_webdefault_xml()
-    modify_server_ini()
     configure_logging()
 
 

--- a/docker-casa/scripts/entrypoint.sh
+++ b/docker-casa/scripts/entrypoint.sh
@@ -45,4 +45,4 @@ exec java \
     -Djava.io.tmpdir=/opt/jetty/temp \
     -Dlog4j2.configurationFile=resources/log4j2.xml \
     ${CN_JAVA_OPTIONS} \
-    -jar /opt/jetty/start.jar
+    -jar /opt/jetty/start.jar jetty.httpConfig.sendServerVersion=false jetty.deploy.scanInterval=0


### PR DESCRIPTION
The following jetty arguments are passed via command-line (entrypoint):

- `jetty.httpConfig.sendServerVersion=false` to disable server info
- `jetty.deploy.scanInterval=0` to disable hot-deployment