### PR TITLE
chore(cloud-native)!: remove spanner support from OCI images

### DIFF
--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -20,7 +20,7 @@ EXPOSE 8080
 # Assets sync
 # ===========
 
-ENV JANS_SOURCE_VERSION=d84d8935eaeb252da8f442f4679bedb45c514aa7
+ENV JANS_SOURCE_VERSION=6e00e723a99d700a4f82713b0c25b2d6e3ef5775
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)
@@ -39,12 +39,11 @@ RUN cd /tmp/jans \
     && cp -R ${JANS_SETUP_DIR}/static/rdbm/sql_data_types.json /app/static/rdbm/ \
     && cp -R ${JANS_SETUP_DIR}/static/rdbm/ldap_sql_data_type_mapping.json /app/static/rdbm/ \
     && cp -R ${JANS_SETUP_DIR}/static/rdbm/opendj_attributes_syntax.json /app/static/rdbm/ \
-    && cp -R ${JANS_SETUP_DIR}/static/rdbm/sub_tables.json /app/static/rdbm/ \
     && cp ${JANS_SETUP_DIR}/schema/jans_schema.json /app/schema/ \
     && cp ${JANS_SETUP_DIR}/schema/custom_schema.json /app/schema/ \
     && cp ${JANS_SETUP_DIR}/schema/opendj_types.json /app/schema/
 
-ENV FLEX_SOURCE_VERSION=b9628dc3e63e093e0ac0a5dd7e9295251587ac3d
+ENV FLEX_SOURCE_VERSION=55e028960e7548c751387e149eab7774f16c09aa
 
 RUN mkdir -p /app/templates/admin-ui
 
@@ -148,9 +147,7 @@ ENV CN_PERSISTENCE_TYPE=sql \
     CN_COUCHBASE_BUCKET_PREFIX=jans \
     CN_COUCHBASE_TRUSTSTORE_ENABLE=true \
     CN_COUCHBASE_KEEPALIVE_INTERVAL=30000 \
-    CN_COUCHBASE_KEEPALIVE_TIMEOUT=2500 \
-    CN_GOOGLE_SPANNER_INSTANCE_ID="" \
-    CN_GOOGLE_SPANNER_DATABASE_ID=""
+    CN_COUCHBASE_KEEPALIVE_TIMEOUT=2500
 
 # ===========
 # Generic ENV

--- a/docker-admin-ui/README.md
+++ b/docker-admin-ui/README.md
@@ -63,7 +63,7 @@ The following environment variables are supported by the container:
 - `CN_TOKEN_SERVER_USERINFO_ENDPOINT`: User info endpoint at token server (default to `/jans-auth/restv1/userinfo`).
 - `CN_TOKEN_SERVER_CLIENT_ID`: Client ID registered at token server.
 - `CN_TOKEN_SERVER_CERT_FILE`: Path to token server certificate (default to `/etc/certs/token_server.crt`).
-- `CN_PERSISTENCE_TYPE`: Persistence backend being used (one of `sql`, `spanner`, `couchbase`, or `hybrid`; default to `sql`).
+- `CN_PERSISTENCE_TYPE`: Persistence backend being used (one of `sql`, `couchbase`, or `hybrid`; default to `sql`).
 - `CN_HYBRID_MAPPING`: Specify data mapping for each persistence (default to `"{}"`). Note this environment only takes effect when `CN_PERSISTENCE_TYPE` is set to `hybrid`. See [hybrid mapping](#hybrid-mapping) section for details.
 - `CN_COUCHBASE_URL`: Address of Couchbase server (default to `localhost`).
 - `CN_COUCHBASE_USER`: Username of Couchbase server (default to `admin`).
@@ -81,12 +81,8 @@ The following environment variables are supported by the container:
 - `CN_SQL_DB_PORT`: Port of SQL backend (default to `3306`).
 - `CN_SQL_DB_NAME`: Database name (default to `jans`)
 - `CN_SQL_DB_USER`: Username to interact with SQL backend (default to `jans`).
-- `CN_GOOGLE_SPANNER_INSTANCE_ID`: Instance ID of Google Spanner (default to empty string).
-- `CN_GOOGLE_SPANNER_DATABASE_ID`: Database ID of Google Spanner (default to empty string).
 - `GOOGLE_PROJECT_ID`: Google Project ID (default to empty string).
 - `GOOGLE_PROJECT_ID`: Google Project ID (default to empty string). Used when `CN_CONFIG_ADAPTER` or `CN_SECRET_ADAPTER` set to `google`.
-- `CN_GOOGLE_SPANNER_INSTANCE_ID`: Google Spanner instance ID.
-- `CN_GOOGLE_SPANNER_DATABASE_ID`: Google Spanner database ID.
 - `GLUU_ADMIN_UI_AUTH_METHOD`: Authentication method for admin-ui (default to `basic`). Note, changing the value require restart to jans-config-api.
 
 ### Hybrid mapping
@@ -99,12 +95,12 @@ Hybrid persistence supports all available persistence types. To configure hybrid
 
     ```
     {
-        "default": "<couchbase|spanner|sql>",
-        "user": "<couchbase|spanner|sql>",
-        "site": "<couchbase|spanner|sql>",
-        "cache": "<couchbase|spanner|sql>",
-        "token": "<couchbase|spanner|sql>",
-        "session": "<couchbase|spanner|sql>",
+        "default": "<couchbase|sql>",
+        "user": "<couchbase|sql>",
+        "site": "<couchbase|sql>",
+        "cache": "<couchbase|sql>",
+        "token": "<couchbase|sql>",
+        "session": "<couchbase|sql>",
     }
     ```
 
@@ -113,10 +109,10 @@ Hybrid persistence supports all available persistence types. To configure hybrid
     ```
     {
         "default": "sql",
-        "user": "spanner",
+        "user": "sql",
         "site": "sql",
         "cache": "sql",
         "token": "couchbase",
-        "session": "spanner",
+        "session": "sql",
     }
     ```

--- a/docker-admin-ui/scripts/bootstrap.py
+++ b/docker-admin-ui/scripts/bootstrap.py
@@ -9,8 +9,6 @@ from jans.pycloudlib import wait_for_persistence
 from jans.pycloudlib.persistence.couchbase import CouchbaseClient
 from jans.pycloudlib.persistence.couchbase import id_from_dn
 from jans.pycloudlib.persistence.couchbase import sync_couchbase_password
-from jans.pycloudlib.persistence.spanner import SpannerClient
-from jans.pycloudlib.persistence.spanner import sync_google_credentials
 from jans.pycloudlib.persistence.sql import doc_id_from_dn
 from jans.pycloudlib.persistence.sql import SqlClient
 from jans.pycloudlib.persistence.sql import sync_sql_password
@@ -35,9 +33,6 @@ def main():
 
     if "sql" in persistence_groups:
         sync_sql_password(manager)
-
-    if "spanner" in persistence_groups:
-        sync_google_credentials(manager)
 
     wait_for_persistence(manager)
 
@@ -65,7 +60,6 @@ class PersistenceSetup:
 
         client_classes = {
             "couchbase": CouchbaseClient,
-            "spanner": SpannerClient,
             "sql": SqlClient,
         }
 
@@ -175,7 +169,7 @@ class PersistenceSetup:
 
         dn = "ou=admin-ui,ou=configuration,o=jans"
 
-        if self.persistence_type in ("sql", "spanner"):
+        if self.persistence_type == "sql":
             dn = doc_id_from_dn(dn)
             table_name = "jansAppConf"
 
@@ -211,30 +205,6 @@ class PersistenceSetup:
                 logger.info("Updating admin-ui config app")
                 rev = entry["jansRevision"] + 1
                 self.client.exec_query(f"UPDATE {bucket} USE KEYS '{dn}' SET jansConfApp={json.dumps(merged_conf)}, jansRevision={rev}")  # nosec: B608
-
-        else:
-            entry = self.client.get(dn)
-            attrs = entry.entry_attributes_as_dict
-
-            try:
-                conf = attrs.get("jansConfApp", [])[0]
-            except IndexError:
-                conf = "{}"
-
-            should_update, merged_conf = resolve_conf_app(
-                json.loads(conf),
-                json.loads(conf_from_file),
-            )
-
-            if should_update:
-                logger.info("Updating admin-ui config app")
-                self.client.modify(
-                    dn,
-                    {
-                        "jansRevision": [(self.client.MODIFY_REPLACE, attrs["jansRevision"][0] + 1)],
-                        "jansConfApp": [(self.client.MODIFY_REPLACE, json.dumps(merged_conf))],
-                    }
-                )
 
 
 def resolve_conf_app(old_conf, new_conf):
@@ -314,6 +284,11 @@ def resolve_conf_app(old_conf, new_conf):
             if old_conf["oidcConfig"]["auiBackendApiClient"][endpoint] != new_conf["oidcConfig"]["auiBackendApiClient"][endpoint]:
                 old_conf["oidcConfig"]["auiBackendApiClient"][endpoint] = new_conf["oidcConfig"]["auiBackendApiClient"][endpoint]
                 should_update = True
+
+        # add missing config under uiConfig
+        if "allowSmtpKeystoreEdit" not in old_conf["uiConfig"]:
+            old_conf["uiConfig"]["allowSmtpKeystoreEdit"] = True
+            should_update = True
 
     # finalized status and conf
     return should_update, old_conf

--- a/docker-admin-ui/scripts/upgrade.py
+++ b/docker-admin-ui/scripts/upgrade.py
@@ -5,7 +5,6 @@ from collections import namedtuple
 
 from jans.pycloudlib import get_manager
 from jans.pycloudlib.persistence import CouchbaseClient
-from jans.pycloudlib.persistence import SpannerClient
 from jans.pycloudlib.persistence import SqlClient
 from jans.pycloudlib.persistence import PersistenceMapper
 from jans.pycloudlib.persistence import doc_id_from_dn
@@ -90,30 +89,9 @@ class CouchbaseBackend:
         return status, message
 
 
-class SpannerBackend:
-    def __init__(self, manager):
-        self.manager = manager
-        self.client = SpannerClient(manager)
-        self.type = "spanner"
-
-    def get_entry(self, key, filter_="", attrs=None, **kwargs):
-        table_name = kwargs.get("table_name")
-        entry = self.client.get(table_name, key, attrs)
-
-        if not entry:
-            return None
-        return Entry(key, entry)
-
-    def modify_entry(self, key, attrs=None, **kwargs):
-        attrs = attrs or {}
-        table_name = kwargs.get("table_name")
-        return self.client.update(table_name, key, attrs), ""
-
-
 BACKEND_CLASSES = {
     "sql": SQLBackend,
     "couchbase": CouchbaseBackend,
-    "spanner": SpannerBackend,
 }
 
 
@@ -136,7 +114,7 @@ class Upgrade:
         client_id = self.manager.config.get("admin_ui_client_id")
         id_ = f"inum={client_id},ou=clients,o=jans"
 
-        if self.backend.type in ("sql", "spanner"):
+        if self.backend.type == "sql":
             kwargs = {"table_name": "jansClnt"}
             id_ = doc_id_from_dn(id_)
         elif self.backend.type == "couchbase":
@@ -214,7 +192,7 @@ class Upgrade:
         client_id = self.manager.config.get("token_server_admin_ui_client_id")
         id_ = f"inum={client_id},ou=clients,o=jans"
 
-        if self.backend.type in ("sql", "spanner"):
+        if self.backend.type == "sql":
             kwargs = {"table_name": "jansClnt"}
             id_ = doc_id_from_dn(id_)
         elif self.backend.type == "couchbase":

--- a/docker-flex-all-in-one/Dockerfile
+++ b/docker-flex-all-in-one/Dockerfile
@@ -66,7 +66,7 @@ RUN ln -sf /app/flex_aio/admin_ui/entrypoint.sh /app/bin/admin-ui-entrypoint.sh
 # Assets sync
 # ===========
 
-ENV JANS_SOURCE_VERSION=d84d8935eaeb252da8f442f4679bedb45c514aa7
+ENV JANS_SOURCE_VERSION=6e00e723a99d700a4f82713b0c25b2d6e3ef5775
 
 # note that as we're pulling from a monorepo (with multiple project in it)
 # we are using partial-clone and sparse-checkout to get the assets

--- a/docker-flex-monolith/Dockerfile
+++ b/docker-flex-monolith/Dockerfile
@@ -42,7 +42,7 @@ EXPOSE 443 8080 1636
 # flex-linux-setup
 # =====================
 
-ENV FLEX_SOURCE_VERSION=969158f9b757291e826cd230db5372cb73918af7
+ENV FLEX_SOURCE_VERSION=55e028960e7548c751387e149eab7774f16c09aa
 # cleanup
 RUN rm -rf /tmp/jans
 


### PR DESCRIPTION
The changeset removes spanner support from OCI images.

Closes #1879 