### PR TITLE
fix: charts java memory options passed

### DIFF
--- a/charts/gluu/charts/auth-server/templates/_helpers.tpl
+++ b/charts/gluu/charts/auth-server/templates/_helpers.tpl
@@ -75,12 +75,11 @@ Create JAVA_OPTIONS ENV for passing custom work and detailed logs
 {{- $cnCustomJavaOptions := index .Values.global "auth-server" "cnCustomJavaOptions" }}
 {{- $custom := printf "%s" $cnCustomJavaOptions }}
 {{ $memory := .Values.resources.limits.memory | replace "Mi" "" | int -}}
-{{- $maxDirectMemory := printf "-XX:MaxDirectMemorySize=%dm" $memory -}}
-{{- $xmx := printf "-Xmx%dm" (sub $memory 300) -}}
+{{- $maxDirectMemory := printf "-XX:MaxDirectMemorySize=%dm" ( mul (mulf $memory 0.41) 1 ) -}}
+{{- $xmx := printf "-Xmx%dm" (sub $memory (mulf $memory 0.49)) -}}
 {{- $customJavaOptions := printf "%s %s %s" $custom $maxDirectMemory $xmx -}}
 {{ $customJavaOptions | trim | quote }}
 {{- end }}
-
 
 {{/*
 Create topologySpreadConstraints lists

--- a/charts/gluu/charts/casa/templates/_helpers.tpl
+++ b/charts/gluu/charts/casa/templates/_helpers.tpl
@@ -85,8 +85,8 @@ Create JAVA_OPTIONS ENV for passing custom work and detailed logs
 {{ $custom := "" }}
 {{ $custom = printf "%s" .Values.global.casa.cnCustomJavaOptions }}
 {{ $memory := .Values.resources.limits.memory | replace "Mi" "" | int -}}
-{{- $maxDirectMemory := printf "-XX:MaxDirectMemorySize=%dm" $memory -}}
-{{- $xmx := printf "-Xmx%dm" (sub $memory 300) -}}
+{{- $maxDirectMemory := printf "-XX:MaxDirectMemorySize=%dm" ( mul (mulf $memory 0.41) 1 ) -}}
+{{- $xmx := printf "-Xmx%dm" (sub $memory (mulf $memory 0.49)) -}}
 {{- $customJavaOptions := printf "%s %s %s" $custom $maxDirectMemory $xmx -}}
 {{ $customJavaOptions | trim | quote }}
 {{- end }}

--- a/charts/gluu/charts/config-api/templates/_helpers.tpl
+++ b/charts/gluu/charts/config-api/templates/_helpers.tpl
@@ -75,8 +75,8 @@ Create JAVA_OPTIONS ENV for passing custom work and detailed logs
 {{- $cnCustomJavaOptions := index .Values.global "config-api" "cnCustomJavaOptions" }}
 {{- $custom := printf "%s" $cnCustomJavaOptions }}
 {{ $memory := .Values.resources.limits.memory | replace "Mi" "" | int -}}
-{{- $maxDirectMemory := printf "-XX:MaxDirectMemorySize=%dm" $memory -}}
-{{- $xmx := printf "-Xmx%dm" (sub $memory 300) -}}
+{{- $maxDirectMemory := printf "-XX:MaxDirectMemorySize=%dm" ( mul (mulf $memory 0.41) 1 ) -}}
+{{- $xmx := printf "-Xmx%dm" (sub $memory (mulf $memory 0.49)) -}}
 {{- $customJavaOptions := printf "%s %s %s" $custom $maxDirectMemory $xmx -}}
 {{ $customJavaOptions | trim | quote }}
 {{- end }}

--- a/charts/gluu/charts/fido2/templates/_helpers.tpl
+++ b/charts/gluu/charts/fido2/templates/_helpers.tpl
@@ -74,8 +74,8 @@ Create JAVA_OPTIONS ENV for passing custom work and detailed logs
 {{ $custom := "" }}
 {{ $custom = printf "%s" .Values.global.fido2.cnCustomJavaOptions }}
 {{ $memory := .Values.resources.limits.memory | replace "Mi" "" | int -}}
-{{- $maxDirectMemory := printf "-XX:MaxDirectMemorySize=%dm" $memory -}}
-{{- $xmx := printf "-Xmx%dm" (sub $memory 300) -}}
+{{- $maxDirectMemory := printf "-XX:MaxDirectMemorySize=%dm" ( mul (mulf $memory 0.41) 1 ) -}}
+{{- $xmx := printf "-Xmx%dm" (sub $memory (mulf $memory 0.49)) -}}
 {{- $customJavaOptions := printf "%s %s %s" $custom $maxDirectMemory $xmx -}}
 {{ $customJavaOptions | trim | quote }}
 {{- end }}

--- a/charts/gluu/charts/link/templates/_helpers.tpl
+++ b/charts/gluu/charts/link/templates/_helpers.tpl
@@ -74,8 +74,8 @@ Create JAVA_OPTIONS ENV for passing custom work and detailed logs
 {{ $custom := "" }}
 {{ $custom = printf "%s" .Values.global.link.cnCustomJavaOptions }}
 {{ $memory := .Values.resources.limits.memory | replace "Mi" "" | int -}}
-{{- $maxDirectMemory := printf "-XX:MaxDirectMemorySize=%dm" $memory -}}
-{{- $xmx := printf "-Xmx%dm" (sub $memory 300) -}}
+{{- $maxDirectMemory := printf "-XX:MaxDirectMemorySize=%dm" ( mul (mulf $memory 0.41) 1 ) -}}
+{{- $xmx := printf "-Xmx%dm" (sub $memory (mulf $memory 0.49)) -}}
 {{- $customJavaOptions := printf "%s %s %s" $custom $maxDirectMemory $xmx -}}
 {{ $customJavaOptions | trim | quote }}
 {{- end }}

--- a/charts/gluu/charts/saml/templates/_helpers.tpl
+++ b/charts/gluu/charts/saml/templates/_helpers.tpl
@@ -85,8 +85,8 @@ Create JAVA_OPTIONS ENV for passing custom work and detailed logs
 {{ $custom := "" }}
 {{ $custom = printf "%s" .Values.global.saml.cnCustomJavaOptions }}
 {{ $memory := .Values.resources.limits.memory | replace "Mi" "" | int -}}
-{{- $maxDirectMemory := printf "-XX:MaxDirectMemorySize=%dm" $memory -}}
-{{- $xmx := printf "-Xmx%dm" (sub $memory 300) -}}
+{{- $maxDirectMemory := printf "-XX:MaxDirectMemorySize=%dm" ( mul (mulf $memory 0.41) 1 ) -}}
+{{- $xmx := printf "-Xmx%dm" (sub $memory (mulf $memory 0.49)) -}}
 {{- $customJavaOptions := printf "%s %s %s" $custom $maxDirectMemory $xmx -}}
 {{ $customJavaOptions | trim | quote }}
 {{- end }}

--- a/charts/gluu/charts/scim/templates/_helpers.tpl
+++ b/charts/gluu/charts/scim/templates/_helpers.tpl
@@ -74,8 +74,8 @@ Create JAVA_OPTIONS ENV for passing custom work and detailed logs
 {{ $custom := "" }}
 {{ $custom = printf "%s" .Values.global.scim.cnCustomJavaOptions }}
 {{ $memory := .Values.resources.limits.memory | replace "Mi" "" | int -}}
-{{- $maxDirectMemory := printf "-XX:MaxDirectMemorySize=%dm" $memory -}}
-{{- $xmx := printf "-Xmx%dm" (sub $memory 300) -}}
+{{- $maxDirectMemory := printf "-XX:MaxDirectMemorySize=%dm" ( mul (mulf $memory 0.41) 1 ) -}}
+{{- $xmx := printf "-Xmx%dm" (sub $memory (mulf $memory 0.49)) -}}
 {{- $customJavaOptions := printf "%s %s %s" $custom $maxDirectMemory $xmx -}}
 {{ $customJavaOptions | trim | quote }}
 {{- end }}

--- a/charts/gluu/values.yaml
+++ b/charts/gluu/values.yaml
@@ -626,12 +626,12 @@ config-api:
       # -- CPU limit.
       cpu: 1000m
       # -- Memory limit. This value is used to calculate memory allocation for Java. Currently it only supports `Mi`. Please refrain from using other units.
-      memory: 1000Mi
+      memory: 1200Mi
     requests:
       # -- CPU request.
       cpu: 1000m
       # -- Memory request.
-      memory: 1000Mi
+      memory: 1200Mi
   # -- Configure the liveness healthcheck for the auth server if needed.
   livenessProbe:
     # -- http liveness probe endpoint
@@ -1658,12 +1658,12 @@ scim:
       # -- CPU limit.
       cpu: 1000m
       # -- Memory limit. This value is used to calculate memory allocation for Java. Currently it only supports `Mi`. Please refrain from using other units.
-      memory: 1000Mi
+      memory: 1200Mi
     requests:
       # -- CPU request.
       cpu: 1000m
       # -- Memory request.
-      memory: 1000Mi
+      memory: 1200Mi
   service:
     # -- The name of the scim port within the scim service. Please keep it as default.
     name: http-scim
@@ -1767,12 +1767,12 @@ link:
       # -- CPU limit.
       cpu: 500m
       # -- Memory limit. This value is used to calculate memory allocation for Java. Currently it only supports `Mi`. Please refrain from using other units.
-      memory: 1000Mi
+      memory: 1200Mi
     requests:
       # -- CPU request.
       cpu: 500m
       # -- Memory request.
-      memory: 1000Mi
+      memory: 1200Mi
   # -- Configure the liveness healthcheck for the auth server if needed.
   livenessProbe:
     # -- http liveness probe endpoint
@@ -1874,12 +1874,12 @@ saml:
       # -- CPU limit.
       cpu: 500m
       # -- Memory limit. This value is used to calculate memory allocation for Java. Currently it only supports `Mi`. Please refrain from using other units.
-      memory: 1000Mi
+      memory: 1200Mi
     requests:
       # -- CPU request.
       cpu: 500m
       # -- Memory request.
-      memory: 1000Mi
+      memory: 1200Mi
   # -- Configure the liveness healthcheck for the auth server if needed.
   livenessProbe:
     # -- http liveness probe endpoint


### PR DESCRIPTION
The changesets modify memory allocation for Gluu chart.

Closes 1735