### PR TITLE
fix(docker-admin-ui): remove non-existent function calls

### DIFF
--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -43,7 +43,7 @@ RUN cd /tmp/jans \
     && cp ${JANS_SETUP_DIR}/schema/custom_schema.json /app/schema/ \
     && cp ${JANS_SETUP_DIR}/schema/opendj_types.json /app/schema/
 
-ENV FLEX_SOURCE_VERSION=55e028960e7548c751387e149eab7774f16c09aa
+ENV FLEX_SOURCE_VERSION=12a5729c0fc9d79178fdc29e2566baa600905301
 
 RUN mkdir -p /app/templates/admin-ui
 

--- a/docker-admin-ui/scripts/upgrade.py
+++ b/docker-admin-ui/scripts/upgrade.py
@@ -7,7 +7,6 @@ from jans.pycloudlib import get_manager
 from jans.pycloudlib.persistence import SqlClient
 from jans.pycloudlib.persistence import PersistenceMapper
 from jans.pycloudlib.persistence import doc_id_from_dn
-from jans.pycloudlib.persistence import id_from_dn
 from jans.pycloudlib.utils import as_boolean
 
 from settings import LOGGING_CONFIG


### PR DESCRIPTION
The changeset removes calls to non-existent functions in jans-pycloudlib.

Closes #1896 