### PR TITLE
fix: flex-linux-setup python executable

### DIFF
--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -69,7 +69,7 @@ except ModuleNotFoundError:
         setup_branch = argsp.jans_setup_branch or 'main'
         install_url = 'https://raw.githubusercontent.com/JanssenProject/jans/{}/jans-linux-setup/jans_setup/install.py'.format(setup_branch)
         request.urlretrieve(install_url, 'install.py')
-        install_cmd = 'python3 install.py --setup-branch={}'.format(setup_branch)
+        install_cmd = '{} install.py --setup-branch={}'.format(sys.executable, setup_branch)
 
         if argsp.download_exit:
             nargs.append('--download-exit')


### PR DESCRIPTION
closes #479