### PR TITLE
fix: flex-linux-setup use encoded client secret

### DIFF
--- a/flex-linux-setup/flex_linux_setup/templates/auiConfiguration.properties
+++ b/flex-linux-setup/flex_linux_setup/templates/auiConfiguration.properties
@@ -1,5 +1,5 @@
 authserver.clientId=%(admin_ui_client_id)s
-authserver.clientSecret=%(admin_ui_client_pw)s
+authserver.clientSecret=%(admin_ui_client_encoded_pw)s
 authserver.authzBaseUrl=https://%(hostname)s/jans-auth/restv1/authorize
 authserver.scope=openid+profile+email+user_name
 authserver.acrValues=%(adminui_authentication_mode)s
@@ -12,7 +12,7 @@ authserver.userInfoEndpoint=https://%(hostname)s/jans-auth/restv1/userinfo
 authserver.endSessionEndpoint=https://%(hostname)s/jans-auth/restv1/end_session
 
 tokenServer.clientId=%(admin_ui_client_id)s
-tokenServer.clientSecret=%(admin_ui_client_pw)s
+tokenServer.clientSecret=%(admin_ui_client_encoded_pw)s
 tokenServer.authzBaseUrl=https://%(hostname)s/jans-auth/restv1/authorize
 tokenServer.scope=openid+profile+email+user_name
 tokenServer.acrValues=basic


### PR DESCRIPTION
closese #546