### PR TITLE
chore(docker): update image labels to reflect ghcr migration

### DIFF
--- a/.github/workflows/docker_build_image.yml
+++ b/.github/workflows/docker_build_image.yml
@@ -89,7 +89,7 @@ jobs:
         id: prep
         run: |
           REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
-          MAIN_VERSION=$(python3 -c "from dockerfile_parse import DockerfileParser ; dfparser = DockerfileParser('./docker-${{ matrix.docker-images }}') ; print(dfparser.labels['version'])")
+          MAIN_VERSION=$(python3 -c "from dockerfile_parse import DockerfileParser ; dfparser = DockerfileParser('./docker-${{ matrix.docker-images }}') ; print(dfparser.labels['org.opencontainers.image.version'])")
           DOCKER_IMAGE=ghcr.io/$REPOSITORY/${{ matrix.docker-images }}
           if [[ ${{ matrix.docker-images }} == "flex-monolith" ]]; then
             DOCKER_IMAGE=gluufederation/monolith

--- a/automation/auto_update_image_pr.py
+++ b/automation/auto_update_image_pr.py
@@ -16,7 +16,7 @@ def should_update_build(last_build, new_build):
 
 def update_image(image, source_url_env, build_date_env):
     dfparser = DockerfileParser(f'../{image}')
-    version = dfparser.labels["version"]
+    version = dfparser.labels["org.opencontainers.image.version"]
     try:
         base_url = os.path.dirname(dfparser.envs[source_url_env])
         pkg_url = os.path.basename(dfparser.envs[source_url_env])

--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -187,13 +187,12 @@ ENV CN_WAIT_MAX_TIME=300 \
 # misc stuff
 # ==========
 
-LABEL name="gluufederation/admin-ui" \
-    maintainer="Gluu Inc. <support@gluu.org>" \
-    vendor="Gluu Federation" \
-    version="1.0.11" \
-    release="dev" \
-    summary="Gluu Admin UI" \
-    description=""
+LABEL org.opencontainers.image.url="ghcr.io/gluufederation/flex/admin-ui" \
+    org.opencontainers.image.authors="Gluu Inc. <support@gluu.org>" \
+    org.opencontainers.image.vendor="Gluu Federation" \
+    org.opencontainers.image.version="1.0.11" \
+    org.opencontainers.image.title="Gluu Flex Admin UI" \
+    org.opencontainers.image.description=""
 
 RUN mkdir -p /etc/jans/conf /etc/certs
 COPY templates /app/templates/

--- a/docker-admin-ui/Makefile
+++ b/docker-admin-ui/Makefile
@@ -1,5 +1,5 @@
 GLUU_VERSION?=1.0.11
-IMAGE_NAME=gluufederation/admin-ui
+IMAGE_NAME=ghcr.io/gluufederation/flex/admin-ui
 UNSTABLE_VERSION?=dev
 
 .PHONY: test clean all build-dev trivy-scan grype-scan

--- a/docker-casa/Dockerfile
+++ b/docker-casa/Dockerfile
@@ -1,4 +1,4 @@
-FROM bellsoft/liberica-openjre-alpine:11.0.18
+FROM bellsoft/liberica-openjre-alpine:11.0.16
 
 # ===============
 # Alpine packages
@@ -212,13 +212,12 @@ ENV CN_MAX_RAM_PERCENTAGE=75.0 \
 # misc stuff
 # ==========
 
-LABEL name="gluufederation/casa" \
-    maintainer="Gluu Inc. <support@gluu.org>" \
-    vendor="Gluu Federation" \
-    version="5.0.0" \
-    release="dev" \
-    summary="Gluu Casa" \
-    description="Self-service portal for people to manage their account security preferences in the Gluu Server, like 2FA"
+LABEL org.opencontainers.image.url="ghcr.io/gluufederation/flex/casa" \
+    org.opencontainers.image.authors="Gluu Inc. <support@gluu.org>" \
+    org.opencontainers.image.vendor="Gluu Federation" \
+    org.opencontainers.image.version="5.0.0" \
+    org.opencontainers.image.title="Gluu Flex Casa" \
+    org.opencontainers.image.description="Self-service portal for people to manage their account security preferences in the Gluu Server, like 2FA"
 
 RUN mkdir -p /etc/certs \
     /etc/jans/conf/casa \

--- a/docker-casa/Makefile
+++ b/docker-casa/Makefile
@@ -1,5 +1,5 @@
 GLUU_VERSION?=5.0.0
-IMAGE_NAME=gluufederation/casa
+IMAGE_NAME=ghcr.io/gluufederation/flex/casa
 UNSTABLE_VERSION?=dev
 
 .PHONY: test clean all build-dev trivy-scan grype-scan

--- a/docker-flex-monolith/Dockerfile
+++ b/docker-flex-monolith/Dockerfile
@@ -85,13 +85,12 @@ ENV CN_GLUU_LICENSE_SSA="" \
 # misc stuff
 # ==========
 
-LABEL name="gluufederation/monolith" \
-    maintainer="GluuFederation <support@gluu.org>" \
-    vendor="GluuFederation" \
-    version="5.0.0" \
-    release="10" \
-    summary="GluuFederation Flex Monolith Image" \
-    description="Janssen Authorization server + Casa + AdminUI"
+LABEL org.opencontainers.image.url="ghcr.io/gluufederation/flex/monolith" \
+    org.opencontainers.image.authors="GluuFederation <support@gluu.org>" \
+    org.opencontainers.image.vendor="GluuFederation" \
+    org.opencontainers.image.version="5.0.0" \
+    org.opencontainers.image.title="GluuFederation Flex Monolith Image" \
+    org.opencontainers.image.description="Janssen Authorization server + Casa + AdminUI"
 
 COPY scripts /app/scripts
 RUN chmod +x /app/scripts/entrypoint.sh

--- a/docker-flex-monolith/Makefile
+++ b/docker-flex-monolith/Makefile
@@ -1,5 +1,5 @@
 CN_VERSION?=5.0.0
-IMAGE_NAME=gluufederation/monolith
+IMAGE_NAME=ghcr.io/gluufederation/flex/monolith
 UNSTABLE_VERSION?=dev
 
 .PHONY: test clean all build-dev trivy-scan grype-scan


### PR DESCRIPTION
The image labels are changed to OCI-compliant annotations.

Closes #870 