### PR TITLE
fix(admin-ui): save form value of client in state while navigating between tabs #1341

### DIFF
--- a/admin-ui/app/routes/Apps/Gluu/GluuTypeAheadForDn.js
+++ b/admin-ui/app/routes/Apps/Gluu/GluuTypeAheadForDn.js
@@ -35,7 +35,8 @@ function GluuTypeAheadForDn({
   onPaginate = () => {},
   maxResults = undefined,
   isLoading = false,
-  placeholder = undefined
+  placeholder = undefined,
+  onChange
 }) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
@@ -83,6 +84,7 @@ function GluuTypeAheadForDn({
                     : item.dn,
               ),
             )
+            onChange?.(selected)
           }}
           disabled={disabled}
           id={name}

--- a/admin-ui/app/styles/components/wizard.scss
+++ b/admin-ui/app/styles/components/wizard.scss
@@ -4,6 +4,12 @@
 .wizard {
     display: flex;
     align-items: center;
+    overflow-x: auto;
+}
+
+.wizard-wrapper {
+    max-width: 70vw;
+    margin: 0 auto;
 }
 
 .wizard-step {
@@ -60,8 +66,8 @@
 }
 
 @media (max-width: breakpoint-max('md', $grid-breakpoints)) {
-    .wizard {
-        flex-wrap: wrap;
+    .wizard-wrapper {
+        max-width: 100vw;
     }
 
     .wizard-step {

--- a/admin-ui/plugins/auth-server/components/Clients/ClientAdvancedPanel.js
+++ b/admin-ui/plugins/auth-server/components/Clients/ClientAdvancedPanel.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Col, Container, FormGroup, InputGroup, CustomInput } from 'Components'
 import GluuBooleanSelectBox from 'Routes/Apps/Gluu/GluuBooleanSelectBox'
 import GluuLabel from 'Routes/Apps/Gluu/GluuLabel'
@@ -20,8 +20,8 @@ function ClientAdvancedPanel({ client, scripts, formik, viewOnly }) {
   const request_uri_id = 'request_uri_id'
   const requestUris = []
 
-  const [expirable, setExpirable] = useState(
-    client.expirationDate ? client.expirationDate : false,
+  const [expirable] = useState(
+    formik.values.expirationDate ? formik.values.expirationDate : false,
   )
   const [scopesModal, setScopesModal] = useState(false)
   const [expirationDate, setExpirationDate] = useState(expirable ? dayjs(expirable) : undefined)
@@ -29,14 +29,10 @@ function ClientAdvancedPanel({ client, scripts, formik, viewOnly }) {
     setScopesModal(!scopesModal)
   }
 
-  function handleExpirable() {
-    setExpirable(!expirable)
-  }
-
-  scripts = scripts
-    .filter((item) => item.scriptType == 'person_authentication')
-    .filter((item) => item.enabled)
-    .map((item) => (item.name))
+  const filteredScripts = scripts
+    ?.filter((item) => item.scriptType == 'person_authentication')
+    ?.filter((item) => item.enabled)
+    ?.map((item) => (item.name))
   function uriValidator(uri) {
     return uri
   }
@@ -46,26 +42,15 @@ function ClientAdvancedPanel({ client, scripts, formik, viewOnly }) {
     }
     return total.filter((item) => partial.includes(item))
   }
-  const [softwareSection, setSoftwareSection] = useState(false)
-  const [cibaSection, setCibaSection] = useState(false)
 
-  function handleCibaSection() {
-    setCibaSection(!cibaSection)
-  }
-  function handleSoftwareSection() {
-    setSoftwareSection(!softwareSection)
-  }
-  function emailValidator(email) {
-    return /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/.test(
-      email,
-    )
-  }
-  function getScopeMapping(exitingScopes, scopes) {
-    if (!exitingScopes) {
-      exitingScopes = []
+  useEffect(() => {
+    // Listen for changes on expirable input switch
+    if (!formik.values.expirable) {
+      formik.setFieldValue('expirationDate', null)
+      setExpirationDate(null)
     }
-    return scopes.filter((item) => exitingScopes.includes(item.dn))
-  }
+  }, [formik.values.expirable])
+
   return (
     <Container>
       <ClientShowSpontaneousScopes handler={handler} isOpen={scopesModal} />
@@ -78,7 +63,7 @@ function ClientAdvancedPanel({ client, scripts, formik, viewOnly }) {
               id="subjectType"
               name="subjectType"
               disabled={viewOnly}
-              defaultValue={client.subjectType}
+              defaultValue={formik.values.subjectType}
               onChange={formik.handleChange}
             >
               <option value="">{t('actions.choose')}...</option>
@@ -91,18 +76,18 @@ function ClientAdvancedPanel({ client, scripts, formik, viewOnly }) {
 
       <GluuToogleRow
         name="persistClientAuthorizations"
-        lsize={9}
-        rsize={3}
+        lsize={3}
+        rsize={9}
         formik={formik}
         label="fields.persist_client_authorizations"
-        value={client.persistClientAuthorizations}
+        value={formik.values.persistClientAuthorizations}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
       <GluuBooleanSelectBox
         name="allowSpontaneousScopes"
         label="fields.allow_spontaneous_scopes"
-        value={client.allowSpontaneousScopes}
+        value={formik.values.allowSpontaneousScopes}
         formik={formik}
         lsize={3}
         rsize={9}
@@ -142,7 +127,7 @@ function ClientAdvancedPanel({ client, scripts, formik, viewOnly }) {
         label="fields.initiateLoginUri"
         name="initiateLoginUri"
         formik={formik}
-        value={client.initiateLoginUri}
+        value={formik.values.initiateLoginUri}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
@@ -151,7 +136,7 @@ function ClientAdvancedPanel({ client, scripts, formik, viewOnly }) {
         label="fields.requestUris"
         formik={formik}
         placeholder={t('Enter a valid request uri eg') + ' https://...'}
-        value={client.requestUris || []}
+        value={formik.values.requestUris || []}
         options={requestUris}
         validator={uriValidator}
         inputId={request_uri_id}
@@ -164,8 +149,8 @@ function ClientAdvancedPanel({ client, scripts, formik, viewOnly }) {
         name="defaultAcrValues"
         label="fields.defaultAcrValues"
         formik={formik}
-        value={getMapping(client.defaultAcrValues, scripts)}
-        options={scripts}
+        value={getMapping(formik.values.defaultAcrValues, filteredScripts)}
+        options={filteredScripts}
         doc_category={DOC_CATEGORY}
         lsize={3}
         rsize={9}
@@ -175,8 +160,8 @@ function ClientAdvancedPanel({ client, scripts, formik, viewOnly }) {
         name="authorizedAcrValues"
         label="fields.authorizedAcrValues"
         formik={formik}
-        value={getMapping(client.authorizedAcrValues, scripts)}
-        options={scripts}
+        value={getMapping(formik.values.authorizedAcrValues, filteredScripts)}
+        options={filteredScripts}
         doc_category={DOC_CATEGORY}
         lsize={3}
         rsize={9}
@@ -188,7 +173,7 @@ function ClientAdvancedPanel({ client, scripts, formik, viewOnly }) {
         rsize={9}
         formik={formik}
         label="fields.defaultPromptLogin"
-        value={client.jansDefaultPromptLogin}
+        value={formik.values.jansDefaultPromptLogin}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
@@ -196,35 +181,33 @@ function ClientAdvancedPanel({ client, scripts, formik, viewOnly }) {
         label="fields.tls_client_auth_subject_dn"
         name="tlsClientAuthSubjectDn"
         formik={formik}
-        value={client.tlsClientAuthSubjectDn}
+        value={formik.values.tlsClientAuthSubjectDn}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
 
       <FormGroup row>
         <Col sm={6}>
-          {client.expirable && (
             <GluuToogleRow
               name="expirable"
               formik={formik}
               label="fields.is_expirable_client"
-              value={client.expirable?.length ? true : false}
-              handler={handleExpirable}
+              value={formik.values.expirable}
               doc_category={DOC_CATEGORY}
               lsize={6}
               rsize={6}
               disabled={viewOnly}
             />
-          )}
         </Col>
         <Col sm={6}>
-          {client.expirable?.length ? (
+          {formik.values.expirable ? (
             <FormGroup row>
               <Col sm={12}>
                 <LocalizationProvider dateAdapter={AdapterDayjs}>
                   <DateTimePicker
                     id="expirationDate"
                     name="expirationDate"
+                    disablePast
                     value={expirationDate}
                     onChange={(date) => {
                       formik.setFieldValue('expirationDate', new Date(date))

--- a/admin-ui/plugins/auth-server/components/Clients/ClientCibaParUmaPanel.js
+++ b/admin-ui/plugins/auth-server/components/Clients/ClientCibaParUmaPanel.js
@@ -18,10 +18,7 @@ import GluuTypeAheadForDn from 'Routes/Apps/Gluu/GluuTypeAheadForDn'
 import applicationStyle from 'Routes/Apps/Gluu/styles/applicationstyle'
 import { deleteUMAResource } from 'Plugins/auth-server/redux/features/umaResourceSlice'
 import { setCurrentItem } from 'Plugins/auth-server/redux/features/scopeSlice'
-import {
-  setCurrentItem as setCurrentItemClient,
-  viewOnly,
-} from 'Plugins/auth-server/redux/features/oidcSlice'
+import { setCurrentItem as setCurrentItemClient } from 'Plugins/auth-server/redux/features/oidcSlice'
 import GluuDialog from 'Routes/Apps/Gluu/GluuDialog'
 import 'ace-builds/src-noconflict/mode-json'
 import 'ace-builds/src-noconflict/ext-language_tools'
@@ -29,8 +26,13 @@ import GluuTooltip from 'Routes/Apps/Gluu/GluuTooltip'
 
 const DOC_CATEGORY = 'openid_client'
 
+function uriValidator(uri) {
+  return uri
+}
+const claim_uri_id = 'claim_uri_id'
+const cibaDeliveryModes = ['poll', 'push', 'ping']
+
 function ClientCibaParUmaPanel({
-  client,
   clients,
   dispatch,
   umaResources,
@@ -42,13 +44,7 @@ function ClientCibaParUmaPanel({
 }) {
   const { t } = useTranslation()
   const navigate =useNavigate()
-  const claim_uri_id = 'claim_uri_id'
-  const cibaDeliveryModes = ['poll', 'push', 'ping']
   const claimRedirectURI = []
-
-  function uriValidator(uri) {
-    return uri
-  }
 
   const [open, setOpen] = useState(false)
   const [selectedUMA, setSelectedUMA] = useState()
@@ -127,7 +123,7 @@ function ClientCibaParUmaPanel({
         name="backchannelTokenDeliveryMode"
         label="fields.backchannelTokenDeliveryMode"
         formik={formik}
-        value={client.backchannelTokenDeliveryMode}
+        value={formik.values.backchannelTokenDeliveryMode}
         values={cibaDeliveryModes}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
@@ -136,7 +132,7 @@ function ClientCibaParUmaPanel({
         label="fields.backchannelClientNotificationEndpoint"
         name="backchannelClientNotificationEndpoint"
         formik={formik}
-        value={client.backchannelClientNotificationEndpoint}
+        value={formik.values.backchannelClientNotificationEndpoint}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
@@ -145,7 +141,7 @@ function ClientCibaParUmaPanel({
         name="backchannelUserCodeParameter"
         formik={formik}
         label="fields.backchannelUserCodeParameter"
-        value={client.backchannelUserCodeParameter}
+        value={formik.values.backchannelUserCodeParameter}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
@@ -154,7 +150,7 @@ function ClientCibaParUmaPanel({
         label="fields.parLifetime"
         name="parLifetime"
         formik={formik}
-        value={client.parLifetime}
+        value={formik.values.parLifetime}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
@@ -162,7 +158,7 @@ function ClientCibaParUmaPanel({
         name="requirePar"
         formik={formik}
         label="fields.requirePar"
-        value={client.requirePar}
+        value={formik.values.requirePar}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
@@ -173,24 +169,22 @@ function ClientCibaParUmaPanel({
           <Col sm={6}>
             <RadioGroup
               row
-              name="accessTokenAsJwt"
-              value={client.rptAsJwt || true}
+              name="rptAsJwt"
+              value={formik.values.rptAsJwt?.toString() || 'true'}
               onChange={(e) => {
-                formik.setFieldValue('rptAsJwt', e.target.value == 'true')
+                formik.setFieldValue('rptAsJwt', e.target.value === 'true' ? 'true' : 'false')
               }}
             >
               <FormControlLabel
-                value={true}
+                value={'true'}
                 control={<Radio color="primary" />}
                 label="JWT"
-                checked={client.rptAsJwt == true}
                 disabled={viewOnly}
               />
               <FormControlLabel
-                value={false}
+                value={'false'}
                 control={<Radio color="primary" />}
                 label="Reference"
-                checked={client.rptAsJwt == false}
                 disabled={viewOnly}
               />
             </RadioGroup>
@@ -198,11 +192,11 @@ function ClientCibaParUmaPanel({
         </FormGroup>
       </GluuTooltip>
       <GluuTypeAheadWithAdd
-        name="claimRedirectURIs"
+        name="claimRedirectUris"
         label="fields.claimRedirectURIs"
         formik={formik}
         placeholder={t('Enter a valid claim uri eg') + ' https://...'}
-        value={client.claimRedirectUris || []}
+        value={formik.values.claimRedirectUris || []}
         options={claimRedirectURI}
         validator={uriValidator}
         inputId={claim_uri_id}
@@ -215,7 +209,7 @@ function ClientCibaParUmaPanel({
         name="rptClaimsScripts"
         label="fields.rpt_scripts"
         formik={formik}
-        value={client.rptClaimsScripts}
+        value={formik.values.rptClaimsScripts}
         options={rptScripts}
         doc_category={DOC_CATEGORY}
         doc_entry="rptClaimsScripts"

--- a/admin-ui/plugins/auth-server/components/Clients/ClientEncryptionSigningPanel.js
+++ b/admin-ui/plugins/auth-server/components/Clients/ClientEncryptionSigningPanel.js
@@ -5,7 +5,7 @@ import GluuSelectRow from 'Routes/Apps/Gluu/GluuSelectRow'
 import { useTranslation } from 'react-i18next'
 const DOC_CATEGORY = 'openid_client'
 
-function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewOnly }) {
+function ClientEncryptionSigningPanel({ formik, oidcConfiguration, viewOnly }) {
   const { t } = useTranslation()
   const accessTokenSigningAlg = !!oidcConfiguration.tokenEndpointAuthSigningAlgValuesSupported
     ? oidcConfiguration.tokenEndpointAuthSigningAlgValuesSupported
@@ -47,30 +47,13 @@ function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewO
     ? oidcConfiguration.userInfoEncryptionEncValuesSupported
     : []
 
-  // authorization
-  const jansAuthSignedRespAlg = !!oidcConfiguration.authorizationSigningAlgValuesSupported
-    ? oidcConfiguration.authorizationSigningAlgValuesSupported
-    : []
-
-  const jansAuthEncRespAlg = !!oidcConfiguration.authorizationEncryptionAlgValuesSupported
-    ? oidcConfiguration.authorizationEncryptionAlgValuesSupported
-    : []
-
-  const jansAuthEncRespEnc = !!oidcConfiguration.authorizationEncryptionEncValuesSupported
-    ? oidcConfiguration.authorizationEncryptionEncValuesSupported
-    : []
-
-  const tokenEndpointAuthMethod = !!oidcConfiguration.tokenEndpointAuthMethodsSupported
-    ? oidcConfiguration.tokenEndpointAuthMethodsSupported
-    : []
-
   return (
     <Container>
       <GluuInputRow
         label="fields.jwks_uri"
         name="jwksUri"
         formik={formik}
-        value={client.jwksUri}
+        value={formik.values.jwksUri}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
@@ -78,7 +61,7 @@ function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewO
         label="fields.jwks"
         name="jwks"
         formik={formik}
-        value={client.jwks}
+        value={formik.values.jwks}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
@@ -88,7 +71,7 @@ function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewO
           <GluuSelectRow
             label="fields.id_token_signed_response_alg"
             formik={formik}
-            value={client.accessTokenSigningAlg}
+            value={formik.values.accessTokenSigningAlg}
             values={idTokenSignedResponseAlg}
             lsize={6}
             rsize={6}
@@ -103,7 +86,7 @@ function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewO
             formik={formik}
             lsize={6}
             rsize={6}
-            value={client.idTokenEncryptedResponseAlg}
+            value={formik.values.idTokenEncryptedResponseAlg}
             values={idTokenEncryptedResponseAlg}
             name="idTokenEncryptedResponseAlg"
             doc_category={DOC_CATEGORY}
@@ -114,7 +97,7 @@ function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewO
           <GluuSelectRow
             label="fields.id_token_encrypted_response_enc"
             formik={formik}
-            value={client.idTokenEncryptedResponseEnc}
+            value={formik.values.idTokenEncryptedResponseEnc}
             values={idTokenEncryptedResponseEnc}
             lsize={6}
             rsize={6}
@@ -130,7 +113,7 @@ function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewO
           <GluuSelectRow
             label="fields.access_token_signing_alg"
             formik={formik}
-            value={client.accessTokenSigningAlg}
+            value={formik.values.accessTokenSigningAlg}
             values={accessTokenSigningAlg}
             lsize={6}
             rsize={6}
@@ -146,7 +129,7 @@ function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewO
           <GluuSelectRow
             label="fields.user_info_signed_response_alg"
             formik={formik}
-            value={client.userInfoSignedResponseAlg}
+            value={formik.values.userInfoSignedResponseAlg}
             values={userInfoSignedResponseAlg}
             lsize={6}
             rsize={6}
@@ -159,7 +142,7 @@ function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewO
           <GluuSelectRow
             label="fields.user_info_encrypted_response_alg"
             formik={formik}
-            value={client.userInfoEncryptedResponseAlg}
+            value={formik.values.userInfoEncryptedResponseAlg}
             values={userInfoEncryptedResponseAlg}
             lsize={6}
             rsize={6}
@@ -172,7 +155,7 @@ function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewO
           <GluuSelectRow
             label="fields.user_info_encrypted_response_enc"
             formik={formik}
-            value={client.userInfoEncryptedResponseEnc}
+            value={formik.values.userInfoEncryptedResponseEnc}
             values={userInfoEncryptedResponseEnc}
             lsize={6}
             rsize={6}
@@ -188,7 +171,7 @@ function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewO
           <GluuSelectRow
             label="fields.authorizationSignedResponseAlg"
             formik={formik}
-            value={client.jansAuthSignedRespAlg}
+            value={formik.values.jansAuthSignedRespAlg}
             values={idTokenSignedResponseAlg}
             lsize={6}
             rsize={6}
@@ -203,7 +186,7 @@ function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewO
             formik={formik}
             lsize={6}
             rsize={6}
-            value={client.jansAuthEncRespAlg}
+            value={formik.values.jansAuthEncRespAlg}
             values={idTokenEncryptedResponseAlg}
             name="jansAuthEncRespAlg"
             doc_category={DOC_CATEGORY}
@@ -214,7 +197,7 @@ function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewO
           <GluuSelectRow
             label="fields.authorizationEncryptedResponseEnc"
             formik={formik}
-            value={client.jansAuthEncRespEnc}
+            value={formik.values.jansAuthEncRespEnc}
             values={idTokenEncryptedResponseEnc}
             lsize={6}
             rsize={6}
@@ -230,7 +213,7 @@ function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewO
           <GluuSelectRow
             label="fields.request_object_signing_alg"
             formik={formik}
-            value={client.requestObjectSigningAlg}
+            value={formik.values.requestObjectSigningAlg}
             values={requestObjectSignedResponseAlg}
             lsize={6}
             rsize={6}
@@ -243,7 +226,7 @@ function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewO
           <GluuSelectRow
             label="fields.request_object_encryption_alg"
             formik={formik}
-            value={client.requestObjectEncryptionAlg}
+            value={formik.values.requestObjectEncryptionAlg}
             values={requestObjectEncryptedResponseAlg}
             lsize={6}
             rsize={6}
@@ -256,7 +239,7 @@ function ClientEncryptionSigningPanel({ client, formik, oidcConfiguration, viewO
           <GluuSelectRow
             label="fields.request_object_encryption_enc"
             formik={formik}
-            value={client.requestObjectEncryptionEnc}
+            value={formik.values.requestObjectEncryptionEnc}
             values={requestObjectEncryptedResponseEnc}
             lsize={6}
             rsize={6}

--- a/admin-ui/plugins/auth-server/components/Clients/ClientLogoutPanel.js
+++ b/admin-ui/plugins/auth-server/components/Clients/ClientLogoutPanel.js
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
-import { Col, Container, FormGroup } from 'Components'
+import React from 'react'
+import { Container } from 'Components'
 import GluuToogleRow from 'Routes/Apps/Gluu/GluuToogleRow'
 import GluuInputRow from 'Routes/Apps/Gluu/GluuInputRow'
 import GluuTypeAheadWithAdd from 'Routes/Apps/Gluu/GluuTypeAheadWithAdd'
@@ -7,28 +7,19 @@ import GluuBooleanSelectBox from 'Routes/Apps/Gluu/GluuBooleanSelectBox'
 import { useTranslation } from 'react-i18next'
 const DOC_CATEGORY = 'openid_client'
 
-function ClientLogoutPanel({ client, scripts, formik, viewOnly }) {
+function uriValidator(uri) {
+  return uri
+}
+const post_uri_id = 'post_uri_id'
+const postLogoutRedirectUris = []
+function postUriValidator(uri) {
+  return uri
+}
+const backchannelLogoutUris = []
+const backchannel_uri_id = 'backchannel_uri_id'
+
+function ClientLogoutPanel({ formik, viewOnly }) {
   const { t } = useTranslation()
-
-  scripts = scripts
-    .filter((item) => item.scriptType == 'person_authentication')
-    .filter((item) => item.enabled)
-    .map((item) => ({ dn: item.dn, name: item.name }))
-  function uriValidator(uri) {
-    return uri
-  }
-
-  const postLogoutRedirectUris = []
-  function postUriValidator(uri) {
-    return uri
-  }
-  const post_uri_id = 'post_uri_id'
-
-  const backchannelLogoutUris = []
-  function uriValidator(uri) {
-    return uri
-  }
-  const backchannel_uri_id = 'backchannel_uri_id'
 
   return (
     <Container>
@@ -36,7 +27,7 @@ function ClientLogoutPanel({ client, scripts, formik, viewOnly }) {
         label="fields.frontChannelLogoutUri"
         name="frontChannelLogoutUri"
         formik={formik}
-        value={client.frontChannelLogoutUri}
+        value={formik.values.frontChannelLogoutUri}
         doc_category={DOC_CATEGORY}
         lsize={4}
         rsize={8}
@@ -47,7 +38,7 @@ function ClientLogoutPanel({ client, scripts, formik, viewOnly }) {
         label="fields.post_logout_redirect_uris"
         formik={formik}
         placeholder={t('placeholders.post_logout_redirect_uris')}
-        value={client.postLogoutRedirectUris || []}
+        value={formik.values.postLogoutRedirectUris || []}
         options={postLogoutRedirectUris}
         validator={postUriValidator}
         inputId={post_uri_id}
@@ -60,7 +51,7 @@ function ClientLogoutPanel({ client, scripts, formik, viewOnly }) {
         label="fields.backchannelLogoutUri"
         formik={formik}
         placeholder={t('Enter a valid uri with pattern') + ' https://'}
-        value={client.backchannelLogoutUri || []}
+        value={formik.values.backchannelLogoutUri || []}
         options={backchannelLogoutUris}
         validator={uriValidator}
         inputId={backchannel_uri_id}
@@ -70,7 +61,7 @@ function ClientLogoutPanel({ client, scripts, formik, viewOnly }) {
       <GluuBooleanSelectBox
         name="backchannelLogoutSessionRequired"
         label="fields.backchannelLogoutSessionRequired"
-        value={client.backchannelLogoutSessionRequired}
+        value={formik.values.backchannelLogoutSessionRequired}
         formik={formik}
         lsize={4}
         rsize={8}
@@ -84,7 +75,7 @@ function ClientLogoutPanel({ client, scripts, formik, viewOnly }) {
         rsize={8}
         formik={formik}
         label="fields.frontChannelLogoutSessionRequired"
-        value={client.frontChannelLogoutSessionRequired}
+        value={formik.values.frontChannelLogoutSessionRequired}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />

--- a/admin-ui/plugins/auth-server/components/Clients/ClientScriptPanel.js
+++ b/admin-ui/plugins/auth-server/components/Clients/ClientScriptPanel.js
@@ -4,7 +4,7 @@ import GluuTypeAheadForDn from 'Routes/Apps/Gluu/GluuTypeAheadForDn'
 
 const DOC_CATEGORY = 'openid_client'
 
-function ClientScriptPanel({ client, scripts, formik, viewOnly }) {
+function ClientScriptPanel({ scripts, formik, viewOnly }) {
   const postScripts = scripts
     .filter((item) => item.scriptType == 'post_authn')
     .filter((item) => item.enabled)
@@ -45,7 +45,7 @@ function ClientScriptPanel({ client, scripts, formik, viewOnly }) {
         name="spontaneousScopeScriptDns"
         label="fields.spontaneous_scopes"
         formik={formik}
-        value={getMapping(client?.spontaneousScopeScriptDns,spontaneousScripts)}
+        value={getMapping(formik.values?.spontaneousScopeScriptDns,spontaneousScripts)}
         options={spontaneousScripts}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
@@ -54,7 +54,7 @@ function ClientScriptPanel({ client, scripts, formik, viewOnly }) {
         name="updateTokenScriptDns"
         label="fields.updateTokenScriptDns"
         formik={formik}
-        value={getMapping(client?.updateTokenScriptDns, updateTokenScriptDns)}
+        value={getMapping(formik.values?.updateTokenScriptDns, updateTokenScriptDns)}
         options={updateTokenScriptDns}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
@@ -63,7 +63,7 @@ function ClientScriptPanel({ client, scripts, formik, viewOnly }) {
         name="postAuthnScripts"
         label="fields.post_authn_scripts"
         formik={formik}
-        value={getMapping(client?.postAuthnScripts, postScripts)}
+        value={getMapping(formik.values?.postAuthnScripts, postScripts)}
         options={postScripts}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
@@ -72,7 +72,7 @@ function ClientScriptPanel({ client, scripts, formik, viewOnly }) {
         name="introspectionScripts"
         label="fields.introspection_scripts"
         formik={formik}
-        value={getMapping(client?.introspectionScripts, instrospectionScripts)}
+        value={getMapping(formik.values?.introspectionScripts, instrospectionScripts)}
         options={instrospectionScripts}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
@@ -81,7 +81,7 @@ function ClientScriptPanel({ client, scripts, formik, viewOnly }) {
         name="ropcScripts"
         label="fields.ropcScripts"
         formik={formik}
-        value={getMapping(client?.ropcScripts, ropcScripts)}
+        value={getMapping(formik.values?.ropcScripts, ropcScripts)}
         options={ropcScripts}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
@@ -90,7 +90,7 @@ function ClientScriptPanel({ client, scripts, formik, viewOnly }) {
         name="consentGatheringScripts"
         label="fields.consent_gathering_scripts"
         formik={formik}
-        value={getMapping(client?.consentGatheringScripts, consentScripts)}
+        value={getMapping(formik.values?.consentGatheringScripts, consentScripts)}
         options={consentScripts}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}

--- a/admin-ui/plugins/auth-server/components/Clients/ClientSoftwarePanel.js
+++ b/admin-ui/plugins/auth-server/components/Clients/ClientSoftwarePanel.js
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
-import { Col, Container, FormGroup } from 'Components'
+import React from 'react'
+import { Container } from 'Components'
 import GluuInputRow from 'Routes/Apps/Gluu/GluuInputRow'
 import GluuTypeAheadWithAdd from 'Routes/Apps/Gluu/GluuTypeAheadWithAdd'
 import { useTranslation } from 'react-i18next'
@@ -7,33 +7,31 @@ import isEmpty from 'lodash/isEmpty'
 const DOC_CATEGORY = 'openid_client'
 
 const EMPTY = ''
-function ClientSoftwarePanel({ client, scripts, formik, viewOnly }) {
+const origin_uri_id = 'origin_uri_id'
+const contact_uri_id = 'contact_uri_id'
+const contacts = []
+const authorizedOrigins = []
+
+function uriValidator(uri) {
+  return uri
+}
+
+function emailValidator(email) {
+  return /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/.test(
+    email,
+  )
+}
+
+function ClientSoftwarePanel({ formik, viewOnly }) {
   const { t } = useTranslation()
 
-  const origin_uri_id = 'origin_uri_id'
-  const contact_uri_id = 'contact_uri_id'
-  const contacts = []
-  const authorizedOrigins = []
-  scripts = scripts
-    .filter((item) => item.scriptType == 'person_authentication')
-    .filter((item) => item.enabled)
-    .map((item) => ({ dn: item.dn, name: item.name }))
-  function uriValidator(uri) {
-    return uri
-  }
-
-  function emailValidator(email) {
-    return /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/.test(
-      email,
-    )
-  }
   return (
     <Container>
       <GluuInputRow
         label="fields.clientUri"
         name="clientUri"
         formik={formik}
-        value={isEmpty(client.clientUri) ? EMPTY : client.clientUri}
+        value={isEmpty(formik.values.clientUri) ? EMPTY : formik.values.clientUri}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
@@ -41,7 +39,7 @@ function ClientSoftwarePanel({ client, scripts, formik, viewOnly }) {
         label="fields.policy_uri"
         name="policyUri"
         formik={formik}
-        value={isEmpty(client.policyUri) ? EMPTY : client.policyUri}
+        value={isEmpty(formik.values.policyUri) ? EMPTY : formik.values.policyUri}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
@@ -49,7 +47,7 @@ function ClientSoftwarePanel({ client, scripts, formik, viewOnly }) {
         label="fields.logo_uri"
         name="logoUri"
         formik={formik}
-        value={isEmpty(client.logoUri) ? EMPTY : client.logoUri}
+        value={isEmpty(formik.values.logoUri) ? EMPTY : formik.values.logoUri}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
@@ -57,7 +55,7 @@ function ClientSoftwarePanel({ client, scripts, formik, viewOnly }) {
         label="fields.tosUri"
         name="tosUri"
         formik={formik}
-        value={isEmpty(client.tosUri) ? EMPTY : client.tosUri}
+        value={isEmpty(formik.values.tosUri) ? EMPTY : formik.values.tosUri}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
@@ -66,7 +64,7 @@ function ClientSoftwarePanel({ client, scripts, formik, viewOnly }) {
         label="fields.contacts"
         formik={formik}
         placeholder="Eg. sample@org.com"
-        value={client.contacts || []}
+        value={formik.values.contacts || []}
         options={contacts}
         validator={emailValidator}
         inputId={contact_uri_id}
@@ -80,7 +78,7 @@ function ClientSoftwarePanel({ client, scripts, formik, viewOnly }) {
         label="fields.authorizedOrigins"
         formik={formik}
         placeholder={t('Enter a valid origin uri eg') + ' https://...'}
-        value={client.authorizedOrigins || []}
+        value={formik.values.authorizedOrigins || []}
         options={authorizedOrigins}
         validator={uriValidator}
         inputId={origin_uri_id}
@@ -94,7 +92,7 @@ function ClientSoftwarePanel({ client, scripts, formik, viewOnly }) {
         label="fields.softwareId"
         name="softwareId"
         formik={formik}
-        value={client.softwareId}
+        value={formik.values.softwareId}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
@@ -103,7 +101,7 @@ function ClientSoftwarePanel({ client, scripts, formik, viewOnly }) {
         label="fields.softwareVersion"
         name="softwareVersion"
         formik={formik}
-        value={client.softwareVersion}
+        value={formik.values.softwareVersion}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />
@@ -112,7 +110,7 @@ function ClientSoftwarePanel({ client, scripts, formik, viewOnly }) {
         label="fields.softwareStatement"
         name="softwareStatement"
         formik={formik}
-        value={client.softwareStatement}
+        value={formik.values.softwareStatement}
         doc_category={DOC_CATEGORY}
         disabled={viewOnly}
       />

--- a/admin-ui/plugins/auth-server/components/Clients/ClientTokensPanel.js
+++ b/admin-ui/plugins/auth-server/components/Clients/ClientTokensPanel.js
@@ -1,50 +1,19 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { Col, Container, FormGroup } from 'Components'
 import GluuLabel from 'Routes/Apps/Gluu/GluuLabel'
 import GluuToogleRow from 'Routes/Apps/Gluu/GluuToogleRow'
 import GluuInputRow from 'Routes/Apps/Gluu/GluuInputRow'
 import GluuBooleanSelectBox from 'Routes/Apps/Gluu/GluuBooleanSelectBox'
 import GluuTypeAheadWithAdd from 'Routes/Apps/Gluu/GluuTypeAheadWithAdd'
-import { useTranslation } from 'react-i18next'
 import { FormControlLabel, Radio, RadioGroup } from '@mui/material'
-import GluuTooltip from 'Routes/Apps/Gluu/GluuTooltip'
 const DOC_CATEGORY = 'openid_client'
 
-function ClientTokensPanel({ client, scripts, formik, viewOnly }) {
-  const { t } = useTranslation()
-  const additionalAudiences = []
-  function audienceValidator(aud) {
-    return aud
-  }
-  const audience_id = 'audience_id'
+const audience_id = 'audience_id'
+function audienceValidator(aud) {
+  return aud
+}
 
-  scripts = scripts
-    .filter((item) => item.scriptType == 'person_authentication')
-    .filter((item) => item.enabled)
-    .map((item) => ({ dn: item.dn, name: item.name }))
-  function uriValidator(uri) {
-    return uri
-  }
-  function getMapping(partial, total) {
-    if (!partial) {
-      partial = []
-    }
-    return total.filter((item) => partial.includes(item.dn))
-  }
-  const [softwareSection, setSoftwareSection] = useState(false)
-  const [cibaSection, setCibaSection] = useState(false)
-
-  function handleCibaSection() {
-    setCibaSection(!cibaSection)
-  }
-  function handleSoftwareSection() {
-    setSoftwareSection(!softwareSection)
-  }
-  function emailValidator(email) {
-    return /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/.test(
-      email,
-    )
-  }
+function ClientTokensPanel({ formik, viewOnly }) {
   return (
     <Container>
       <FormGroup row>
@@ -56,26 +25,24 @@ function ClientTokensPanel({ client, scripts, formik, viewOnly }) {
                 <RadioGroup
                   row
                   name="accessTokenAsJwt"
-                  value={client.accessTokenAsJwt || true}
+                  value={formik.values.accessTokenAsJwt?.toString() || 'true'}
                   onChange={(e) => {
                     formik.setFieldValue(
                       'accessTokenAsJwt',
-                      e.target.value == 'true',
+                      e.target.value === 'true' ? 'true' : 'false',
                     )
                   }}
                 >
                   <FormControlLabel
-                    value={true}
+                    value={'true'}
                     control={<Radio color="primary" />}
                     label="JWT"
-                    checked={client.accessTokenAsJwt == true}
                     disabled={viewOnly}
                   />
                   <FormControlLabel
-                    value={false}
+                    value={'false'}
                     control={<Radio color="primary" />}
                     label="Reference"
-                    checked={client.accessTokenAsJwt == false}
                     disabled={viewOnly}
                   />
                 </RadioGroup>
@@ -89,7 +56,7 @@ function ClientTokensPanel({ client, scripts, formik, viewOnly }) {
             rsize={8}
             formik={formik}
             label="fields.includeClaimsInIdToken"
-            value={client.includeClaimsInIdToken}
+            value={formik.values.includeClaimsInIdToken}
             doc_category={DOC_CATEGORY}
             disabled={viewOnly}
           />
@@ -101,7 +68,7 @@ function ClientTokensPanel({ client, scripts, formik, viewOnly }) {
             rsize={8}
             formik={formik}
             label="fields.requireAuthTime"
-            value={client.requireAuthTime}
+            value={formik.values.requireAuthTime}
             doc_category={DOC_CATEGORY}
             disabled={viewOnly}
           />
@@ -112,7 +79,7 @@ function ClientTokensPanel({ client, scripts, formik, viewOnly }) {
         name="runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims"
         label="fields.run_introspection_script_before_accesstoken"
         value={
-          client.runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims
+          formik.values.runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims
         }
         formik={formik}
         lsize={8}
@@ -124,7 +91,7 @@ function ClientTokensPanel({ client, scripts, formik, viewOnly }) {
         label="fields.idTokenTokenBindingCnf"
         name="idTokenTokenBindingCnf"
         formik={formik}
-        value={client.idTokenTokenBindingCnf}
+        value={formik.values.idTokenTokenBindingCnf}
         doc_category={DOC_CATEGORY}
         lsize={4}
         rsize={8}
@@ -134,8 +101,8 @@ function ClientTokensPanel({ client, scripts, formik, viewOnly }) {
         name="additionalAudience"
         label="fields.additionalAudience"
         formik={formik}
-        value={client.additionalAudience || []}
-        options={additionalAudiences}
+        value={formik.values.additionalAudience || []}
+        options={[]}
         validator={audienceValidator}
         inputId={audience_id}
         doc_category={DOC_CATEGORY}
@@ -147,7 +114,7 @@ function ClientTokensPanel({ client, scripts, formik, viewOnly }) {
         name="accessTokenLifetime"
         formik={formik}
         type="number"
-        value={client.accessTokenLifetime}
+        value={formik.values.accessTokenLifetime}
         doc_category={DOC_CATEGORY}
         lsize={4}
         rsize={8}
@@ -158,7 +125,7 @@ function ClientTokensPanel({ client, scripts, formik, viewOnly }) {
         name="refreshTokenLifetime"
         formik={formik}
         type="number"
-        value={client.refreshTokenLifetime}
+        value={formik.values.refreshTokenLifetime}
         doc_category={DOC_CATEGORY}
         lsize={4}
         rsize={8}
@@ -169,7 +136,7 @@ function ClientTokensPanel({ client, scripts, formik, viewOnly }) {
         name="defaultMaxAge"
         formik={formik}
         type="number"
-        value={client.defaultMaxAge}
+        value={formik.values.defaultMaxAge}
         doc_category={DOC_CATEGORY}
         lsize={4}
         rsize={8}

--- a/admin-ui/plugins/auth-server/redux/features/oidcSlice.js
+++ b/admin-ui/plugins/auth-server/redux/features/oidcSlice.js
@@ -43,12 +43,10 @@ const oidcSlice = createSlice({
     },
     addClientResponse: (state, action) => {
       state.loading = false
+      state.saveOperationFlag = true
       if (action.payload?.data) {
-        state.items = [...state.items]
-        state.saveOperationFlag = true
         state.errorInSaveOperationFlag = false
       } else {
-        state.saveOperationFlag = true
         state.errorInSaveOperationFlag = true
       }
     },
@@ -61,7 +59,7 @@ const oidcSlice = createSlice({
     editClientResponse: (state, action) => {
       state.loading = false
       if (action.payload?.data) {
-        const clients = state.items.filter(
+        const clients = state?.items?.filter(
           (e) => e.inum !== action.payload.data.inum
         )
         state.items = [action.payload.data, ...clients]

--- a/admin-ui/plugins/auth-server/redux/features/scopeSlice.js
+++ b/admin-ui/plugins/auth-server/redux/features/scopeSlice.js
@@ -11,6 +11,7 @@ const initialState = {
   entriesCount: 0,
   clientScopes: [],
   loadingClientScopes: false,
+  selectedClientScopes: []
 }
 
 const scopeSlice = createSlice({
@@ -125,6 +126,9 @@ const scopeSlice = createSlice({
     },
     emptyScopes: (state) => {
       state.items = []
+    },
+    setClientSelectedScopes: (state, action) => {
+      state.selectedClientScopes = action.payload
     }
   },
 })
@@ -147,7 +151,8 @@ export const {
   getScopeByCreator,
   getScopeByInum,
   getClientScopes,
-  emptyScopes
+  emptyScopes,
+  setClientSelectedScopes
 } = scopeSlice.actions
 export { initialState }
 export const { actions, reducer, state } = scopeSlice


### PR DESCRIPTION
closes #1341

changes includes
- UI improvements in add/edit client form screen
- fixed expirable client input field
- removed dead unused code in form
- fixed radio selection of Access token type & RPT token type fields
- use `formik` to display input values (this will help UI input elements to display input values even if there are changes in tab) 