### PR TITLE
ci(automation): skip generating version footer when using helm-docs

### DIFF
--- a/automation/docs/generated-cn-docs.sh
+++ b/automation/docs/generated-cn-docs.sh
@@ -14,7 +14,7 @@ tar xvf helm-docs_"${HELM_DOCS_VERSION}"_Linux_x86_64.tar.gz
 sudo cp helm-docs /usr/local/bin/
 cd ..
 # Generate Helm docs
-helm-docs "$MAIN_DIRECTORY_LOCATION"/charts/
+helm-docs "$MAIN_DIRECTORY_LOCATION"/charts/ --skip-version-footer
 rm -rf helmtemp
 echo "Copying Helm chart Readme to helm-chart.md"
 cp "$MAIN_DIRECTORY_LOCATION"/charts/gluu/README.md "$MAIN_DIRECTORY_LOCATION"/docs/reference/kubernetes/helm-chart.md

--- a/automation/janssen_helm_chart/prepare_chart.sh
+++ b/automation/janssen_helm_chart/prepare_chart.sh
@@ -55,7 +55,7 @@ remove_all <  $temp_chart_folder/charts/config/templates/_helpers.tpl > tmpfile 
 $temp_chart_folder/charts/config/templates/_helpers.tpl
 
 python3 ./automation/janssen_helm_chart/analyze_chart.py
-helm-docs ${temp_chart_folder}
+helm-docs ${temp_chart_folder} --skip-version-footer
 helm package ${temp_chart_folder} -d charts
 helm repo index charts
 echo "Chart preparation is finished!"

--- a/automation/release/release.sh
+++ b/automation/release/release.sh
@@ -32,7 +32,7 @@ modify_helm_chart() {
   egrep -lRZ --include=values.yaml --exclude-dir=gluu-all-in-one . | xargs -0 -l sed -i -e "s/:1.*_dev/: $JANS_VERSION-1/g"
   # Update chart `appVersion` `version` and image tags to the official prospected versions and tags.
   egrep -lRZ --include=Chart.yaml --exclude-dir=gluu . | xargs -0 -l sed -i -e "s/version: .*/version: $JANS_VERSION/g"
-  helm-docs ./charts
+  helm-docs ./charts --skip-version-footer
 }
 
 modify_version_files() {
@@ -60,7 +60,7 @@ modify_snapshot_helm_chart() {
   egrep -lRZ --include=values.yaml --exclude-dir=gluu-all-in-one . | xargs -0 -l sed -i -e "s/:1.*_dev/: $NEXT_JANS_VERSION_dev/g"
   # Update chart `appVersion` `version` and image tags to the official prospected versions and tags.
   egrep -lRZ --include=Chart.yaml --exclude-dir=gluu . | xargs -0 -l sed -i -e "s/version: .*/version: $NEXT_JANS_VERSION/g"
-  helm-docs ./charts
+  helm-docs ./charts --skip-version-footer
   egrep -lRZ --exclude=CONTRIBUTING.md --exclude-dir=workflows . | xargs -0 -l sed -i -e "s/$SETUP_VERSION/$NEXT_SETUP_VERSION-SNAPSHOT/g"
 }
 


### PR DESCRIPTION
The changeset adds `--skip-version-footer` option when running `helm-docs` command.

Closes #1924 