### PR TITLE
fix(admin-ui): use getCustomScriptType to fetch script-types

### DIFF
--- a/admin-ui/plugins/admin/redux/api/ScriptApi.js
+++ b/admin-ui/plugins/admin/redux/api/ScriptApi.js
@@ -14,7 +14,7 @@ export default class ScriptApi {
 
   getCustomScriptTypes = () => {
     return new Promise((resolve, reject) => {
-      this.api.getCustomScriptTypes((error, data) => {
+      this.api.getCustomScriptType((error, data) => {
         handleResponse(error, reject, resolve, data)
       })
     })


### PR DESCRIPTION
testing `/script-types` endpoint using method `getCustomScriptType` instead of `getCustomScriptTypes`.