### PR TITLE
fix: pf4j annotation processing

### DIFF
--- a/casa/config/pom.xml
+++ b/casa/config/pom.xml
@@ -29,6 +29,10 @@
             <artifactId>jans-doc</artifactId>
             <version>1.0.6-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.pf4j</groupId>
+            <artifactId>pf4j</artifactId>
+        </dependency>
         
         <!-- JACKSON -->
         <dependency>

--- a/casa/pom.xml
+++ b/casa/pom.xml
@@ -158,6 +158,9 @@
                             <annotationProcessor>
                                 io.jans.doc.annotation.DocFeatureFlagProcessor
                             </annotationProcessor>
+                            <annotationProcessor>
+                                org.pf4j.processor.ExtensionAnnotationProcessor
+                            </annotationProcessor>
                         </annotationProcessors>
                         <compilerArgument>-Amodule=Casa</compilerArgument>
                         <forceJavacCompilerUse>true</forceJavacCompilerUse>


### PR DESCRIPTION
closes #748 

### Root-cause:

In order to integrate annotation processors for property documentation, `<annotationProcessors>` configuration element was added. This did not list `org.pf4j.processor.ExtensionAnnotationProcessor`. 

### Tests:
- [x] Checked that `casa/app/target/classes/META-INF/extensions.idx` is created
- [x] Checked that the property documentation is also getting generated if relevant annotations are used in the code
