### PR TITLE
docs: replaced admin ui WIP page with general config options

### DIFF
--- a/docs/admin/config.md
+++ b/docs/admin/config.md
@@ -18,4 +18,4 @@ If needed, a command-line alternative to the TUI is available. Instructions can 
 
 ## Admin UI
 
-Exclusive to Gluu Flex, the new Gluu Flex Admin UI is a browser-based GUI in development. Many features are available now, and it can be accessed by accessing the hostname set during installation in the browser.
+The Gluu Flex Admin UI is a reactive web interface to simplify the management and configuration of your Auth Server. The Admin UI enables you to easily view and edit configuration properties, interception scripts, clients, and metrics in one place. The Admin UI can be accessed by accessing the hostname set during installation in the browser.

--- a/docs/admin/config.md
+++ b/docs/admin/config.md
@@ -1,0 +1,21 @@
+# Configuring Gluu Flex
+
+## Overview
+
+After installing, there are four primary strategies to configure Gluu Flex.
+
+## Text-based User Interface (TUI)
+
+The current recommendation is to use the Janssen TUI to configure Flex components. The TUI calls the Config API to perform ad hoc configuration, and instructions can be found in the Janssen [documentation here.](https://docs.jans.io/v1.0.9/admin/config-guide/jans-tui/)
+
+## CURL Commands
+
+As an alternative, the Config API can be called directly using [CURL commands.](https://docs.jans.io/v1.0.9/admin/config-guide/curl/)
+
+## Command Line Interface (CLI)
+
+If needed, a command-line alternative to the TUI is available. Instructions can be found in the Janssen [documentation here.](https://docs.jans.io/v1.0.9/admin/config-guide/jans-cli/)
+
+## Admin UI
+
+Exclusive to Gluu Flex, the new Gluu Flex Admin UI is a browser-based GUI in development. Many features are available now, and it can be accessed by accessing the hostname set during installation in the browser.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,9 +123,10 @@ nav:
         - 'Suse': 'install/vm-install/suse.md'
 - 'Administration':
     - 'admin/README.md'
-    - 'Admin UI':
-        - 'admin/admin-ui/README.md'
-        - 'Admin UI Properties': 'admin/admin-ui/properties.md'
+    - 'Configuration': 'admin/config.md'
+#    - 'Admin UI':
+#        - 'admin/admin-ui/README.md'
+#        - 'Admin UI Properties': 'admin/admin-ui/properties.md'
 #    - 'SAML':
  #       - 'admin/saml/README.md'
   #      - 'SAML IDP': 'admin/saml/idp.md'


### PR DESCRIPTION
For this commit, I used a static version number in Jans but in the future we should make a replacement term for corresponding Jans versions, as well as Flex