### PR TITLE
refactor: Flex Linux Setup install with properties file

### DIFF
--- a/flex-linux-setup/README.md
+++ b/flex-linux-setup/README.md
@@ -19,6 +19,25 @@ If you installed Janssen server before, the script will install additional Gluu 
  
    `python3 flex_setup.py`
 
+    If you have `setup.properties` file and want to automate installation, you can pass properties file as
+    `python3 flex_setup.py -f /path/to/setup.properties -n -c`
+
+    Minimal example setup.properties file:
+    ```
+    ip=10.146.197.201
+    hostname=flex.gluu.org
+    orgName=Gluu
+    admin_email=flex@gluu.org
+    city=Austing
+    state=Texas
+    countryCode=US
+    installLdap=True
+    admin_password=MyAdminPassword
+    ldapPass=MyLdapPassword
+    casa_client_id=3000.7986c837-2a8f-4c31-9c63-1bd2f6abce77
+    casa_client_pw=MyCasaClientSecret
+    ```
+
 Add/Remove Admin UI plugins
 --------------------------------------
 

--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -100,6 +100,7 @@ base.current_app.app_info['ox_version'] = base.current_app.app_info['JANS_APP_VE
 sys.path.insert(0, base.pylib_dir)
 sys.path.insert(0, os.path.join(base.pylib_dir, 'gcs'))
 
+from setup_app.pylib.jproperties import Properties
 from setup_app.utils.package_utils import packageUtils
 from setup_app.config import Config
 from setup_app.utils.collect_properties import CollectProperties
@@ -109,7 +110,7 @@ from setup_app.installers.config_api import ConfigApiInstaller
 from setup_app.installers.jetty import JettyInstaller
 from setup_app.installers.jans_auth import JansAuthInstaller
 from setup_app.installers.jans_cli import JansCliInstaller
-
+from setup_app.utils.properties_utils import propertiesUtils
 
 Config.outputFolder = os.path.join(__STATIC_SETUP_DIR__, 'output')
 if not os.path.join(Config.outputFolder):
@@ -383,9 +384,22 @@ class flex_installer(JettyInstaller):
             print("Restarting Apache")
             httpd_installer.restart()
 
-
-
         self.enable()
+
+
+    def save_properties(self):
+        fn = Config.savedProperties
+        print("Saving properties", fn)
+        if os.path.exists(fn):
+            p = Properties()
+            with open(fn, 'rb') as f:
+                p.load(f, 'utf-8')
+            for prop in ('casa_client_id', 'casa_client_pw', 'casa_client_encoded_pw'):
+                p[prop] = Config.get(prop)
+            with open(fn, 'wb') as f:
+                p.store(f, encoding="utf-8")
+        else:
+            propertiesUtils.save_properties()
 
 
 def main():
@@ -400,10 +414,9 @@ def main():
 
     installer_obj = flex_installer()
     installer_obj.download_files()
-
     installer_obj.install_gluu_admin_ui()
-
     installer_obj.install_casa()
+    installer_obj.save_properties()
 
     print("Starting Casa")
     config_api_installer.start('casa')


### PR DESCRIPTION
In this PR
1) Install flex with setup properties with command `python3 flex_setup.py -f /path/to/setup.properties -n -c`
2) Save setup.properties.last after installing flex to include casa related properties
3) Update document for automating installation with setup.properties