### PR TITLE
fix(cloud-native): demo scripts fail to deploy cluster due to python externally-managed-environment error

### DIFF
--- a/automation/startflexdemo.sh
+++ b/automation/startflexdemo.sh
@@ -36,9 +36,6 @@ if [[ -z $EXT_IP ]]; then
 fi
 
 sudo apt-get update
-sudo apt-get install python3-pip -y
-sudo pip3 install requests --upgrade
-sudo pip3 install shiv
 sudo snap install microk8s --classic
 sudo microk8s.status --wait-ready
 sudo microk8s.enable dns registry ingress hostpath-storage helm3

--- a/automation/startflexmonolithdemo.sh
+++ b/automation/startflexmonolithdemo.sh
@@ -47,9 +47,7 @@ git clone --filter blob:none --no-checkout https://github.com/gluufederation/fle
 
 # -- Parse compose and docker file
 sudo apt-get update
-sudo python3 -m pip install --upgrade pip
-pip3 install setuptools --upgrade
-pip3 install dockerfile-parse ruamel.yaml
+PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install dockerfile-parse ruamel.yaml
 
 # switching to version defined by FLEX_BUILD_COMMIT
 if [[ "$FLEX_BUILD_COMMIT" ]]; then


### PR DESCRIPTION
The changeset removes unnecessary Python libs and add `PIP_BREAK_SYSTEM_PACKAGES` to address externally-managed-environment error while installing some libs not available in OS package manager.

Closes #2052 