### PR TITLE
feat(docker-admin-ui): set org_id as licenseHardwareKey

### DIFF
--- a/docker-admin-ui/scripts/bootstrap.py
+++ b/docker-admin-ui/scripts/bootstrap.py
@@ -275,6 +275,11 @@ def resolve_conf_app(old_conf, new_conf):
                 old_conf["licenseConfig"]["oidcClient"][attr] = new_conf["licenseConfig"]["oidcClient"][attr]
                 should_update = True
 
+        # license hardware key is changed to org_id
+        if old_conf["licenseConfig"]["licenseHardwareKey"] != new_conf["licenseConfig"]["licenseHardwareKey"]:
+            old_conf["licenseConfig"]["licenseHardwareKey"] = new_conf["licenseConfig"]["licenseHardwareKey"]
+            should_update = True
+
     # finalized status and conf
     return should_update, old_conf
 

--- a/docker-admin-ui/scripts/ssa.py
+++ b/docker-admin-ui/scripts/ssa.py
@@ -81,11 +81,7 @@ def get_license_config(manager):
         manager.config.set("license_client_id", client_id)
         manager.secret.set("license_client_pw", client_secret)
 
-    # hardware key (unique per-installation)
-    hw_key = manager.config.get("license_hardware_key")
-    if not hw_key:
-        hw_key = str(uuid.uuid4())
-        manager.config.set("license_hardware_key", hw_key)
+    hw_key = payload.get("org_id", str(uuid.uuid4()))
 
     return {
         "license_hardware_key": hw_key,


### PR DESCRIPTION
The changeset sets SSA `org_id` as license hardware key.

Closes #1052 