### PR TITLE
chore: remove jansRequireAuthTime attribute of clients

### DIFF
--- a/docker-admin-ui/templates/clients.ldif
+++ b/docker-admin-ui/templates/clients.ldif
@@ -17,7 +17,6 @@ jansIdTknSignedRespAlg: RS256
 jansInclClaimsInIdTkn: false
 jansLogoutSessRequired: false
 jansPersistClntAuthzs: true
-jansRequireAuthTime: false
 jansRespTyp: code
 jansRptAsJwt: false
 jansPostLogoutRedirectURI: https://%(hostname)s/admin
@@ -53,7 +52,6 @@ jansPersistClntAuthzs: true
 jansLogoutSessRequired: false
 jansPostLogoutRedirectURI: https://%(hostname)s/admin/logout
 jansRedirectURI: https://%(hostname)s/admin
-jansRequireAuthTime: false
 jansRespTyp: code
 jansRptAsJwt: false
 jansScope: inum=F0C4,ou=scopes,o=jans

--- a/flex-cn-setup/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/upgrade-ldap-101-jans.yaml
+++ b/flex-cn-setup/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/upgrade-ldap-101-jans.yaml
@@ -496,11 +496,6 @@ data:
       SUBSTR caseIgnoreSubstringsMatch
       SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
       X-ORIGIN 'Jans created attribute' )
-    attributeTypes: ( 1.3.6.1.4.1.48710.1.3.81 NAME 'jansRequireAuthTime'
-      DESC 'jans Require Authn Time'
-      EQUALITY booleanMatch
-      SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
-      X-ORIGIN 'Jans created attribute' )
     attributeTypes: ( 1.3.6.1.4.1.48710.1.3.82 NAME 'jansRespTyp'
       DESC 'jans Resp Typ'
       EQUALITY caseIgnoreMatch
@@ -1627,7 +1622,7 @@ data:
       SUP ( top )
       STRUCTURAL
       MUST ( objectclass )
-      MAY ( displayName $ description $ inum $ jansAppTyp $ jansClntIdIssuedAt $ jansClntSecret $ jansClntSecretExpAt $ exp $ del $ jansClntURI $ jansContact $ jansDefAcrValues $ jansDefMaxAge $ jansGrantTyp $ jansIdTknEncRespAlg $ jansIdTknEncRespEnc $ jansIdTknSignedRespAlg $ jansInitiateLoginURI $ jansJwksURI $ jansJwks $ jansLogoURI $ jansPolicyURI $ jansPostLogoutRedirectURI $ jansRedirectURI $ jansRegistrationAccessTkn $ jansReqObjSigAlg $ jansReqObjEncAlg $ jansReqObjEncEnc $ jansReqURI $ jansRequireAuthTime $ jansRespTyp $ jansScope $ jansClaim $ jansSectorIdentifierURI $ jansSignedRespAlg $ jansSubjectTyp $ jansTknEndpointAuthMethod $ jansTknEndpointAuthSigAlg $ jansTosURI $ jansTrustedClnt $ jansUsrInfEncRespAlg $ jansUsrInfEncRespEnc $ jansExtraConf $ jansClaimRedirectURI $ jansLastAccessTime $ jansLastLogonTime $ jansPersistClntAuthzs $ jansInclClaimsInIdTkn $ jansRefreshTknLife $ jansDisabled $ jansLogoutURI $ jansLogoutSessRequired $ jansdId $ jansAuthorizedOrigins $ tknBndCnf $ jansAccessTknAsJwt $ jansAccessTknSigAlg $ jansAccessTknLife $ jansSoftId $ jansSoftVer $ jansSoftStatement $ jansRptAsJwt $ jansAttrs $ jansBackchannelTknDeliveryMode $ jansBackchannelClntNotificationEndpoint $ jansBackchannelAuthnReqSigAlg $ jansBackchannelUsrCodeParameter )
+      MAY ( displayName $ description $ inum $ jansAppTyp $ jansClntIdIssuedAt $ jansClntSecret $ jansClntSecretExpAt $ exp $ del $ jansClntURI $ jansContact $ jansDefAcrValues $ jansDefMaxAge $ jansGrantTyp $ jansIdTknEncRespAlg $ jansIdTknEncRespEnc $ jansIdTknSignedRespAlg $ jansInitiateLoginURI $ jansJwksURI $ jansJwks $ jansLogoURI $ jansPolicyURI $ jansPostLogoutRedirectURI $ jansRedirectURI $ jansRegistrationAccessTkn $ jansReqObjSigAlg $ jansReqObjEncAlg $ jansReqObjEncEnc $ jansReqURI $ jansRespTyp $ jansScope $ jansClaim $ jansSectorIdentifierURI $ jansSignedRespAlg $ jansSubjectTyp $ jansTknEndpointAuthMethod $ jansTknEndpointAuthSigAlg $ jansTosURI $ jansTrustedClnt $ jansUsrInfEncRespAlg $ jansUsrInfEncRespEnc $ jansExtraConf $ jansClaimRedirectURI $ jansLastAccessTime $ jansLastLogonTime $ jansPersistClntAuthzs $ jansInclClaimsInIdTkn $ jansRefreshTknLife $ jansDisabled $ jansLogoutURI $ jansLogoutSessRequired $ jansdId $ jansAuthorizedOrigins $ tknBndCnf $ jansAccessTknAsJwt $ jansAccessTknSigAlg $ jansAccessTknLife $ jansSoftId $ jansSoftVer $ jansSoftStatement $ jansRptAsJwt $ jansAttrs $ jansBackchannelTknDeliveryMode $ jansBackchannelClntNotificationEndpoint $ jansBackchannelAuthnReqSigAlg $ jansBackchannelUsrCodeParameter )
       X-ORIGIN 'Jans created objectclass' )
     objectClasses: ( 1.3.6.1.4.1.48710.1.4.10 NAME 'jansScope'
       SUP ( top )

--- a/flex-linux-setup/flex_linux_setup/templates/casa_client.ldif
+++ b/flex-linux-setup/flex_linux_setup/templates/casa_client.ldif
@@ -20,7 +20,6 @@ jansPersistClntAuthzs: true
 jansRedirectURI: %(casa_redirect_uri)s
 jansPostLogoutRedirectURI: %(casa_redirect_logout_uri)s
 jansLogoutURI: %(casa_frontchannel_logout_uri)s
-jansRequireAuthTime: false
 jansRespTyp: code
 jansRptAsJwt: false
 jansScope: inum=F0C4,ou=scopes,o=jans
@@ -31,4 +30,3 @@ jansSignedRespAlg: RS256
 jansSubjectTyp: pairwise
 jansTknEndpointAuthMethod: client_secret_basic
 jansTrustedClnt: true
-


### PR DESCRIPTION
The changeset removes `jansRequireAuthTime` attribute to address issue #360.