### PR TITLE
chore(flex-cn-setup): remove duo script from flex

### DIFF
--- a/flex-cn-setup/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/configmaps.yaml
+++ b/flex-cn-setup/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/configmaps.yaml
@@ -221,6 +221,8 @@ data:
   | squote
   }}
   {{- end }}
+  # delete Duo script (https://github.com/GluuFederation/flex/issues/1120) by disabling the feature
+  CN_DUO_ENABLED: "false"
 ---
 
 apiVersion: v1


### PR DESCRIPTION
Duo script is deleted from Flex CN installation as per https://github.com/GluuFederation/flex/issues/1120.