### PR TITLE
chore(docker): sync patched jans_schema.json

### DIFF
--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -7,7 +7,7 @@ RUN apk update \
 # TODO:
 # - use NODE_ENV=production
 # - download build package (not git clone)
-ENV ADMIN_UI_VERSION=4485b8757999131d2d5d02fe7e0ef76abe652f0d
+ENV ADMIN_UI_VERSION=344035e0ad34d178845271a320d5a067984447f4
 
 RUN mkdir -p /opt/flex
 
@@ -68,7 +68,7 @@ RUN python3 -m ensurepip \
 # jans-linux-setup sync
 # =====================
 
-ENV JANS_SOURCE_VERSION=2918c11a25b50a395c71ad5dc252cf49d319a407
+ENV JANS_SOURCE_VERSION=44a893b1141e34f74f809362c84e68c90eb2c05e
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)


### PR DESCRIPTION
Sync fixed `jans_schema.json` from Janssen.

Closes #1497 