### PR TITLE
fix(admin-ui): Update ES lint plugin 

### DIFF
--- a/admin-ui/.eslintrc.js
+++ b/admin-ui/.eslintrc.js
@@ -1,9 +1,9 @@
 module.exports = {
   root: true,
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
   plugins: ['react', 'jest'],
   parserOptions: {
-    parser: 'babel-eslint',
+    parser: '@babel/eslint-parser',
     ecmaVersion: 6,
     sourceType: 'module',
     ecmaFeatures: {

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -80,7 +80,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@webpack-cli/serve": "^1.5.2",
     "autoprefixer": "^10.3.1",
-    "babel-eslint": "^10.0.1",
+    "@babel/eslint-parser": "^7.19.1",
     "babel-jest": "^29.0.1",
     "babel-loader": "^8.2.2",
     "babel-plugin-recharts": "^2.0.0",


### PR DESCRIPTION
The issue is because the package we are using is deprecated. Update with the latest one.

Updated Package link : https://www.npmjs.com/package/@babel/eslint-parser

https://github.com/GluuFederation/flex/issues/495