### PR TITLE
fix(docker-casa): update jetty to v11.0.16

### DIFF
--- a/docker-casa/Dockerfile
+++ b/docker-casa/Dockerfile
@@ -13,7 +13,7 @@ RUN apk update \
 # Jetty
 # =====
 
-ARG JETTY_VERSION=11.0.15
+ARG JETTY_VERSION=11.0.16
 ARG JETTY_HOME=/opt/jetty
 ARG JETTY_BASE=/opt/jans/jetty
 ARG JETTY_USER_HOME_LIB=/home/jetty/lib


### PR DESCRIPTION
The changeset updates Jetty to v11.0.16.

Closes #1320 