### PR TITLE
fix(charts): incorrect data type passed as optional_scopes input

### DIFF
--- a/charts/gluu-all-in-one/templates/secret.yaml
+++ b/charts/gluu-all-in-one/templates/secret.yaml
@@ -31,7 +31,7 @@ stringData:
         "orgName": {{ .Values.orgName | quote }},
         "auth_sig_keys": {{ index .Values "auth-server" "authSigKeys" | quote }},
         "auth_enc_keys": {{ index .Values "auth-server" "authEncKeys" | quote }},
-        "optional_scopes": {{ list (include "flex-all-in-one.optionalScopes" . | fromJsonArray | join ",") }},
+        "optional_scopes": {{ list (include "flex-all-in-one.optionalScopes" . | fromJsonArray | join ",") | quote }},
         "init_keys_exp": {{ index .Values "auth-server-key-rotation" "initKeysLife"  }}
       },
       "_secret": {


### PR DESCRIPTION
Fixed incorrect data type of `optional_scopes`.

Closes #1777 