### PR TITLE
feat(flex-linux-setup): admin-ui command line utility

### DIFF
--- a/flex-linux-setup/flex_linux_setup/admin-ui
+++ b/flex-linux-setup/flex_linux_setup/admin-ui
@@ -1,0 +1,33 @@
+#! /usr/bin/env python3
+
+import sys
+import argparse
+import subprocess
+
+parser = argparse.ArgumentParser(description="Gluu/Flex Admin-UI command line utility")
+parser.add_argument('-restart', help="Restarts services for Janssen config-api and apache web server", action='store_true')
+argsp = parser.parse_args()
+
+if len(sys.argv) < 2:
+    print("No argument was provided.")
+    sys.exit()
+
+httpd_name = None
+for sname in ('httpd', 'apache2'):
+    cmd = f'systemctl show --no-pager {sname} | grep LoadState=loaded'
+    cmd_output = subprocess.getoutput(cmd).strip()
+    if cmd_output:
+        httpd_name = sname
+        break
+if not httpd_name:
+    print("\033[93mUnable to determine httpd server name\033[0m")
+    sys.exit()
+
+if argsp.restart:
+    print("Restarting Admin-UI components")
+    for service in ('jans-config-api', httpd_name):
+        cmd = f'sudo systemctl restart {service}'
+        print(f"Executing {cmd}")
+        out = subprocess.getoutput(cmd).strip()
+        if out:
+            print(f"Command output: {out}")

--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -538,6 +538,12 @@ class flex_installer(JettyInstaller):
 
         self.rewrite_cli_ini()
 
+        print(f"Copying admin-ui command line utility to {Config.jansOptBinFolder}")
+        config_api_installer.copyFile(
+            os.path.join(self.flex_setup_dir, 'admin-ui'),
+            Config.jansOptBinFolder
+            )
+        config_api_installer.run([base.paths.cmd_chmod, '+x', os.path.join(Config.jansOptBinFolder, 'admin-ui')])
 
     def install_config_api_plugin(self):
 


### PR DESCRIPTION
Closes #1130

`admin-ui` command line utility will be available under directory `/opt/jans/bin`. To restart admin-ui components, execute
`/opt/jans/bin/admin-ui -restart`