### PR TITLE
fix(docker-admin-ui): incompatible py3-grpcio version

### DIFF
--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:hydrogen-alpine AS builder
+FROM node:hydrogen-alpine3.17 AS builder
 
 RUN apk update \
     && apk upgrade --available \
@@ -34,7 +34,7 @@ RUN cd /opt/flex/admin-ui && npm rebuild node-sass
 # Application
 # ===========
 
-FROM node:hydrogen-alpine
+FROM node:hydrogen-alpine3.17
 
 # ======
 # alpine


### PR DESCRIPTION
The changeset changes base images from `node:hydrogen-alpine` to `node:hydrogen-alpine3.17` for `py3-grpcio` compatibility.

Closes #1094 