### PR TITLE
fix(admin-ui): change max size of attribute results

### DIFF
--- a/admin-ui/plugins/saml/components/TrustRelationForm.js
+++ b/admin-ui/plugins/saml/components/TrustRelationForm.js
@@ -246,7 +246,7 @@ const TrustRelationForm = ({ configs, viewOnly }) => {
   }, [savedForm]);
 
   useEffect(() => {
-    const options = {};
+    const options = { limit: 70 };
     dispatch(getAttributes({ options }));
   }, []);
 


### PR DESCRIPTION
What is in the PR : 
==============

Fix the missing `email` attribute on the Released Attributes selection. by changing the limit search