### PR TITLE
refactor(docker-casa): unify path to JVM cacert file

### DIFF
--- a/docker-casa/Dockerfile
+++ b/docker-casa/Dockerfile
@@ -7,9 +7,7 @@ FROM bellsoft/liberica-openjre-alpine:11.0.16
 RUN apk update \
     && apk upgrade --available \
     && apk add --no-cache python3 openssl tini py3-cryptography py3-psycopg2 py3-grpcio \
-    && apk add --no-cache --virtual .build-deps git wget zip \
-    && mkdir -p /usr/java/latest \
-    && ln -sf /usr/lib/jvm/jre /usr/java/latest/jre
+    && apk add --no-cache --virtual .build-deps git wget zip
 
 # =====
 # Jetty
@@ -245,6 +243,8 @@ RUN chmod +x /app/scripts/entrypoint.sh
 
 RUN sed -i 's/\(<New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"\)\/\(>\)/\1\2<Set name="showContexts">false<\/Set><\/New>/' /opt/jetty/etc/jetty.xml
 
+RUn ln -sf /usr/lib/jvm/jre /opt/java
+
 # create non-root user
 RUN adduser -s /bin/sh -h /home/1000 -D -G root -u 1000 jetty
 
@@ -258,7 +258,7 @@ RUN chmod -R g=u ${JETTY_BASE}/casa/static \
     && chmod -R g=u ${JETTY_BASE}/casa/logs \
     && chmod -R g=u /etc/certs \
     && chmod -R g=u /etc/jans \
-    && chmod 664 /usr/java/latest/jre/lib/security/cacerts \
+    && chmod 664 /opt/java/lib/security/cacerts \
     && chown -R 1000:0 ${JETTY_BASE}/common/libs \
     && chown -R 1000:0 /usr/share/java \
     && chown -R 1000:0 /opt/prometheus \

--- a/docker-casa/scripts/bootstrap.py
+++ b/docker-casa/scripts/bootstrap.py
@@ -162,7 +162,7 @@ def main():
     cert_to_truststore(
         "web_https",
         "/etc/certs/web_https.crt",
-        "/usr/java/latest/jre/lib/security/cacerts",
+        "/opt/java/lib/security/cacerts",
         "changeit",
     )
 


### PR DESCRIPTION
The changeset change the symlink to JVM (JRE).

Closes #1307 