### PR TITLE
refactor(docker-casa): handle custom jetty.xml and webdefault.xml

### DIFF
--- a/docker-casa/Dockerfile
+++ b/docker-casa/Dockerfile
@@ -236,6 +236,8 @@ COPY conf/*.tmpl /app/templates/
 COPY scripts /app/scripts
 RUN chmod +x /app/scripts/entrypoint.sh
 
+RUN sed -i 's/\(<New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"\)\/\(>\)/\1\2<Set name="showContexts">false<\/Set><\/New>/' /opt/jetty/etc/jetty.xml
+
 # create non-root user
 RUN adduser -s /bin/sh -h /home/1000 -D -G root -u 1000 jetty
 
@@ -250,8 +252,6 @@ RUN chmod -R g=u ${JETTY_BASE}/casa/static \
     && chmod -R g=u /etc/certs \
     && chmod -R g=u /etc/jans \
     && chmod 664 /usr/java/latest/jre/lib/security/cacerts \
-    && chmod 664 /opt/jetty/etc/jetty.xml \
-    && chmod 664 /opt/jetty/etc/webdefault.xml \
     && chown -R 1000:0 ${JETTY_BASE}/common/libs \
     && chown -R 1000:0 /usr/share/java \
     && chown -R 1000:0 /opt/prometheus \

--- a/docker-casa/scripts/bootstrap.py
+++ b/docker-casa/scripts/bootstrap.py
@@ -40,40 +40,6 @@ logger = logging.getLogger("entrypoint")
 manager = get_manager()
 
 
-def modify_webdefault_xml():
-    fn = "/opt/jetty/etc/webdefault.xml"
-    with open(fn) as f:
-        txt = f.read()
-
-    # disable dirAllowed
-    updates = re.sub(
-        r'(<param-name>dirAllowed</param-name>)(\s*)(<param-value>)true(</param-value>)',
-        r'\1\2\3false\4',
-        txt,
-        flags=re.DOTALL | re.M,
-    )
-
-    with open(fn, "w") as f:
-        f.write(updates)
-
-
-def modify_jetty_xml():
-    fn = "/opt/jetty/etc/jetty.xml"
-    with open(fn) as f:
-        txt = f.read()
-
-    # disable contexts
-    updates = re.sub(
-        r'<New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"/>',
-        r'<New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler">\n\t\t\t\t <Set name="showContexts">false</Set>\n\t\t\t </New>',
-        txt,
-        flags=re.DOTALL | re.M,
-    )
-
-    with open(fn, "w") as f:
-        f.write(updates)
-
-
 def configure_logging():
     # default config
     config = {
@@ -200,8 +166,6 @@ def main():
         "changeit",
     )
 
-    modify_jetty_xml()
-    modify_webdefault_xml()
     configure_logging()
 
     persistence_setup = PersistenceSetup(manager)


### PR DESCRIPTION
Overview:

1. remove script to modify `/opt/jetty/etc/webdefault.xml`.
2. modifying `/opt/jetty/etc/jetty.xml` is done at image-level ops.

Closes #1249 