### PR TITLE
chore(docker-jans): upgrade jetty to mitigate vulnerabilities

### DIFF
--- a/docker-casa/Dockerfile
+++ b/docker-casa/Dockerfile
@@ -15,7 +15,7 @@ RUN apk update \
 # Jetty
 # =====
 
-ARG JETTY_VERSION=11.0.13
+ARG JETTY_VERSION=11.0.15
 ARG JETTY_HOME=/opt/jetty
 ARG JETTY_BASE=/opt/jans/jetty
 ARG JETTY_USER_HOME_LIB=/home/jetty/lib


### PR DESCRIPTION
The changeset upgrades Jetty to 11.0.15 in Casa image.

Closes #972 