### PR TITLE
feat(redux store): update deprecated createStore

### DIFF
--- a/admin-ui/app/components/App/AppMain.js
+++ b/admin-ui/app/components/App/AppMain.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import { BrowserRouter as Router } from 'react-router-dom'
 import { Provider } from 'react-redux'
-import { configureStore } from 'Redux/store'
+import { configStore } from 'Redux/store'
 import { PersistGate } from 'redux-persist/integration/react'
 import AuthenticatedRouteSelector from './AuthenticatedRouteSelector'
 const basePath = process.env.BASE_PATH || '/admin'
 
 const AppMain = () => {
-  const { store, persistor } = configureStore()
+  const { store, persistor } = configStore()
   return (
     <Provider store={store}>
       <PersistGate loading={null} persistor={persistor}>

--- a/admin-ui/app/redux/store/index.js
+++ b/admin-ui/app/redux/store/index.js
@@ -1,4 +1,5 @@
-import { createStore, applyMiddleware, compose, combineReducers } from 'redux'
+import { combineReducers } from 'redux'
+import { configureStore } from '@reduxjs/toolkit'
 import createSagaMiddleware from 'redux-saga'
 import appReducers from '../reducers'
 import RootSaga from '../sagas'
@@ -10,7 +11,6 @@ import process from 'Plugins/PluginReducersResolver'
 // create the saga middleware
 const sagaMiddleware = createSagaMiddleware()
 const middlewares = [sagaMiddleware]
-const composeEnhancer = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
 const persistConfig = {
   key: 'root',
   storage,
@@ -30,12 +30,12 @@ const reducers = combine(reducerRegistry.getReducers())
 process()
 const persistedReducer = persistReducer(persistConfig, reducers)
 
-export function configureStore(initialState) {
-  const store = createStore(
-    persistedReducer,
+export function configStore(initialState) {
+  const store = configureStore({
+    middleware: middlewares,
+    reducer: persistedReducer,
     initialState,
-    composeEnhancer(applyMiddleware(...middlewares)),
-  )
+  })
   const persistor = persistStore(store)
   window.dsfaStore = store
   reducerRegistry.setChangeListener((reds) => {

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -121,6 +121,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",
     "@miltonbo/dashboard-style-airframe": "^0.2.0",
+    "@reduxjs/toolkit": "^1.8.2",
     "ag-grid-community": "^21.0.1",
     "ag-grid-react": "^21.0.1",
     "axios": "^0.27.2",


### PR DESCRIPTION
### Description

- Development target issue
We recommend using the `configureStore` method of the @reduxjs/toolkit package, to replaces `createStore`.

Redux Toolkit is our recommended approach for writing Redux logic today, including store setup, reducers, data fetching, and more.

## Implementation Details
Replace `createStore` with `configureStore` and make sure all functionality still 100% properly working

<img width="932" alt="Screen Shot 2022-06-07 at 15 10 25" src="https://user-images.githubusercontent.com/7929947/172330023-d5fffe35-c1b5-4a9b-a744-8aa392775959.png">
