### PR TITLE
fix(docker-casa): upgrade lxml version

### DIFF
--- a/.github/workflows/docker_build_image.yml
+++ b/.github/workflows/docker_build_image.yml
@@ -113,7 +113,7 @@ jobs:
           fi
           # If the user passed a war version to build off ,change this war version.
           GLUU_VERSION=${{ github.event.inputs.gluu_version }}
-          if [ ! -z "GLUU_VERSION" ]
+          if [ ! -z "$GLUU_VERSION" ]
           then
             python3 -c "from dockerfile_parse import DockerfileParser ; dfparser = DockerfileParser('./docker-${{ matrix.docker-images }}') ; dfparser.envs['GLUU_VERSION'] = '${{ github.event.inputs.gluu_version }}'"
             echo "War vesrion has been modified."

--- a/docker-casa/.hadolint.yaml
+++ b/docker-casa/.hadolint.yaml
@@ -1,0 +1,4 @@
+ignored:
+  - DL3018    # Pin versions in apk add
+  - DL3013    # Pin versions in pip
+  - DL3003    # Use WORKDIR to switch to a directory

--- a/docker-casa/Dockerfile
+++ b/docker-casa/Dockerfile
@@ -5,8 +5,8 @@ FROM bellsoft/liberica-openjre-alpine:11.0.15
 # ===============
 
 RUN apk update \
-    && apk upgrade \
-    && apk add --no-cache python3 openssl tini py3-cryptography py3-lxml py3-psycopg2 py3-grpcio \
+    && apk upgrade --available \
+    && apk add --no-cache python3 openssl tini py3-cryptography py3-psycopg2 py3-grpcio \
     && apk add --no-cache --virtual .build-deps git wget zip \
     && mkdir -p /usr/java/latest \
     && ln -sf /usr/lib/jvm/jre /usr/java/latest/jre

--- a/docker-casa/Makefile
+++ b/docker-casa/Makefile
@@ -1,7 +1,18 @@
-GLUU_VERSION=5.0.0
+GLUU_VERSION?=5.0.0
 IMAGE_NAME=gluufederation/casa
-UNSTABLE_VERSION=dev
+UNSTABLE_VERSION?=dev
+
+.PHONY: test clean all build-dev trivy-scan grype-scan
+.DEFAULT_GOAL := build-dev
 
 build-dev:
 	@echo "[I] Building Docker image ${IMAGE_NAME}:${GLUU_VERSION}_${UNSTABLE_VERSION}"
 	@docker build --rm --force-rm -t ${IMAGE_NAME}:${GLUU_VERSION}_${UNSTABLE_VERSION} .
+
+trivy-scan:
+	@echo "[I] Scanning Docker image ${IMAGE_NAME}:${GLUU_VERSION}_${UNSTABLE_VERSION} using trivy"
+	@trivy image ${IMAGE_NAME}:${GLUU_VERSION}_${UNSTABLE_VERSION}
+
+grype-scan:
+	@echo "[I] Scanning Docker image ${IMAGE_NAME}:${GLUU_VERSION}_${UNSTABLE_VERSION} using grype"
+	@grype -v ${IMAGE_NAME}:${GLUU_VERSION}_${UNSTABLE_VERSION}


### PR DESCRIPTION
Overview:

Previously, `lxml` (v4.8.0) is installed from Alpine 3.16 repo.
By removing the package, `lxml` is now installed via `pip` (as direct dependency of `webdavclient3` library).

Misc: update `Makefile` and `hadolint` config