### PR TITLE
ci: add changes for property and feature flag doc generation

### DIFF
--- a/automation/docs/generate-property-docs.sh
+++ b/automation/docs/generate-property-docs.sh
@@ -8,7 +8,12 @@ echo "Generate properties and feature flag documents from elements annotated wit
 
 # Compile modules where classes that use these annotations exist.
 # This will generate markdown files under target/classes directory
-
+mvn -q -f casa/pom.xml clean compile
 
 # Move markdown files to appropriate locations under documentation root 'doc'
+# Sample commands to move generated files are given below. Properties files and feature flag doc files
+# will be generated automatically when annotations are added to respective modules. Use commands like
+# samples below to place files in appropriate documentation site directory.
 
+#mv -f casa/config/target/classes/casaconfig-properties.md reference/json-config/properties
+#mv -f casa/app/target/classes/casa-properties.md reference/json-config/properties

--- a/casa/app/pom.xml
+++ b/casa/app/pom.xml
@@ -294,6 +294,12 @@
             <artifactId>oauth2-oidc-sdk</artifactId>
             <version>10.4</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.jans</groupId>
+            <artifactId>jans-doc</artifactId>
+            <version>${jans.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -369,6 +375,13 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>-Amodule=Casa</compilerArgument>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/casa/config/pom.xml
+++ b/casa/config/pom.xml
@@ -24,6 +24,11 @@
             <artifactId>jans-orm-model</artifactId>
             <version>1.0.6-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>io.jans</groupId>
+            <artifactId>jans-doc</artifactId>
+            <version>1.0.6-SNAPSHOT</version>
+        </dependency>
         
         <!-- JACKSON -->
         <dependency>
@@ -34,10 +39,15 @@
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-            </plugins>
-        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>-Amodule=Casa Config</compilerArgument>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/casa/pom.xml
+++ b/casa/pom.xml
@@ -151,6 +151,15 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.10.1</version>                    
                     <configuration>
+                        <annotationProcessors>
+                            <annotationProcessor>
+                                io.jans.doc.annotation.DocPropertyProcessor
+                            </annotationProcessor>
+                            <annotationProcessor>
+                                io.jans.doc.annotation.DocFeatureFlagProcessor
+                            </annotationProcessor>
+                        </annotationProcessors>
+                        <compilerArgument>-Amodule=Casa</compilerArgument>
                         <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     </configuration>
                 </plugin>

--- a/casa/shared/pom.xml
+++ b/casa/shared/pom.xml
@@ -95,6 +95,24 @@
             <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
             <version>1.0.1.Final</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.jans</groupId>
+            <artifactId>jans-doc</artifactId>
+            <version>${jans.version}</version>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>-Amodule=Casa Shared</compilerArgument>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,5 +141,10 @@ nav:
     - 'Flex Docker Image': 'reference/kubernetes/docker-flex-monolith.md'
     - 'Admin UI Docker Image': 'reference/kubernetes/docker-admin-ui.md'
     - 'Casa Docker Image': 'reference/kubernetes/docker-casa.md'
-
-
+#   Use section below to configure documentation structure as per available property and feature-flag documents
+#    - 'JSON Configuration':
+#      - 'reference/json-config/README.md'
+#      - 'Properties':
+#          - 'reference/json-config/properties/README.md'
+#          - 'Casa': 'reference/json-config/properties/casa-properties.md'
+#          - 'Casa Config': 'reference/json-config/properties/casaconfig-properties.md'


### PR DESCRIPTION
This PR includes required changes so developers can auto-generate property and feature flag documentation using annotations. 
- Changes in this PR puts in place the infrastructure code
- Some of this code must be updated when developers add annotations first time to a module. Commentary has been added to indicate such places.