### PR TITLE
feat(lodash): update lodash import to be more readable and smaller

### DIFF
--- a/admin-ui/app/colors.js
+++ b/admin-ui/app/colors.js
@@ -1,9 +1,9 @@
-import _ from 'lodash';
+import chain from 'lodash/chain';
+import pick from 'lodash/pick';
 
 import colors from './colors.scss';
 
-const colorKeys = _
-  .chain(colors)
+const colorKeys = chain(colors)
   .keys()
   .filter((colorKey) => (
     colorKey.indexOf('bg-') === -1 &&
@@ -11,4 +11,4 @@ const colorKeys = _
   ))
   .value();
 
-export default _.pick(colors, colorKeys);
+export default pick(colors, colorKeys);

--- a/admin-ui/app/colors.js
+++ b/admin-ui/app/colors.js
@@ -1,5 +1,4 @@
-import chain from 'lodash/chain';
-import pick from 'lodash/pick';
+import { chain, pick } from 'lodash';
 
 import colors from './colors.scss';
 

--- a/admin-ui/app/components/Avatar/Avatar.js
+++ b/admin-ui/app/components/Avatar/Avatar.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import _ from 'lodash';
+import filter from 'lodash/filter';
+import find from 'lodash/find';
+import reduce from 'lodash/reduce';
+import isEmpty from 'lodash/isEmpty';
+import first from 'lodash/first';
 
 const Avatar = (props) => {
   const avatarClass = classNames(
@@ -10,11 +14,11 @@ const Avatar = (props) => {
     props.className
   );
   const addOnsdArr = React.Children.toArray(props.addOns);
-  const badge = _.find(addOnsdArr, (avatarAddOn) =>
+  const badge = find(addOnsdArr, (avatarAddOn) =>
     avatarAddOn.type.addOnId === "avatar--badge");
-  const icons = _.filter(addOnsdArr, (avatarAddOn) =>
+  const icons = filter(addOnsdArr, (avatarAddOn) =>
     avatarAddOn.type.addOnId === "avatar--icon");
-  const isNested = _.reduce(addOnsdArr, (acc, avatarAddOn) =>
+  const isNested = reduce(addOnsdArr, (acc, avatarAddOn) =>
     acc || !!avatarAddOn.props.small, false);
 
   return (
@@ -27,12 +31,12 @@ const Avatar = (props) => {
         )
       }
       {
-        !_.isEmpty(icons) && (() => {
+        !isEmpty(icons) && (() => {
           switch(icons.length) {
           case 1:
             return (
               <div className="avatar__icon">
-                { _.first(icons) }
+                { first(icons) }
               </div>
             );
           default:

--- a/admin-ui/app/components/Avatar/AvatarImage.js
+++ b/admin-ui/app/components/Avatar/AvatarImage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import _ from 'lodash';
+import omit from 'lodash/omit';
 
 import { Avatar } from './Avatar';
 import { AvatarFont } from './AvatarFont';
@@ -12,7 +12,7 @@ class AvatarImage extends React.PureComponent {
       placeholder: PropTypes.node,
       alt: PropTypes.string,
       className: PropTypes.string,
-      ..._.omit(Avatar.propTypes, ['children'])
+      ...omit(Avatar.propTypes, ['children'])
     };
 
     static defaultProps = {

--- a/admin-ui/app/components/EmptyLayout/EmptyLayoutSection.js
+++ b/admin-ui/app/components/EmptyLayout/EmptyLayoutSection.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import isNumber from 'lodash';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -7,7 +7,7 @@ const EmptyLayoutSection = (props) => {
   const sectionClass = classNames(props.className, 'fullscreen__section', {
     'fullscreen__section--center': props.center
   });
-  const maxWidth = _.isNumber(props.width) ? `${props.width}px` : props.width;
+  const maxWidth = isNumber(props.width) ? `${props.width}px` : props.width;
   return (
     <div className={ sectionClass }>
       {

--- a/admin-ui/app/components/FloatGrid/Col.js
+++ b/admin-ui/app/components/FloatGrid/Col.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import { isUndefined, omit, pick, keys, extend } from 'lodash';
 import classNames from 'classnames';
 
 import { Col as BootstrapCol } from 'reactstrap';
@@ -18,8 +18,8 @@ const getCurrentbreakPoint = (width, breakPoints) => {
   let output = 'xl';
   for (const bp of breakPoints) {
     if (
-      (_.isUndefined(bp.min) || bp.min <= width) &&
-            (_.isUndefined(bp.max) || bp.max > width)
+      (isUndefined(bp.min) || bp.min <= width) &&
+            (isUndefined(bp.max) || bp.max > width)
     ) {
       output = bp.id;
     }
@@ -66,8 +66,8 @@ export class Col extends React.Component {
 
     render() {
       const { active, children, className, trueSize } = this.props;
-      const bsColumnProps = _.pick(this.props, ['xl', 'lg', 'md', 'sm', 'xs']);
-      const otherProps = _.omit(this.props, [..._.keys(Col.propTypes),
+      const bsColumnProps = pick(this.props, ['xl', 'lg', 'md', 'sm', 'xs']);
+      const otherProps = omit(this.props, [...keys(Col.propTypes),
         'minW', 'maxW', 'minH', 'maxH', 'moved', 'static', 'isDraggable', 'isResizable']);
       const floatColBpId = trueSize ? getCurrentbreakPoint(trueSize.wPx, breakPoints) : 'xl';
       const floatColClasses = classNames(className, 'float-col',
@@ -79,7 +79,7 @@ export class Col extends React.Component {
         </div>
       ) : (
         <BootstrapCol
-          { ...(_.extend(bsColumnProps, otherProps)) }
+          { ...(extend(bsColumnProps, otherProps)) }
           className={ classNames(className, 'pb-3') }
         >
           { children }

--- a/admin-ui/app/components/FloatGrid/Row.js
+++ b/admin-ui/app/components/FloatGrid/Row.js
@@ -1,6 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import { 
+  keys,
+  map,
+  isEqual,
+  isEmpty,
+  drop,
+  isUndefined,
+  pick,
+  indexOf,
+  max
+} from 'lodash';
 import {
   WidthProvider,
   Responsive
@@ -14,10 +24,10 @@ const responsiveBreakpoints = {
   xl: 1139, lg: 959, md: 719, sm: 539, xs: 0
   //xl: Number.MAX_VALUE, lg: 1199, md: 991, sm: 767, xs: 576
 };
-const breakPointSteps = _.keys(responsiveBreakpoints);
+const breakPointSteps = keys(responsiveBreakpoints);
 const TOTAL_ROW = 12;
 
-const simplifyChildrenArray = (reactChildren) => _.map(reactChildren, child => (
+const simplifyChildrenArray = (reactChildren) => map(reactChildren, child => (
   { ...child, key: child.key.replace(/\.\$/g, '') }
 ));
 
@@ -40,8 +50,8 @@ export class Row extends React.Component {
     initialDebounceTimeout = false;
 
     componentDidUpdate(nextProps) {
-      if (!_.isEqual(nextProps.gridSize, this.props.gridSize)) {
-        if (!_.isEmpty(this._lastLayouts)) {
+      if (!isEqual(nextProps.gridSize, this.props.gridSize)) {
+        if (!isEmpty(this._lastLayouts)) {
           this._updateTrueColSizes(this._lastLayouts[this.state.activeLayout]);
         }
       }
@@ -121,8 +131,8 @@ export class Row extends React.Component {
      */
     _findClosestBreakpoint = (breakpoint, definition) => {
       let found = 12;
-      for (const bp of _.drop(breakPointSteps, _.indexOf(breakPointSteps, breakpoint))) {
-        if (!_.isUndefined(definition[bp])) {
+      for (const bp of drop(breakPointSteps, indexOf(breakPointSteps, breakpoint))) {
+        if (!isUndefined(definition[bp])) {
           found = definition[bp];
         }
       }
@@ -139,7 +149,7 @@ export class Row extends React.Component {
         for (const child of childrenArray) {
           let bpData = { };
           // Save the props for current child and breakpoint
-          const config = _.pick(child.props, [
+          const config = pick(child.props, [
             'i',
             'h', 'minH', 'maxH',
             'minW', 'maxW',
@@ -153,7 +163,7 @@ export class Row extends React.Component {
             ...{
               // Set the x to the calculated value or take from the 
               // props if defined for controlled type
-              x: _.isUndefined(child.props[`${breakPoint}X`]) ?
+              x: isUndefined(child.props[`${breakPoint}X`]) ?
                 rowCounter : child.props[`${breakPoint}X`],
               h: child.props[`${breakPoint}H`] || config.h || 1,
               minH: config.minH || (config.h || 1),
@@ -163,14 +173,14 @@ export class Row extends React.Component {
                         this._findClosestBreakpoint(breakPoint, child.props),
             // Set the y to the calculated value or take from the 
             // props if defined for controlled type
-            y: _.isUndefined(child.props[`${breakPoint}Y`]) ?
+            y: isUndefined(child.props[`${breakPoint}Y`]) ?
               y : child.props[`${breakPoint}Y`]
           });
           rowChildren = [...rowChildren, bpData];
           rowCounter += bpData.w;
           if (rowCounter + bpData.x > TOTAL_ROW) {
             // Increase by the largest found height
-            y += _.max(_.map(rowChildren, 'h'));
+            y += max(map(rowChildren, 'h'));
             rowCounter = 0;
             rowChildren = [];
           }

--- a/admin-ui/app/components/HolderProvider/HolderTextProvider.js
+++ b/admin-ui/app/components/HolderProvider/HolderTextProvider.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import omit from 'lodash/omit';
 import uid from 'uuid/v4';
 import qs from 'query-string';
 
@@ -78,7 +78,7 @@ class HolderTextProvider extends React.Component {
     render() {
       const onlyChild = React.Children.only(this.props.children);
 
-      const phProps = _.omit(this.props, ['children', 'width', 'height']);
+      const phProps = omit(this.props, ['children', 'width', 'height']);
       const phPropsQuery = qs.stringify(phProps);
 
       return React.cloneElement(onlyChild, {

--- a/admin-ui/app/components/InputGroupAddon/InputGroupAddon.js
+++ b/admin-ui/app/components/InputGroupAddon/InputGroupAddon.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import _ from 'lodash';
+import some from 'lodash/some';
+import includes from 'lodash/includes';
 
 import {
   InputGroupAddon as BsInputGroupAddon
@@ -8,9 +9,9 @@ import {
 const InputGroupAddon = (props) => {
   const { children, ...otherProps } = props;
   const childArr = React.Children.toArray(children);
-  const isFa = _.some(childArr, (child) =>
-    React.isValidElement(child) && child.props.className && _.includes(child.props.className, 'fa'));
-  const isCheckRadio = _.some(childArr, (child) =>
+  const isFa = some(childArr, (child) =>
+    React.isValidElement(child) && child.props.className && includes(child.props.className, 'fa'));
+  const isCheckRadio = some(childArr, (child) =>
     React.isValidElement(child) && (child.props.type === 'radio' || child.props.type === 'checkbox'));
 
   const child = isFa || isCheckRadio ? (

--- a/admin-ui/app/components/Layout/Layout.js
+++ b/admin-ui/app/components/Layout/Layout.js
@@ -4,7 +4,15 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Helmet } from 'react-helmet';
 import { withRouter } from 'react-router-dom';
-import _ from 'lodash';
+import {
+  filter,
+  forOwn,
+  isUndefined,
+  compact,
+  differenceBy,
+  pick,
+  map 
+} from 'lodash';
 
 import { LayoutContent } from './LayoutContent';
 import { LayoutNavbar } from './LayoutNavbar';
@@ -26,7 +34,7 @@ const findChildByType = (children, targetType) => {
   return result;
 };
 const findChildrenByType = (children, targetType) => {
-  return _.filter(React.Children.toArray(children), (child) =>
+  return filter(React.Children.toArray(children), (child) =>
     child.type.layoutPartName === targetType.layoutPartName);
 };
 
@@ -73,12 +81,12 @@ class Layout extends React.Component {
         const { screenSize } = this.state;
         let currentScreenSize;
 
-        _.forOwn(responsiveBreakpoints, (value, key) => {
+        forOwn(responsiveBreakpoints, (value, key) => {
           const queryParts = [
-            `${ _.isUndefined(value.min) ? '' : `(min-width: ${value.min}px)` }`,
-            `${ _.isUndefined(value.max) ? '' : `(max-width: ${value.max}px)`}`
+            `${ isUndefined(value.min) ? '' : `(min-width: ${value.min}px)` }`,
+            `${ isUndefined(value.max) ? '' : `(max-width: ${value.max}px)`}`
           ];
-          const query = _.compact(queryParts).join(' and ');
+          const query = compact(queryParts).join(' and ');
 
           if (window.matchMedia(query).matches) {
             currentScreenSize = key;
@@ -196,7 +204,7 @@ class Layout extends React.Component {
     }
 
     setElementsVisibility(elements) {
-      this.setState(_.pick(elements, ['sidebarHidden', 'navbarHidden', 'footerHidden']));
+      this.setState(pick(elements, ['sidebarHidden', 'navbarHidden', 'footerHidden']));
     }
 
     render() {
@@ -204,7 +212,7 @@ class Layout extends React.Component {
       const sidebar = findChildByType(children, LayoutSidebar);
       const navbars = findChildrenByType(children, LayoutNavbar);
       const content = findChildByType(children, LayoutContent);
-      const otherChildren = _.differenceBy(
+      const otherChildren = differenceBy(
         React.Children.toArray(children),
         [
           sidebar,
@@ -237,7 +245,7 @@ class Layout extends React.Component {
             <link rel="canonical" href={ config.siteCannonicalUrl } />
             <meta name="description" content={ this.state.pageDescription } />
             {
-              _.map(favIcons, (favIcon, index) => (
+              map(favIcons, (favIcon, index) => (
                 <link { ...favIcon } key={ index } />
               ))
             }

--- a/admin-ui/app/components/Layout/setupPage.js
+++ b/admin-ui/app/components/Layout/setupPage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import pick from 'lodash/pick';
 import PropTypes from 'prop-types';
 import { withPageConfig } from './withPageConfig';
 
@@ -10,7 +10,7 @@ export const setupPage = (startupConfig) =>
               pageConfig: PropTypes.object
             }
             componentDidMount() {
-              this.prevConfig = _.pick(this.props.pageConfig,
+              this.prevConfig = pick(this.props.pageConfig,
                 ['pageTitle', 'pageDescription', 'pageKeywords']);
               this.props.pageConfig.changeMeta(startupConfig);
             }

--- a/admin-ui/app/components/OuterClick/OuterClick.js
+++ b/admin-ui/app/components/OuterClick/OuterClick.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import _ from 'lodash';
+import some from 'lodash/some';
 
 // Safely gets the browser document object,
 // returns a simple mock for server rendering purposes
@@ -54,7 +54,7 @@ class OuterClick extends React.Component {
           // eslint-disable-next-line react/no-find-dom-node
           const domElement = ReactDOM.findDOMNode(this.elementRef);
   
-          const isExcluded = _.some(this.props.excludedElements,
+          const isExcluded = some(this.props.excludedElements,
             // eslint-disable-next-line react/no-find-dom-node
             (element) => element && ReactDOM.findDOMNode(element).contains(evt.target));
   

--- a/admin-ui/app/components/SidebarMenu/SidebarMenu.js
+++ b/admin-ui/app/components/SidebarMenu/SidebarMenu.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { withRouter } from 'react-router-dom'
-import _ from 'lodash'
+import find from 'lodash/find'
+import includes from 'lodash/includes'
+import mapValues from 'lodash/mapValues'
 import classNames from 'classnames'
 import { withPageConfig } from './../Layout/withPageConfig'
 import Common from './../../common'
@@ -65,7 +67,7 @@ class SidebarMenu extends React.Component {
       return previous
     }
 
-    const activeChild = _.find(this.state.entries, (entry) => {
+    const activeChild = find(this.state.entries, (entry) => {
       const { pathname } = this.props.location
 
       const noTailSlashLocation =
@@ -75,7 +77,7 @@ class SidebarMenu extends React.Component {
 
       return entry.exact
         ? entry.url === noTailSlashLocation
-        : _.includes(noTailSlashLocation, entry.url)
+        : includes(noTailSlashLocation, entry.url)
     })
 
     if (activeChild) {
@@ -85,8 +87,8 @@ class SidebarMenu extends React.Component {
       ]
 
       this.setState({
-        entries: (this.entries = _.mapValues(this.entries, (entry) => {
-          const isActive = _.includes(activeEntries, entry.id)
+        entries: (this.entries = mapValues(this.entries, (entry) => {
+          const isActive = includes(activeEntries, entry.id)
 
           return {
             ...entry,

--- a/admin-ui/app/components/Theme/ThemeSelector.js
+++ b/admin-ui/app/components/Theme/ThemeSelector.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import map from 'lodash/map';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import {
@@ -83,7 +83,7 @@ class ThemeSelector extends React.Component {
                   Nav Color
                 </span>
                 {
-                  _.map(this.props.colorOptions, (option, index) => (
+                  map(this.props.colorOptions, (option, index) => (
                     <CustomInput
                       key={ index }
                       type="radio"
@@ -113,7 +113,7 @@ class ThemeSelector extends React.Component {
                   Nav Style
                 </span>
                 {
-                  _.map(this.props.styleOptions, (option, index) => (
+                  map(this.props.styleOptions, (option, index) => (
                     <CustomInput
                       key={ index }
                       type="radio"

--- a/admin-ui/app/components/UncontrolledTabs/UncontrolledTabsNavLink.js
+++ b/admin-ui/app/components/UncontrolledTabs/UncontrolledTabsNavLink.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import _ from 'lodash';
+import omit from 'lodash/omit';
 import { NavLink } from 'reactstrap';
 
 import { Consumer } from './context';
@@ -11,7 +11,7 @@ const UncontrolledTabsNavLink = (props) => (
     {
       (value) => (
         <NavLink
-          { ..._.omit(props, ['tabId']) }
+          { ...omit(props, ['tabId']) }
           onClick={ () => { value.setActiveTabId(props.tabId); } }
           className={ classNames({ active: props.tabId === value.activeTabId }) }
           href="#"

--- a/admin-ui/app/components/Wizard/Wizard.js
+++ b/admin-ui/app/components/Wizard/Wizard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import isUndefined from 'lodash/isUndefined';
+import map from 'lodash/map';
 
 import './../../styles/components/wizard.scss';
 
@@ -40,7 +41,7 @@ export class Wizard extends React.Component {
 
     getActiveStep() {
       const { activeStep, onStepChanged } = this.props;
-      if (_.isUndefined(activeStep) || _.isUndefined(onStepChanged)) {
+      if (isUndefined(activeStep) || isUndefined(onStepChanged)) {
         return this.state.activeStep;
       }
       return this.props.activeStep;
@@ -53,7 +54,7 @@ export class Wizard extends React.Component {
       return (
         <div className='wizard'>
           {
-            _.map(children, (child, index) => (
+            map(children, (child, index) => (
               React.cloneElement(child, {
                 onClick: () => {this.stepClick(child.props.id || '');},
                 active: child.props.id === activeStep,

--- a/admin-ui/app/routes/Layouts/DragAndDropLayout/DragAndDropLayout.js
+++ b/admin-ui/app/routes/Layouts/DragAndDropLayout/DragAndDropLayout.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import v4 from 'uuid/v4';
-import chain from 'lodash/chain';
-import random from 'lodash/random';
-import mapValues from 'lodash/mapValues';
+import {
+  chain,
+  random,
+  mapValues
+} from 'lodash';
 
 import {
   Container,

--- a/admin-ui/app/routes/Layouts/DragAndDropLayout/DragAndDropLayout.js
+++ b/admin-ui/app/routes/Layouts/DragAndDropLayout/DragAndDropLayout.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import v4 from 'uuid/v4';
-import _ from 'lodash';
+import chain from 'lodash/chain';
+import random from 'lodash/random';
+import mapValues from 'lodash/mapValues';
 
 import {
   Container,
@@ -147,7 +149,7 @@ export class DragAndDropLayout extends React.Component {
             rowHeight={ 55 }
           >
             {
-              _.chain(this.state.layouts)
+              chain(this.state.layouts)
                 .keys()
                 .map((layoutKey) => (
                   <Grid.Col {...applyColumn(layoutKey, this.state.layouts)} key={ layoutKey }>
@@ -178,7 +180,7 @@ export class DragAndDropLayout extends React.Component {
         let availableRow = TOTAL_ROWS;
         while (availableRow > 0) {
           const newCol = availableRow < TOTAL_ROWS ? availableRow : 
-            _.random(3, 9);
+            random(3, 9);
 
           availableRow -= newCol;
           output = {
@@ -192,7 +194,7 @@ export class DragAndDropLayout extends React.Component {
     }
 
     _generateTexts = (layouts) =>
-      _.mapValues(layouts, () => ({
+      mapValues(layouts, () => ({
         title: 'faker.commerce.productName()',
         desc: 'faker.lorem.paragraph()'
       }))

--- a/admin-ui/app/routes/components/Analytics/TinyAreaChart.js
+++ b/admin-ui/app/routes/components/Analytics/TinyAreaChart.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import times from 'lodash/times';
 import {  
   ResponsiveContainer,
   AreaChart, 
@@ -9,7 +9,7 @@ import {
 
 import colors from './../../../colors';
 
-const data = _.times(20, () => ({ pv: Math.random() * 100 }));
+const data = times(20, () => ({ pv: Math.random() * 100 }));
 
 const TinyAreaChart = ({ height }) => (
   <ResponsiveContainer width='100%' height={ height }>

--- a/admin-ui/app/routes/components/Analytics/TinyAreaChartSpend.js
+++ b/admin-ui/app/routes/components/Analytics/TinyAreaChartSpend.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import times from 'lodash/times';
 import {  
   ResponsiveContainer,
   AreaChart, 
@@ -8,7 +8,7 @@ import {
 
 import colors from './../../../colors';
 
-const data = _.times(20, () => ({ pv: Math.random() * 100 }));
+const data = times(20, () => ({ pv: Math.random() * 100 }));
 
 const TinyAreaChartSpend = () => (
   <ResponsiveContainer width='100%' height={ 125 }>

--- a/admin-ui/app/routes/components/Analytics/TrTableTrafficChannels.js
+++ b/admin-ui/app/routes/components/Analytics/TrTableTrafficChannels.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import times from 'lodash/times';
 
 import { randomArray } from './../../../utilities';
 
@@ -24,7 +24,7 @@ const change = [
 const TrTableTrafficChannels = () => (
   <React.Fragment>
     {
-      _.times(5, (index) => (
+      times(5, (index) => (
         <tr key={ index }>
           <td className="align-middle text-inverse">
             { randomArray(channel) }

--- a/admin-ui/app/routes/components/Colors/CardRgbaColor.js
+++ b/admin-ui/app/routes/components/Colors/CardRgbaColor.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import times from 'lodash/times';
 import { 
   Card, 
   CardBody, 
@@ -14,7 +14,7 @@ import { InfoPopover } from './InfoPopover';
 const CardRgbaColor = (props) => (
   <Card className={ `mb-3 ${ props.cardClass }` }>
     {
-      _.times(9, (index) => {
+      times(9, (index) => {
         let Tag = CardFooter;
         Tag = index === 0 ? CardHeader : CardBody;
         Tag = index === 8 ? CardFooter : CardBody;

--- a/admin-ui/app/routes/components/Financial/TrTableInvoices.js
+++ b/admin-ui/app/routes/components/Financial/TrTableInvoices.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import times from 'lodash/times';
 
 import {  
   Media, 
@@ -15,7 +15,7 @@ const TrTableInvoices = () => {
   return (
     <React.Fragment>
       {
-        _.times(6, (index) => (
+        times(6, (index) => (
           <tr key={ index }>
             <td className="align-middle">
               <span className="text-inverse">{ 'faker.company.companyName()' }</span><br />

--- a/admin-ui/app/routes/components/Financial/TrTableRecentFundings.js
+++ b/admin-ui/app/routes/components/Financial/TrTableRecentFundings.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import times from 'lodash/times';
 import { useTranslation } from 'react-i18next'
 
 const TrTableRecentFundings = () => {
@@ -7,7 +7,7 @@ const TrTableRecentFundings = () => {
   return (
     <React.Fragment>
       {
-        _.times(6, (index) => (
+        times(6, (index) => (
           <tr key={ index }>
             <td className="align-middle">
               <span className="text-inverse">{ 'faker.company.companyName()' }</span>

--- a/admin-ui/app/routes/components/Monitor/TrTableMonitor.js
+++ b/admin-ui/app/routes/components/Monitor/TrTableMonitor.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import times from 'lodash/times';
 
 import { 
   Badge,
@@ -31,7 +31,7 @@ const TrTableMonitor = () => {
   return (
     <React.Fragment>
       {
-        _.times(14, (index) => (
+        times(14, (index) => (
           <tr key={ index } className="text-nowrap">
             <td className="align-middle">
               <span className="text-inverse">HDD1</span> <span className="small">(ada0)</span>

--- a/admin-ui/app/routes/components/Stock/TrTableFavStock.js
+++ b/admin-ui/app/routes/components/Stock/TrTableFavStock.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import times from 'lodash/times';
 import { randomArray } from './../../../utilities';
 import {
   Badge
@@ -34,7 +34,7 @@ const TrTableFavStock = () => {
   return (
     <React.Fragment>
       {
-        _.times(5, (index) => (
+        times(5, (index) => (
           <tr key={ index }>
             <td className="align-middle">
               {t( randomArray(name) )}

--- a/admin-ui/app/routes/components/Stock/TrTableStock.js
+++ b/admin-ui/app/routes/components/Stock/TrTableStock.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import times from 'lodash/times';
 import { randomArray } from './../../../utilities';
 
 const name = [
@@ -64,7 +64,7 @@ const TrTableStock = () => {
   return (
     <React.Fragment>
       {
-        _.times(5, (index) => (
+        times(5, (index) => (
           <tr key={ index }>
             <td className="align-middle">
               { randomArray(name) }

--- a/admin-ui/app/routes/components/Stock/TrTableSummary.js
+++ b/admin-ui/app/routes/components/Stock/TrTableSummary.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import times from 'lodash/times';
 import { randomArray } from './../../../utilities';
 
 const name = [
@@ -25,7 +25,7 @@ const ttm = [
 const TrTableSummary = () => (
   <React.Fragment>
     {
-      _.times(9, (index) => (
+      times(9, (index) => (
         <tr key={ index }>
           <td className="align-middle text-inverse">
             { randomArray(name) }

--- a/admin-ui/app/routes/components/VersionSelector.js
+++ b/admin-ui/app/routes/components/VersionSelector.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import fetch from 'node-fetch';
 import classNames from 'classnames';
-import _ from 'lodash';
+import { filter, find, isEmpty, map } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import {
@@ -42,7 +42,7 @@ export class VersionSelector extends React.Component {
       } catch(exc) {
         this.setState({ isError: true });
       }
-      const targetVersions = _.filter(versions, { dashboardName: dashboard });
+      const targetVersions = filter(versions, { dashboardName: dashboard });
         
       this.setState({ versions: targetVersions });
     }
@@ -60,12 +60,12 @@ export class VersionSelector extends React.Component {
     render() {
       const { down, render, className, sidebar } = this.props;
       const { versions } = this.state;
-      const currentVersion = _.find(versions, { label: "React" });
+      const currentVersion = find(versions, { label: "React" });
 
       return (
         <UncontrolledButtonDropdown direction={ down ? "down" : "up" } className={ className }>
           <DropdownToggle
-            disabled={ _.isEmpty(versions) }
+            disabled={ isEmpty(versions) }
             tag="a"
             href="javascript:;"
             className={classNames(
@@ -92,13 +92,13 @@ export class VersionSelector extends React.Component {
             }
           </DropdownToggle>
           {
-            (!_.isEmpty(versions)) && (
+            (!isEmpty(versions)) && (
               <DropdownMenu>
                 <DropdownItem header>
                   Bootstrap 4 Versions:
                 </DropdownItem>
                 {
-                  _.map(versions, (version, index) => (
+                  map(versions, (version, index) => (
                     <DropdownItem
                       key={ index }
                       href={ version.demoUrl }


### PR DESCRIPTION
## Description
Update code that uses import lodash library to be
1. More readable 
2. Reduce import size

## Rules
1. If only import <= 3 function in the file then use, import specific `import map from 'lodash/map'`
 It will reduce import size significantly and also got clean and more readable code 
2. If importing more than 3 functions the use import function one by one, `import { map, reduce, isEmpty, max } from 'lodash'`
It will reduce import size and also got clean and more readable code 

Signed-off-by: Harry Andriyan <harry.andriyan@gmail.com>