### PR TITLE
refactor(docker): avoid context collision on custom log4j2.xml

### DIFF
--- a/docker-casa/jetty/log4j2.xml
+++ b/docker-casa/jetty/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="ERROR">
     <Properties>
-        <Property name="log.console.prefix" value="casa" />
+        <Property name="casa.log.console.prefix" value="casa" />
     </Properties>
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
@@ -25,7 +25,7 @@
 
     <Loggers>
         <Logger name="org.gluu.casa.timer" level="$timer_log_level" additivity="false">
-            <Property name="log.console.group">-timer</Property>
+            <Property name="casa.log.console.group">-timer</Property>
             <AppenderRef ref="$timer_log_target" />
         </Logger>
         <Logger name="org.gluu.casa" level="$casa_log_level" additivity="false">

--- a/docker-casa/scripts/bootstrap.py
+++ b/docker-casa/scripts/bootstrap.py
@@ -131,8 +131,11 @@ def configure_logging():
         else:
             config[key] = file_aliases[key]
 
-    if as_boolean(custom_config.get("enable_stdout_log_prefix")):
-        config["log_prefix"] = "${sys:log.console.prefix}%X{log.console.group} - "
+    if any([
+        as_boolean(custom_config.get("enable_stdout_log_prefix")),
+        as_boolean(os.environ.get("CN_ENABLE_STDOUT_LOG_PREFIX")),
+    ]):
+        config["log_prefix"] = "${sys:casa.log.console.prefix}%X{casa.log.console.group} - "
 
     with open("/app/templates/log4j2.xml") as f:
         txt = f.read()


### PR DESCRIPTION
The changeset sets namespaced context for `log.console.*` in `log4j2.xml`.

Closes #1240 