### PR TITLE
fix(docker-flex-monolith): unable to run processes due to offline systemd

### DIFF
--- a/automation/startflexmonolithdemo.sh
+++ b/automation/startflexmonolithdemo.sh
@@ -54,13 +54,23 @@ sudo apt-get update
 sudo python3 -m pip install --upgrade pip
 pip3 install setuptools --upgrade
 pip3 install dockerfile-parse ruamel.yaml
+
+# switching to version defined by FLEX_BUILD_COMMIT
 if [[ "$FLEX_BUILD_COMMIT" ]]; then
   echo "Updating build commit in Dockerfile to $FLEX_BUILD_COMMIT"
+
   python3 -c "from dockerfile_parse import DockerfileParser ; dfparser = DockerfileParser('/tmp/flex/docker-flex-monolith') ; dfparser.envs['FLEX_SOURCE_VERSION'] = '$FLEX_BUILD_COMMIT'"
+
+  python3 -c "from dockerfile_parse import DockerfileParser ; dfparser = DockerfileParser('/tmp/flex/docker-flex-monolith') ; dfparser.envs['CN_GLUU_LICENSE_SSA'] = '$GLUU_LICENSE_SSA'"
+
+  # as FLEX_SOURCE_VERSION is changed, allow docker compose to rebuild image on-the-fly
+  # and use the respective image instead of the default image
+  python3 -c "from pathlib import Path ; import ruamel.yaml ; compose = Path('/tmp/flex/docker-flex-monolith/flex-mysql-compose.yml') ; yaml = ruamel.yaml.YAML() ; data = yaml.load(compose) ; data['services']['flex']['build'] = '.' ; del data['services']['flex']['image'] ; yaml.dump(data, compose)"
+
+  python3 -c "from pathlib import Path ; import ruamel.yaml ; compose = Path('/tmp/flex/docker-flex-monolith/flex-postgres-compose.yml') ; yaml = ruamel.yaml.YAML() ; data = yaml.load(compose) ; data['services']['flex']['build'] = '.' ; del data['services']['flex']['image'] ; yaml.dump(data, compose)"
+
+  python3 -c "from pathlib import Path ; import ruamel.yaml ; compose = Path('/tmp/flex/docker-flex-monolith/flex-ldap-compose.yml') ; yaml = ruamel.yaml.YAML() ; data = yaml.load(compose) ; data['services']['flex']['build'] = '.' ; del data['services']['flex']['image'] ; yaml.dump(data, compose)"
 fi
-python3 -c "from dockerfile_parse import DockerfileParser ; dfparser = DockerfileParser('/tmp/flex/docker-flex-monolith') ; dfparser.envs['CN_GLUU_LICENSE_SSA'] = '$GLUU_LICENSE_SSA'"
-python3 -c "from pathlib import Path ; import ruamel.yaml ; compose = Path('/tmp/flex/docker-flex-monolith/flex-mysql-compose.yml') ; yaml = ruamel.yaml.YAML() ; data = yaml.load(compose) ; data['services']['flex']['build'] = '.' ; del data['services']['flex']['image'] ; yaml.dump(data, compose)"
-python3 -c "from pathlib import Path ; import ruamel.yaml ; compose = Path('/tmp/flex/docker-flex-monolith/flex-postgres-compose.yml') ; yaml = ruamel.yaml.YAML() ; data = yaml.load(compose) ; data['services']['flex']['build'] = '.' ; del data['services']['flex']['image'] ; yaml.dump(data, compose)"
 # --
 if [[ $GLUU_PERSISTENCE == "MYSQL" ]]; then
   docker compose -f /tmp/flex/docker-flex-monolith/flex-mysql-compose.yml up -d

--- a/automation/startflexmonolithdemo.sh
+++ b/automation/startflexmonolithdemo.sh
@@ -61,8 +61,6 @@ if [[ "$FLEX_BUILD_COMMIT" ]]; then
 
   python3 -c "from dockerfile_parse import DockerfileParser ; dfparser = DockerfileParser('/tmp/flex/docker-flex-monolith') ; dfparser.envs['FLEX_SOURCE_VERSION'] = '$FLEX_BUILD_COMMIT'"
 
-  python3 -c "from dockerfile_parse import DockerfileParser ; dfparser = DockerfileParser('/tmp/flex/docker-flex-monolith') ; dfparser.envs['CN_GLUU_LICENSE_SSA'] = '$GLUU_LICENSE_SSA'"
-
   # as FLEX_SOURCE_VERSION is changed, allow docker compose to rebuild image on-the-fly
   # and use the respective image instead of the default image
   python3 -c "from pathlib import Path ; import ruamel.yaml ; compose = Path('/tmp/flex/docker-flex-monolith/flex-mysql-compose.yml') ; yaml = ruamel.yaml.YAML() ; data = yaml.load(compose) ; data['services']['flex']['build'] = '.' ; del data['services']['flex']['image'] ; yaml.dump(data, compose)"
@@ -71,6 +69,8 @@ if [[ "$FLEX_BUILD_COMMIT" ]]; then
 
   python3 -c "from pathlib import Path ; import ruamel.yaml ; compose = Path('/tmp/flex/docker-flex-monolith/flex-ldap-compose.yml') ; yaml = ruamel.yaml.YAML() ; data = yaml.load(compose) ; data['services']['flex']['build'] = '.' ; del data['services']['flex']['image'] ; yaml.dump(data, compose)"
 fi
+
+python3 -c "from dockerfile_parse import DockerfileParser ; dfparser = DockerfileParser('/tmp/flex/docker-flex-monolith') ; dfparser.envs['CN_GLUU_LICENSE_SSA'] = '$GLUU_LICENSE_SSA'"
 # --
 if [[ $GLUU_PERSISTENCE == "MYSQL" ]]; then
   docker compose -f /tmp/flex/docker-flex-monolith/flex-mysql-compose.yml up -d

--- a/docker-flex-monolith/.gitignore
+++ b/docker-flex-monolith/.gitignore
@@ -1,2 +1,3 @@
 *-custom
 flex-deployed
+db-data

--- a/docker-flex-monolith/Dockerfile
+++ b/docker-flex-monolith/Dockerfile
@@ -16,7 +16,7 @@ RUN echo 'APT::Install-Suggests "0";' >> /etc/apt/apt.conf.d/00-docker \
 # Prevent prompt errors during package installation
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update \
-    && apt-get install -y python3 tini curl ca-certificates dbus systemd iproute2 gpg python3-pip python3-dev libpq-dev gcc \
+    && apt-get install -y python3 tini curl ca-certificates dbus systemd iproute2 gpg python3-pip python3-dev libpq-dev gcc python3-psycopg2 python3-ldap3 \
     # install certbot
     && apt-get -y install libaugeas0 \
     && pip install certbot certbot-apache \

--- a/docker-flex-monolith/flex-ldap-compose.yml
+++ b/docker-flex-monolith/flex-ldap-compose.yml
@@ -31,7 +31,7 @@ services:
       - ./jans-config-api-custom:/opt/jans/jetty/jans-config-api/custom
       - ./jans-fido2-custom:/opt/jans/jetty/jans-fido2/custom
       - ./jans-scim-custom:/opt/jans/jetty/jans-scim/custom
-      - ./flex-casa:/opt/jans/jetty/casa/custom
+      - ./flex-casa-custom:/opt/jans/jetty/casa/custom
 volumes:
   db-data:
 networks:

--- a/docker-flex-monolith/flex-mysql-compose.yml
+++ b/docker-flex-monolith/flex-mysql-compose.yml
@@ -52,7 +52,7 @@ services:
       - ./jans-config-api-custom:/opt/jans/jetty/jans-config-api/custom
       - ./jans-fido2-custom:/opt/jans/jetty/jans-fido2/custom
       - ./jans-scim-custom:/opt/jans/jetty/jans-scim/custom
-      - ./flex-casa:/opt/jans/jetty/casa/custom
+      - ./flex-casa-custom:/opt/jans/jetty/casa/custom
 volumes:
   db-data:
 networks:

--- a/docker-flex-monolith/flex-postgres-compose.yml
+++ b/docker-flex-monolith/flex-postgres-compose.yml
@@ -50,7 +50,7 @@ services:
       - ./jans-config-api-custom:/opt/jans/jetty/jans-config-api/custom
       - ./jans-fido2-custom:/opt/jans/jetty/jans-fido2/custom
       - ./jans-scim-custom:/opt/jans/jetty/jans-scim/custom
-      - ./flex-casa:/opt/jans/jetty/casa/customk
+      - ./flex-casa-custom:/opt/jans/jetty/casa/custom
 volumes:
   db-data:
 networks:

--- a/docker-flex-monolith/scripts/entrypoint.sh
+++ b/docker-flex-monolith/scripts/entrypoint.sh
@@ -46,7 +46,7 @@ install_flex() {
   echo "test_client_id=${TEST_CLIENT_ID}"| tee -a setup.properties > /dev/null
   echo "test_client_pw=${TEST_CLIENT_SECRET}" | tee -a setup.properties > /dev/null
   echo "test_client_trusted=""$([[ ${TEST_CLIENT_TRUSTED} == true ]] && echo True || echo True)" | tee -a setup.properties > /dev/null
-  echo "admin-ui-ssa=/opt/ssa.txt" | tee -a setup.properties > /dev/null
+  echo "admin-ui-ssa=/opt/ssa.jwt" | tee -a setup.properties > /dev/null
   if [[ "${CN_INSTALL_MYSQL}" == "true" ]] || [[ "${CN_INSTALL_PGSQL}" == "true" ]]; then
     echo "Installing with RDBMS"
     echo "rdbm_install=2" | tee -a setup.properties > /dev/null
@@ -70,7 +70,12 @@ install_flex() {
   echo "*****   Running the setup script for ${CN_ORG_NAME}!!   *****"
   echo "*****   PLEASE NOTE THAT THIS MAY TAKE A WHILE TO FINISH. PLEASE BE PATIENT!!   *****"
   echo "*****   Installing Gluu Flex..."
-  echo "$CN_GLUU_LICENSE_SSA" | tee -a /opt/ssa.txt > /dev/null
+
+  # create new ssa.jwt if mounted file doesn't exist
+  if [[ ! -f /opt/ssa.jwt ]]; then
+    echo "$CN_GLUU_LICENSE_SSA" | tee -a /opt/ssa.jwt > /dev/null
+  fi
+
   curl https://raw.githubusercontent.com/GluuFederation/flex/"${FLEX_SOURCE_VERSION}"/flex-linux-setup/flex_linux_setup/flex_setup.py > flex_setup.py
   python3 flex_setup.py -f setup.properties --flex-non-interactive
   echo "*****   Setup script completed!!    *****"

--- a/docker-flex-monolith/scripts/entrypoint.sh
+++ b/docker-flex-monolith/scripts/entrypoint.sh
@@ -103,17 +103,19 @@ start_services() {
   /opt/dist/scripts/jans-config-api start
   /opt/dist/scripts/jans-fido2 start
   /opt/dist/scripts/jans-scim start
-  /opt/dist/scripts/casa start
+
+  # if there's issue while installing admin-ui (for example, missing ssa file),
+  # casa won't be installed, hence the script is missing
+  /opt/dist/scripts/casa start ||:  # no-op if script is missing
 }
 
 check_installed_flex
 start_services
 register_fqdn
 
-tail -f /opt/jans/jetty/jans-auth/logs/*.log \
--f /opt/jans/jetty/jans-config-api/logs/*.log \
--f /opt/jans/jetty/jans-fido2/logs/*.log \
--f /opt/jans/jetty/jans-scim/logs/*.log \
--f /opt/jans/jetty/casa/logs/*.log
-
-
+# use -F option to follow (and retry) logs
+tail -F /opt/jans/jetty/jans-auth/logs/*.log \
+  /opt/jans/jetty/jans-config-api/logs/*.log \
+  /opt/jans/jetty/jans-fido2/logs/*.log \
+  /opt/jans/jetty/jans-scim/logs/*.log \
+  /opt/jans/jetty/casa/logs/*.log


### PR DESCRIPTION
## Notable changes

The following changes closes #992.

1. Add support for running processes using scripts under `/opt/dist/scripts` directory (for example: `/opt/dist/scripts/opendj start`)
2. allow build mode (instead of pulling image) only if `FLEX_BUILD_COMMIT` passed to `automation/startflexmonolithdemo.sh`
