### PR TITLE
fix(monolith): resolve missing ruamel.yaml library inside monolith OCI image

### DIFF
--- a/docker-flex-monolith/Dockerfile
+++ b/docker-flex-monolith/Dockerfile
@@ -19,7 +19,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y python3 tini curl ca-certificates dbus systemd iproute2 gpg python3-pip python3-dev libpq-dev gcc python3-psycopg2 python3-ldap3 \
     # install certbot
     && apt-get -y install libaugeas0 \
-    && pip install certbot certbot-apache \
+    && pip install ruamel.yaml certbot certbot-apache \
     # Cleaning up package lists \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Added missing `ruamel.yaml` library inside monolith OCI image.

Closes #1824 