### PR TITLE
fix(flex-linux-setup): typo auiBackenApiClient

### DIFF
--- a/flex-linux-setup/flex_linux_setup/templates/auiConfiguration.json
+++ b/flex-linux-setup/flex_linux_setup/templates/auiConfiguration.json
@@ -17,7 +17,7 @@
       "postLogoutUri": "https://%(hostname)s/admin",
       "frontchannelLogoutUri": "https://%(hostname)s/admin/logout"
     },
-    "auiBackenApiClient": {
+    "auiBackendApiClient": {
       "opHost": "https://%(hostname)s",
       "clientId": "%(admin_ui_web_client_id)s",
       "clientSecret": "%(admin_ui_web_client_encoded_pw)s",


### PR DESCRIPTION
closes #1399