### PR TITLE
fix: flex-linux-setup download pyjwt and cryptography instead of gcs

### DIFF
--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -119,7 +119,9 @@ if not jans_installer_downloaded:
     from setup_app.utils import base
     downloads.base.current_app.app_info = base.readJsonFile(os.path.join(__STATIC_SETUP_DIR__, 'app_info.json'))
     downloads.download_sqlalchemy()
-    downloads.download_gcs()
+    downloads.download_cryptography()
+    downloads.download_pyjwt()
+
 
 install_components = {
         'admin_ui': argsp.install_admin_ui,


### PR DESCRIPTION
coses #723