### PR TITLE
feat(cloud-native): add support for legacy and simple JSON data

### DIFF
--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -20,7 +20,7 @@ EXPOSE 8080
 # Assets sync
 # ===========
 
-ENV JANS_SOURCE_VERSION=5f3b30e4b565601ccb31cd985920c09071cd1b54
+ENV JANS_SOURCE_VERSION=4f155cfe9e197b15d65be6aa938276862fe36a06
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)
@@ -44,7 +44,7 @@ RUN cd /tmp/jans \
     && cp ${JANS_SETUP_DIR}/schema/custom_schema.json /app/schema/ \
     && cp ${JANS_SETUP_DIR}/schema/opendj_types.json /app/schema/
 
-ENV FLEX_SOURCE_VERSION=969158f9b757291e826cd230db5372cb73918af7
+ENV FLEX_SOURCE_VERSION=b9628dc3e63e093e0ac0a5dd7e9295251587ac3d
 
 RUN mkdir -p /app/templates/admin-ui
 

--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -20,7 +20,7 @@ EXPOSE 8080
 # Assets sync
 # ===========
 
-ENV JANS_SOURCE_VERSION=4f155cfe9e197b15d65be6aa938276862fe36a06
+ENV JANS_SOURCE_VERSION=d84d8935eaeb252da8f442f4679bedb45c514aa7
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)

--- a/docker-admin-ui/scripts/upgrade.py
+++ b/docker-admin-ui/scripts/upgrade.py
@@ -155,7 +155,7 @@ class Upgrade:
             entry.attrs["jansAccessTknAsJwt"] = False
             should_update = True
 
-        if self.backend.type == "sql" and self.backend.client.dialect == "mysql":
+        if not self.backend.client.use_simple_json:
             scopes = entry.attrs["jansScope"]["v"]
             grant_types = entry.attrs["jansGrantTyp"]["v"]
         else:
@@ -188,7 +188,7 @@ class Upgrade:
             grant_types.append("urn:ietf:params:oauth:grant-type:device_code")
             should_update = True
 
-        if self.backend.type == "sql" and self.backend.client.dialect == "mysql":
+        if not self.backend.client.use_simple_json:
             entry.attrs["jansScope"]["v"] = scopes
             entry.attrs["jansGrantTyp"]["v"] = grant_types
         else:
@@ -234,7 +234,7 @@ class Upgrade:
                 entry.attrs[attr] = False
                 should_update = True
 
-        if self.backend.type == "sql" and self.backend.client.dialect == "mysql":
+        if not self.backend.client.use_simple_json:
             scopes = entry.attrs["jansScope"]["v"]
             grant_types = entry.attrs["jansGrantTyp"]["v"]
             resp_types = entry.attrs["jansRespTyp"]["v"]
@@ -284,7 +284,7 @@ class Upgrade:
             scopes.append("inum=B9D2-D6E5,ou=scopes,o=jans")
             should_update = True
 
-        if self.backend.type == "sql" and self.backend.client.dialect == "mysql":
+        if not self.backend.client.use_simple_json:
             entry.attrs["jansScope"]["v"] = scopes
             entry.attrs["jansGrantTyp"]["v"] = grant_types
             entry.attrs["jansRespTyp"]["v"] = resp_types

--- a/docker-flex-all-in-one/Dockerfile
+++ b/docker-flex-all-in-one/Dockerfile
@@ -66,7 +66,7 @@ RUN ln -sf /app/flex_aio/admin_ui/entrypoint.sh /app/bin/admin-ui-entrypoint.sh
 # Assets sync
 # ===========
 
-ENV JANS_SOURCE_VERSION=5f3b30e4b565601ccb31cd985920c09071cd1b54
+ENV JANS_SOURCE_VERSION=4f155cfe9e197b15d65be6aa938276862fe36a06
 
 # note that as we're pulling from a monorepo (with multiple project in it)
 # we are using partial-clone and sparse-checkout to get the assets

--- a/docker-flex-all-in-one/Dockerfile
+++ b/docker-flex-all-in-one/Dockerfile
@@ -66,7 +66,7 @@ RUN ln -sf /app/flex_aio/admin_ui/entrypoint.sh /app/bin/admin-ui-entrypoint.sh
 # Assets sync
 # ===========
 
-ENV JANS_SOURCE_VERSION=4f155cfe9e197b15d65be6aa938276862fe36a06
+ENV JANS_SOURCE_VERSION=d84d8935eaeb252da8f442f4679bedb45c514aa7
 
 # note that as we're pulling from a monorepo (with multiple project in it)
 # we are using partial-clone and sparse-checkout to get the assets


### PR DESCRIPTION
### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #1872 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

The changeset adds support for legacy and new simple JSON data format using auto-detection of column's value.

**How to test:**

1. Flex 5.1.5 and lower:

   - install flex 5.1.5 chart; ensure format `jansAppConf.jansSmtpConf` value is `{"v": []}`
   - upgrade to chart in this PR (change jans image to `1.1.6_json` and flex image to `5.1.6`); ensure format `jansAppConf.jansSmtpConf` value is still `{"v": []}` after upgrade

1. Flex 5.1.6+:

   - install chart in this PR (change jans image to `1.1.6_json` and flex image to `5.1.6_json`); ensure format `jansAppConf.jansSmtpConf` value is `[]`
   - do upgrade; ensure format `jansAppConf.jansSmtpConf` value is still `[]` after upgrade