### PR TITLE
feat(flex-linux-setup): changes in admin-ui configuration

### DIFF
--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -468,6 +468,7 @@ class flex_installer(JettyInstaller):
         config_api_installer.copy_tree(os.path.join(self.source_dir, 'dist'),  Config.templateRenderingDict['admin_ui_apache_root'])
 
         oidc_client = installed_components.get('oidc_client', {})
+        Config.templateRenderingDict['ssa'] = installed_components['ssa']
         Config.templateRenderingDict['oidc_client_id'] = oidc_client.get('client_id', '')
         Config.templateRenderingDict['oidc_client_secret'] = oidc_client.get('client_secret', '')
         Config.templateRenderingDict['license_hardware_key'] = str(uuid.uuid4())

--- a/flex-linux-setup/flex_linux_setup/templates/auiConfiguration.json
+++ b/flex-linux-setup/flex_linux_setup/templates/auiConfiguration.json
@@ -31,6 +31,7 @@
     }
   },
   "licenseConfig": {
+    "ssa": "%(ssa)s",
     "scanLicenseApiHostname": "%(scan_license_api_hostname)s",
     "scanLicenseAuthServerHostname": "%(scan_license_auth_server_hostname)s",
     "licenseHardwareKey": "%(license_hardware_key)s",


### PR DESCRIPTION
closes #884
*  SSA entered by the user need to be saved in licenseConfig object
* Remove the scanLicenseAuthServerHostname field from the licenseConfig object. The value of auth server path needs to be set in licenseConfig.oidcClient.opHost