### PR TITLE
chore(images): apply security updates to docker images

### DIFF
--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:14.20.0-alpine3.16 AS builder
+FROM node:14.20-alpine3.16 AS builder
 
 RUN apk update \
-    && apk upgrade \
+    && apk upgrade --available \
     && apk add --no-cache git openjdk11-jre-headless
 
 # TODO:
@@ -22,13 +22,14 @@ RUN git clone --filter blob:none --no-checkout https://github.com/GluuFederation
     && npm install @openapitools/openapi-generator-cli \
     && npm run api \
     && npm install \
+    && npm uninstall @openapitools/openapi-generator-cli \
     && rm -rf $HOME/.npm
 
 # ===========
 # Application
 # ===========
 
-FROM node:14.20.0-alpine3.16
+FROM node:14.20-alpine3.16
 
 # ======
 # alpine

--- a/docker-admin-ui/Makefile
+++ b/docker-admin-ui/Makefile
@@ -11,7 +11,7 @@ build-dev:
 
 trivy-scan:
 	@echo "[I] Scanning Docker image ${IMAGE_NAME}:${GLUU_VERSION}_${UNSTABLE_VERSION} using trivy"
-	@trivy -d image ${IMAGE_NAME}:${GLUU_VERSION}_${UNSTABLE_VERSION}
+	@trivy image --security-checks vuln ${IMAGE_NAME}:${GLUU_VERSION}_${UNSTABLE_VERSION}
 
 grype-scan:
 	@echo "[I] Scanning Docker image ${IMAGE_NAME}:${GLUU_VERSION}_${UNSTABLE_VERSION} using grype"

--- a/docker-casa/Dockerfile
+++ b/docker-casa/Dockerfile
@@ -1,4 +1,4 @@
-FROM bellsoft/liberica-openjre-alpine:11.0.15
+FROM bellsoft/liberica-openjre-alpine:11.0.16
 
 # ===============
 # Alpine packages
@@ -15,7 +15,7 @@ RUN apk update \
 # Jetty
 # =====
 
-ARG JETTY_VERSION=11.0.8
+ARG JETTY_VERSION=11.0.11
 ARG JETTY_HOME=/opt/jetty
 ARG JETTY_BASE=/opt/jans/jetty
 ARG JETTY_USER_HOME_LIB=/home/jetty/lib

--- a/docker-casa/Makefile
+++ b/docker-casa/Makefile
@@ -11,7 +11,7 @@ build-dev:
 
 trivy-scan:
 	@echo "[I] Scanning Docker image ${IMAGE_NAME}:${GLUU_VERSION}_${UNSTABLE_VERSION} using trivy"
-	@trivy image ${IMAGE_NAME}:${GLUU_VERSION}_${UNSTABLE_VERSION}
+	@trivy image --security-checks vuln ${IMAGE_NAME}:${GLUU_VERSION}_${UNSTABLE_VERSION}
 
 grype-scan:
 	@echo "[I] Scanning Docker image ${IMAGE_NAME}:${GLUU_VERSION}_${UNSTABLE_VERSION} using grype"


### PR DESCRIPTION
The changeset applies security updates to the following components:


## docker-casa

* upgrade Alpine to v3.16.1
* upgrade Liberica JRE to v11.0.16
* upgrade Jetty to v11.0.11

## docker-admin-ui

* upgrade Alpine to v3.16.1
* change base image to node:14.20-alpine3.16 for seamless updates
* remove vulnerable Java JAR file (included in openapitools/openapi-generator-cli) after installation

## misc

* set security-checks=vuln to Trivy scanner