### PR TITLE
fix(charts): invalid template function calls when using AWS secrets manager

### DIFF
--- a/charts/gluu-all-in-one/templates/_helpers.tpl
+++ b/charts/gluu-all-in-one/templates/_helpers.tpl
@@ -333,8 +333,8 @@ Obfuscate configuration schema (only if configuration key is available)
 {{- $_ := set $secretSchema "google_credentials" .Values.configmap.cnGoogleSecretManagerServiceAccount }}
 {{- end }}
 {{- if or (eq .Values.configAdapterName "aws") (eq .Values.configSecretAdapter "aws") }}
-{{- $_ := set $secretSchema "aws_credentials" (include "config.aws-shared-credentials" . | b64enc) }}
-{{- $_ := set $secretSchema "aws_config" (include "config.aws-config" . | b64enc) }}
+{{- $_ := set $secretSchema "aws_credentials" (include "flex-all-in-one.aws-shared-credentials" . | b64enc) }}
+{{- $_ := set $secretSchema "aws_config" (include "flex-all-in-one.aws-config" . | b64enc) }}
 {{- $_ := set $secretSchema "aws_replica_regions" (toJson .Values.configmap.cnAwsSecretsReplicaRegions | b64enc) }}
 {{- end }}
 {{- if .Values.saml.enabled }}


### PR DESCRIPTION
The changeset fixes template loading when using Flex all-in-one chart and AWS as its configmap and secret storage.

Closes #2071 