### PR TITLE
chore(flex-linux-setup): adjust jans version, bump to 1.0.7

### DIFF
--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -225,7 +225,7 @@ app_versions = {
   "SETUP_BRANCH": argsp.jans_setup_branch,
   "FLEX_BRANCH": argsp.flex_branch,
   "JANS_BRANCH": argsp.jans_branch,
-  "JANS_APP_VERSION": "1.0.6",
+  "JANS_APP_VERSION": "1.0.7",
   "JANS_BUILD": "-SNAPSHOT", 
   "NODE_VERSION": "v14.18.2",
   "CASA_VERSION": "5.0.0-SNAPSHOT",


### PR DESCRIPTION
What is in the PR
=============

update `JANS_APP_VERSION` to `1.0.7`