### PR TITLE
chore(docker-casa): exclude optional prometheus exporter from images

### DIFF
--- a/docker-casa/Dockerfile
+++ b/docker-casa/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir -p ${JETTY_BASE}/casa/webapps \
     && zip -d casa.war WEB-INF/jetty-web.xml \
     && zip -r casa.war WEB-INF/jetty-env.xml \
     && cp casa.war ${JETTY_BASE}/casa/webapps/casa.war \
-    && java -jar ${JETTY_HOME}/start.jar jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}/casa --add-module=server,deploy,resources,http,jsp,cdi-decorate \
+    && java -jar ${JETTY_HOME}/start.jar jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}/casa --add-module=server,deploy,resources,http,jsp,cdi-decorate,jmx,stats \
     && rm -rf /tmp/casa.war /tmp/WEB-INF
 
 # ======
@@ -63,11 +63,7 @@ RUN python3 -m ensurepip \
 # Prometheus
 # ==========
 
-ARG PROMETHEUS_JAVAAGENT_VERSION=0.17.0
 COPY conf/prometheus-config.yaml /opt/prometheus/
-RUN mkdir -p /opt/prometheus \
-    && wget -q https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${PROMETHEUS_JAVAAGENT_VERSION}/jmx_prometheus_javaagent-${PROMETHEUS_JAVAAGENT_VERSION}.jar -O /opt/prometheus/jmx_prometheus_javaagent.jar \
-    && java -jar ${JETTY_HOME}/start.jar jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}/casa --add-module=jmx,stats
 
 # =====================
 # jans-linux-setup sync
@@ -258,7 +254,8 @@ RUN chmod -R g=u ${JETTY_BASE}/casa/static \
     && chmod 664 /opt/jetty/etc/jetty.xml \
     && chmod 664 /opt/jetty/etc/webdefault.xml \
     && chown -R 1000:0 ${JETTY_BASE}/common/libs \
-    && chown -R 1000:0 /usr/share/java
+    && chown -R 1000:0 /usr/share/java \
+    && chown -R 1000:0 /opt/prometheus
 
 USER 1000
 

--- a/docker-casa/scripts/entrypoint.sh
+++ b/docker-casa/scripts/entrypoint.sh
@@ -31,10 +31,21 @@ get_prometheus_opt() {
     echo "${prom_opt}"
 }
 
+get_prometheus_lib() {
+    if [ -n "${CN_PROMETHEUS_PORT}" ]; then
+        prom_agent_version="0.17.2"
+
+        if [ ! -f /opt/prometheus/jmx_prometheus_javaagent.jar ]; then
+            wget -q https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${prom_agent_version}/jmx_prometheus_javaagent-${prom_agent_version}.jar -O /opt/prometheus/jmx_prometheus_javaagent.jar
+        fi
+    fi
+}
+
 # ==========
 # ENTRYPOINT
 # ==========
 
+get_prometheus_lib
 python3 /app/scripts/wait.py
 python3 /app/scripts/bootstrap.py
 # python3 /app/scripts/jca_sync.py &


### PR DESCRIPTION
The changeset excludes Prometheus JMX exporter from image. The exporter will be downloaded (if necessary) in container-level.

Closes #685 