### PR TITLE
fix(admin-ui): get feature mapped webhooks on read permission

### DIFF
--- a/admin-ui/app/routes/Apps/Gluu/GluuCommitDialog.js
+++ b/admin-ui/app/routes/Apps/Gluu/GluuCommitDialog.js
@@ -15,6 +15,7 @@ import { ThemeContext } from 'Context/theme/themeContext'
 import PropTypes from 'prop-types'
 import { useSelector } from 'react-redux'
 import useWebhookDialogAction from 'Utils/hooks/useWebhookDialogAction'
+import { hasPermission, WEBHOOK_READ } from 'Utils/PermChecker'
 
 const USER_MESSAGE = 'user_action_message'
 
@@ -29,6 +30,7 @@ const GluuCommitDialog = ({
   inputType,
   feature,
 }) => {
+  const permissions = useSelector((state) => state.authReducer.permissions)
   const { t } = useTranslation()
   const theme = useContext(ThemeContext)
   const selectedTheme = theme.state.theme
@@ -70,7 +72,7 @@ const GluuCommitDialog = ({
 
   return (
     <>
-      {webhookModal || loadingWebhooks ? (
+      {(webhookModal || loadingWebhooks) && hasPermission(permissions, WEBHOOK_READ) ? (
         <>{webhookTriggerModal({ closeModal })}</>
       ) : (
         <Modal

--- a/admin-ui/app/routes/Apps/Gluu/GluuDialog.js
+++ b/admin-ui/app/routes/Apps/Gluu/GluuDialog.js
@@ -15,6 +15,7 @@ import { ThemeContext } from 'Context/theme/themeContext'
 import PropTypes from 'prop-types'
 import { useSelector } from 'react-redux'
 import useWebhookDialogAction from 'Utils/hooks/useWebhookDialogAction'
+import { hasPermission, WEBHOOK_READ } from 'Utils/PermChecker'
 
 const GluuDialog = ({
   row,
@@ -25,6 +26,7 @@ const GluuDialog = ({
   name,
   feature,
 }) => {
+  const permissions = useSelector((state) => state.authReducer.permissions)
   const [active, setActive] = useState(false)
   const { t } = useTranslation()
   const [userMessage, setUserMessage] = useState('')
@@ -62,7 +64,7 @@ const GluuDialog = ({
 
   return (
     <>
-      {webhookModal || loadingWebhooks ? (
+      {(webhookModal || loadingWebhooks) && hasPermission(permissions, WEBHOOK_READ) ? (
         <>{webhookTriggerModal({ closeModal })}</>
       ) : (
         <Modal

--- a/admin-ui/app/utils/hooks/useWebhookDialogAction.js
+++ b/admin-ui/app/utils/hooks/useWebhookDialogAction.js
@@ -19,10 +19,12 @@ import TableCell from '@mui/material/TableCell'
 import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
 import Box from '@mui/material/Box'
+import { hasPermission, WEBHOOK_READ } from 'Utils/PermChecker'
 
 const useWebhookDialogAction = ({ feature, modal }) => {
   const dispatch = useDispatch()
   const { t } = useTranslation()
+  const permissions = useSelector((state) => state.authReducer.permissions)
   const theme = useContext(ThemeContext)
   const selectedTheme = theme.state.theme
   const {
@@ -45,13 +47,14 @@ const useWebhookDialogAction = ({ feature, modal }) => {
   }, [dispatch, enabledFeatureWebhooks])
 
   useEffect(() => {
-    if (modal) {
-      if (feature) {
-        dispatch(getWebhooksByFeatureId(feature))
-      } else {
-        dispatch(getWebhooksByFeatureIdResponse([]))
+    if (hasPermission(permissions, WEBHOOK_READ))
+      if (modal) {
+        if (feature) {
+          dispatch(getWebhooksByFeatureId(feature))
+        } else {
+          dispatch(getWebhooksByFeatureIdResponse([]))
+        }
       }
-    }
   }, [modal])
 
   useEffect(() => {
@@ -65,7 +68,7 @@ const useWebhookDialogAction = ({ feature, modal }) => {
   const webhookTriggerModal = ({ closeModal }) => {
     return (
       <Modal
-        isOpen={webhookModal || loadingWebhooks}
+        isOpen={(webhookModal || loadingWebhooks) && hasPermission(permissions, WEBHOOK_READ)}
         size={'lg'}
         toggle={() => {
           if (!loadingWebhooks) {


### PR DESCRIPTION
**Issue Explained**
Display webhook execution acceptance dialog only if webhook trigger endpoint permission exists. `jans-auth-server/config/adminui/webhook.readonly`

part of #1530 