### PR TITLE
feat(docker-casa): enable prefix and group for stdout logs

### DIFF
--- a/docker-casa/Dockerfile
+++ b/docker-casa/Dockerfile
@@ -15,7 +15,7 @@ RUN apk update \
 # Jetty
 # =====
 
-ARG JETTY_VERSION=11.0.11
+ARG JETTY_VERSION=11.0.13
 ARG JETTY_HOME=/opt/jetty
 ARG JETTY_BASE=/opt/jans/jetty
 ARG JETTY_USER_HOME_LIB=/home/jetty/lib
@@ -46,7 +46,7 @@ RUN mkdir -p ${JETTY_BASE}/casa/webapps \
     && zip -d casa.war WEB-INF/jetty-web.xml \
     && zip -r casa.war WEB-INF/jetty-env.xml \
     && cp casa.war ${JETTY_BASE}/casa/webapps/casa.war \
-    && java -jar ${JETTY_HOME}/start.jar jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}/casa --add-module=server,deploy,resources,http,jsp,cdi-decorate,jmx,stats \
+    && java -jar ${JETTY_HOME}/start.jar jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}/casa --add-module=server,deploy,resources,http,jsp,cdi-decorate,jmx,stats,logging-log4j2 --approve-all-licenses \
     && rm -rf /tmp/casa.war /tmp/WEB-INF
 
 # ======
@@ -232,7 +232,7 @@ RUN mkdir -p /etc/certs \
     /opt/jans/jetty/common/libs/couchbase \
     /usr/share/java
 
-COPY jetty/log4j2.xml ${JETTY_BASE}/casa/resources/
+COPY jetty/log4j2.xml /app/templates/
 COPY jetty/casa_web_resources.xml ${JETTY_BASE}/casa/webapps/
 COPY conf/*.tmpl /app/templates/
 COPY scripts /app/scripts
@@ -246,7 +246,7 @@ COPY --chown=1000:0 jetty/casa.xml ${JETTY_BASE}/casa/webapps/
 # adjust ownership
 RUN chmod -R g=u ${JETTY_BASE}/casa/static \
     && chmod -R g=u ${JETTY_BASE}/casa/plugins \
-    && chmod -R g=u ${JETTY_BASE}/casa/resources \
+    && chmod 664 ${JETTY_BASE}/casa/resources/log4j2.xml \
     && chmod -R g=u ${JETTY_BASE}/casa/logs \
     && chmod -R g=u /etc/certs \
     && chmod -R g=u /etc/jans \

--- a/docker-casa/README.md
+++ b/docker-casa/README.md
@@ -104,6 +104,12 @@ The following key-value pairs are the defaults:
 }
 ```
 
+To enable prefix on `STDOUT` logging, set the `enable_stdout_log_prefix` key. Example:
+
+```
+{"casa_log_target":"STDOUT","timer_log_target":"STDOUT","enable_stdout_log_prefix":true}
+```
+
 ### Exposing metrics
 
 As per v1.0.1, certain metrics can be exposed via Prometheus JMX exporter.

--- a/docker-casa/jetty/log4j2.xml
+++ b/docker-casa/jetty/log4j2.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="ERROR">
+    <Properties>
+        <Property name="log.console.prefix" value="casa" />
+    </Properties>
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{dd-MM HH:mm:ss.SSS} %-5p %C{4} %F:%L- %m%n" />
+            <PatternLayout pattern="$log_prefix%d{dd-MM HH:mm:ss.SSS} %-5p %C{4} %F:%L- %m%n" />
         </Console>
         <RollingFile name="LOG_FILE" fileName="${sys:log.base}/logs/casa.log" filePattern="${sys:log.base}/logs/casa-%d{yyyy-MM-dd}-%i.log">
             <PatternLayout pattern="%d{dd-MM HH:mm:ss.SSS} %-5p [%t] %C{4} %F:%L- %m%n" />
@@ -22,6 +25,7 @@
 
     <Loggers>
         <Logger name="org.gluu.casa.timer" level="$timer_log_level" additivity="false">
+            <Property name="log.console.group">-timer</Property>
             <AppenderRef ref="$timer_log_target" />
         </Logger>
         <Logger name="org.gluu.casa" level="$casa_log_level" additivity="false">

--- a/docker-casa/scripts/bootstrap.py
+++ b/docker-casa/scripts/bootstrap.py
@@ -28,6 +28,7 @@ from jans.pycloudlib.utils import cert_to_truststore
 from jans.pycloudlib.utils import get_random_chars
 from jans.pycloudlib.utils import encode_text
 from jans.pycloudlib.utils import generate_base64_contents
+from jans.pycloudlib.utils import as_boolean
 
 from settings import LOGGING_CONFIG
 
@@ -78,6 +79,7 @@ def configure_logging():
         "casa_log_level": "INFO",
         "timer_log_target": "FILE",
         "timer_log_level": "INFO",
+        "log_prefix": "",
     }
 
     # pre-populate custom config; format is JSON string of ``dict``
@@ -127,10 +129,13 @@ def configure_logging():
         else:
             config[key] = file_aliases[key]
 
-    logfile = "/opt/jans/jetty/casa/resources/log4j2.xml"
-    with open(logfile) as f:
+    if as_boolean(custom_config.get("enable_stdout_log_prefix")):
+        config["log_prefix"] = "${sys:log.console.prefix}%X{log.console.group} - "
+
+    with open("/app/templates/log4j2.xml") as f:
         txt = f.read()
 
+    logfile = "/opt/jans/jetty/casa/resources/log4j2.xml"
     tmpl = Template(txt)
     with open(logfile, "w") as f:
         f.write(tmpl.safe_substitute(config))

--- a/flex-cn-setup/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/configmaps.yaml
+++ b/flex-cn-setup/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/configmaps.yaml
@@ -195,6 +195,18 @@ data:
   | squote
   }}
   {{- end }}
+  {{- if .Values.global.casa.enabled }}
+  # CASA
+  GLUU_CASA_APP_LOGGERS: {{ .Values.global.casa
+  | toJson
+  | replace "casaLogTarget" "casa_log_target"
+  | replace "casaLogLevel" "casa_log_level"
+  | replace "timerLogTarget" "timer_log_target"
+  | replace "timerLogLevel" "timer_log_level"
+  | replace "enableStdoutLogPrefix" "enable_stdout_log_prefix"
+  | squote
+  }}
+  {{- end }}
 ---
 
 apiVersion: v1

--- a/flex-cn-setup/pygluu/kubernetes/templates/helm/gluu/values.yaml
+++ b/flex-cn-setup/pygluu/kubernetes/templates/helm/gluu/values.yaml
@@ -852,6 +852,18 @@ global:
   # -- Azure storage kind if using Azure disks
   azureStorageKind: Managed
   casa:
+    # -- App loggers can be configured to define where the logs will be redirected to and the level of each in which it should be displayed.
+    appLoggers:
+      # -- Enable log prefixing which enables prepending the STDOUT logs with the file name. i.e casa ===> 2022-12-20 17:49:55,744 INFO
+      enableStdoutLogPrefix: "true"
+      # -- casa.log target
+      casaLogTarget: "STDOUT"
+      # -- casa.log level
+      casaLogLevel: "INFO"
+      # -- casa timer log target
+      timerLogTarget: "FILE"
+      # -- casa timer log level
+      timerLogLevel: "INFO"
     # -- Name of the casa service. Please keep it as default.
     casaServiceName: casa
     # -- Boolean flag to enable/disable the casa chart.


### PR DESCRIPTION
The changeset introduces feature to enable prefix on `STDOUT` logging for casa.

Closes #690