### PR TITLE
fix(admin-ui): session expiration dialog is not being displayed #1081

### DIFF
--- a/admin-ui/app/routes/Apps/Gluu/GluuSessionTimeoutDialog.js
+++ b/admin-ui/app/routes/Apps/Gluu/GluuSessionTimeoutDialog.js
@@ -4,10 +4,10 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Button,
   Typography,
   Slide
 } from "@mui/material"
+import { Button } from 'Components'
 import clsx from "clsx"
 import styles from "./styles/GluuSessionTimeoutDialog.style"
 import { ThemeContext } from 'Context/theme/themeContext'


### PR DESCRIPTION
issue #1081

**Cause**
The `Button` component from mui, doesn't accept custom color, 
using `Button` from `reactstrap` will solve the issue with existing feature & preferred styles.