### PR TITLE
fix(flex-linux-setup): do not remove duo script after upgrade

### DIFF
--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -520,9 +520,6 @@ class flex_installer(JettyInstaller):
         for logfn in (self.log4j2_adminui_path, self.log4j2_path):
             config_api_installer.copyFile(logfn, config_api_installer.custom_config_dir)
 
-        print("Removing DUO Script")
-        config_api_installer.dbUtils.delete_dn('inum=5018-F9CF,ou=scripts,o=jans')
-
         config_api_installer.set_class_path(glob.glob(os.path.join(config_api_installer.libDir, '*.jar')))
 
         self.rewrite_cli_ini()


### PR DESCRIPTION
closes #1235