### PR TITLE
fix(admin-ui): show id for scopes in client edit page

### DIFF
--- a/admin-ui/plugins/auth-server/components/Clients/ClientShowSpontaneousScopes.js
+++ b/admin-ui/plugins/auth-server/components/Clients/ClientShowSpontaneousScopes.js
@@ -21,9 +21,7 @@ function ClientShowSpontaneousScopes({ handler, isOpen }) {
           scopesByCreator?.map((scope, key) => {
             return (
               <div key={key}>
-                <Badge color={`primary-${selectedTheme}`}>
-                  {scope?.attributes?.spontaneousClientScopes[0]}
-                </Badge>
+                <Badge color={`primary-${selectedTheme}`}>{scope?.id}</Badge>
               </div>
             )
           })


### PR DESCRIPTION
https://github.com/GluuFederation/flex/issues/357