### PR TITLE
fix: flex-linux-setup missing source_files definition for casa

### DIFF
--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -410,6 +410,8 @@ class flex_installer(JettyInstaller):
 
     def install_casa(self):
 
+        self.source_files = [(self.casa_war_fn,)]
+
         print("Adding twillo and casa config to jans-auth")
         self.copyFile(self.casa_config_fn, self.jans_auth_custom_lib_dir)
         self.copyFile(self.twillo_fn, self.jans_auth_custom_lib_dir)


### PR DESCRIPTION
closes #571