### PR TITLE
chore(docker-admin-ui): add ssa.admin scope to Admin UI backend client

### DIFF
--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -7,7 +7,7 @@ RUN apk update \
 # TODO:
 # - use NODE_ENV=production
 # - download build package (not git clone)
-ENV ADMIN_UI_VERSION=cee44ca8f5e66e5d1861fe499665f9dac40183ce
+ENV ADMIN_UI_VERSION=523ae4cc2ddc460c922b363632f84b85925d0684
 
 RUN mkdir -p /opt/flex
 
@@ -68,7 +68,7 @@ RUN python3 -m ensurepip \
 # jans-linux-setup sync
 # =====================
 
-ENV JANS_SOURCE_VERSION=07c82da7eb1ea1c432cb6d1b3ab2f1e316fbdac3
+ENV JANS_SOURCE_VERSION=ef2943edbc728d55041175c6467a22395545ec58
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)

--- a/docker-admin-ui/scripts/upgrade.py
+++ b/docker-admin-ui/scripts/upgrade.py
@@ -319,6 +319,11 @@ class Upgrade:
             resp_types.append("token")
             should_update = True
 
+        # add SSA admin scope
+        if "inum=B9D2-D6E5,ou=scopes,o=jans" not in scopes:
+            scopes.append("inum=B9D2-D6E5,ou=scopes,o=jans")
+            should_update = True
+
         if self.backend.type == "sql" and self.backend.client.dialect == "mysql":
             entry.attrs["jansScope"]["v"] = scopes
             entry.attrs["jansGrantTyp"]["v"] = grant_types

--- a/docker-admin-ui/templates/admin-ui/clients.ldif
+++ b/docker-admin-ui/templates/admin-ui/clients.ldif
@@ -54,6 +54,7 @@ jansLogoutSessRequired: false
 jansRespTyp: token
 jansRptAsJwt: false
 jansScope: inum=F0C4,ou=scopes,o=jans
+jansScope: inum=B9D2-D6E5,ou=scopes,o=jans
 jansSubjectTyp: pairwise
 jansTknEndpointAuthMethod: client_secret_basic
 jansTrustedClnt: false


### PR DESCRIPTION
The changesets add `https://jans.io/auth/ssa.admin` scope to Admin UI Backend API client.

Closes #1524  