### PR TITLE
fix(flex-linux-setup): stop jans-auth and config-api before building admin-ui

### DIFF
--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -411,6 +411,12 @@ class flex_installer(JettyInstaller):
         print("Extracting admin-ui from", self.flex_path)
         base.extract_from_zip(self.flex_path, 'admin-ui', self.source_dir)
 
+        print("Stopping Jans Auth")
+        config_api_installer.stop('jans-auth')
+
+        print("Stopping Janssen Config Api")
+        config_api_installer.stop()
+
         print("Building Gluu Admin UI Frontend")
         env_tmp = os.path.join(self.source_dir, '.env.tmp')
         config_api_installer.renderTemplateInOut(env_tmp, self.source_dir, self.source_dir)


### PR DESCRIPTION
closes #1501