### PR TITLE
fix(flex-linux-setup): set redirect_uris as AS for client registration

### DIFF
--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -924,7 +924,7 @@ def obtain_oidc_client_credidentials():
     data = {
         "software_statement": ssa,
         "response_types": ["token"],
-        "redirect_uris": ["https://cloud.gluu.org"],
+        "redirect_uris": ["{}".format(Config.hostname)],
         "client_name": "test-ui-client"
     }
 


### PR DESCRIPTION
closes #965