### PR TITLE
feat: flex-linux-setup jans installer args

### DIFF
--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -19,6 +19,7 @@ def get_flex_setup_parser():
     parser.add_argument('--jans-setup-branch', help="Jannsen setup github branch", default='main')
     parser.add_argument('--flex-branch', help="Jannsen flex setup github branch", default='main')
     parser.add_argument('--jans-branch', help="Jannsen github branch", default='main')
+    parser.add_argument('--jans-installer-args', help="Arguments to be passed for Janssen Installer")
 
     return parser
 
@@ -40,9 +41,12 @@ except ModuleNotFoundError:
         install_url = 'https://raw.githubusercontent.com/JanssenProject/jans/{}/jans-linux-setup/jans_setup/install.py'.format(setup_branch)
         request.urlretrieve(install_url, 'install.py')
         install_cmd = 'python3 install.py --setup-branch={}'.format(setup_branch)
+        if argsp.jans_installer_args:
+            install_cmd += ' --args="{}"'.format(argsp.jans_installer_args)
         if '-yes' in sys.argv:
             install_cmd += ' -yes'
         print("Executing", install_cmd)
+
         os.system(install_cmd)
         sys.path.append(__STATIC_SETUP_DIR__)
 


### PR DESCRIPTION
Provide arfuments for Janssen Installer. For example:
` python3 flex_setup.py --jans-installer-args="-f /root/setup.properties -n -c"`