### PR TITLE
build(docker): incorrect label syntax prevent image builds

### DIFF
--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -190,7 +190,7 @@ ENV CN_WAIT_MAX_TIME=300 \
 LABEL org.opencontainers.image.url="ghcr.io/gluufederation/flex/admin-ui" \
     org.opencontainers.image.authors="Gluu Inc. <support@gluu.org>" \
     org.opencontainers.image.vendor="Gluu Federation" \
-    org.opencontainers.image.version="1.0.12"/
+    org.opencontainers.image.version="1.0.12" \
     org.opencontainers.image.title="Gluu Flex Admin UI" \
     org.opencontainers.image.description=""
 

--- a/docker-admin-ui/Makefile
+++ b/docker-admin-ui/Makefile
@@ -1,4 +1,4 @@
-GLUU_VERSION?=1.0.12-SNAPSHOT
+GLUU_VERSION?=1.0.12
 IMAGE_NAME=ghcr.io/gluufederation/flex/admin-ui
 UNSTABLE_VERSION?=dev
 

--- a/docker-casa/Dockerfile
+++ b/docker-casa/Dockerfile
@@ -215,7 +215,7 @@ ENV CN_MAX_RAM_PERCENTAGE=75.0 \
 LABEL org.opencontainers.image.url="ghcr.io/gluufederation/flex/casa" \
     org.opencontainers.image.authors="Gluu Inc. <support@gluu.org>" \
     org.opencontainers.image.vendor="Gluu Federation" \
-    org.opencontainers.image.version="1.0.12"/
+    org.opencontainers.image.version="5.0.0" \
     org.opencontainers.image.title="Gluu Flex Casa" \
     org.opencontainers.image.description="Self-service portal for people to manage their account security preferences in the Gluu Server, like 2FA"
 

--- a/docker-flex-monolith/Dockerfile
+++ b/docker-flex-monolith/Dockerfile
@@ -88,7 +88,7 @@ ENV CN_GLUU_LICENSE_SSA="" \
 LABEL org.opencontainers.image.url="ghcr.io/gluufederation/flex/monolith" \
     org.opencontainers.image.authors="GluuFederation <support@gluu.org>" \
     org.opencontainers.image.vendor="GluuFederation" \
-    org.opencontainers.image.version="1.0.12"/
+    org.opencontainers.image.version="5.0.0" \
     org.opencontainers.image.title="GluuFederation Flex Monolith Image" \
     org.opencontainers.image.description="Janssen Authorization server + Casa + AdminUI"
 


### PR DESCRIPTION
The changeset fixes incorrect LABEL syntax for image builds.

Closes #914 