### PR TITLE
chore(deps): add jwcrypto dependency to flex-all-in-one image

### DIFF
--- a/docker-flex-all-in-one/Dockerfile
+++ b/docker-flex-all-in-one/Dockerfile
@@ -4,11 +4,11 @@
 
 # the following ARGs set default base images
 # they can be overriden in build process via --build-arg option
-ARG JANS_AIO_IMAGE=ghcr.io/janssenproject/jans/all-in-one:1.0.21_dev 
-ARG FLEX_ADMIN_UI_IMAGE=ghcr.io/gluufederation/flex/admin-ui:1.0.21_dev 
+ARG JANS_AIO_IMAGE=ghcr.io/janssenproject/jans/all-in-one:1.0.21_dev
+ARG FLEX_ADMIN_UI_IMAGE=ghcr.io/gluufederation/flex/admin-ui:1.0.21_dev
 
 # original Janssen version
-ARG CN_VERSION="1.0.21" 
+ARG CN_VERSION="1.0.21"
 
 # -----------
 # base images
@@ -60,9 +60,10 @@ RUN ln -sf /app/flex_aio/admin_ui/entrypoint.sh /app/bin/admin-ui-entrypoint.sh
 # Python
 # ------
 
+COPY app/requirements.flex.txt /app/
 RUN python3 -m ensurepip \
     && pip3 install --no-cache-dir -U pip wheel setuptools \
-    && pip3 install --no-cache-dir --default-timeout=300 -r /app/requirements.txt \
+    && pip3 install --no-cache-dir --default-timeout=300 -r /app/requirements.flex.txt \
     && pip3 uninstall -y pip wheel
 
 # -------

--- a/docker-flex-all-in-one/app/requirements.flex.txt
+++ b/docker-flex-all-in-one/app/requirements.flex.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+jwcrypto==1.4.2


### PR DESCRIPTION
Add `jwcrypto` lib as direct dependency of `flex-all-in-one` image.

Closes #1483 