### PR TITLE
feat(admin-ui): reordering Admin-UI's left menu

### DIFF
--- a/admin-ui/app/locales/en/translation.json
+++ b/admin-ui/app/locales/en/translation.json
@@ -597,18 +597,19 @@
     "view_source": "View Source",
     "adminui": "Admin",
     "config-api": "Config-API",
+    "security": "Security",
     "authn": "Authn",
     "webhooks": "Webhooks",
     "agama_flows": "Agama Flows",
     "default_acr": "Default ACR",
     "acrs": "ACRs",
     "aliases": "Aliases",
+    "api_config": "Config API properties",
     "builtIn": "Built-In",
-    "api": {
-      "roles": "Access roles",
-      "permissions": "Permissions",
-      "mapping": "Mapping",
-      "api_config": "Config API properties"
+    "securityDropdown": {
+      "adminUiRoles": "Admin UI Roles",
+      "capabilities": "Capabilities",
+      "mapping": "Mapping"
     },
     "basic_configuration": "Basic Configuration",
     "inum_configuration": "Inum Configuration",
@@ -633,7 +634,7 @@
     "logging": "Logging",
     "ssa": "SSA",
     "mau": "Active Users",
-    "oauthserver": "Auth server",
+    "oauthserver": "Auth Server",
     "persistence": "Persistence",
     "person": "Person",
     "properties": "Auth server properties",

--- a/admin-ui/app/locales/fr/translation.json
+++ b/admin-ui/app/locales/fr/translation.json
@@ -42,6 +42,7 @@
     "adminui": "Administratrice",
     "assets": "Assets",
     "config-api": "Config-API",
+    "security": "Sécurité",
     "webhooks": "Webhooks",
     "add_source": "Ajouter une source",
     "edit_source": "Modifier la source",
@@ -53,12 +54,12 @@
     "acrs": "ACRs",
     "aliases": "Aliases",
     "trust_relationships": "Relations de confiance",
+    "api_config": "Configurer les propriétés de l'API",
     "builtIn": "Intégré",
-    "api": {
-      "roles": "Rôles d'accès",
-      "permissions": "Autorisations",
-      "mapping": "Mapping",
-      "api_config": "Configurer les propriétés de l'API"
+    "securityDropdown": {
+      "adminUiRoles": "Rôles de l'interface utilisateur d'administration",
+      "capabilities": "Capacités",
+      "mapping": "Mapping"
     },
     "lock": "Verrouillage",
     "cache": "Cacher",

--- a/admin-ui/app/locales/pt/translation.json
+++ b/admin-ui/app/locales/pt/translation.json
@@ -42,6 +42,7 @@
     "adminui": "Admin",
     "assets": "Assets",
     "config-api": "Config-API",
+    "security": "Segurança",
     "saml": "SAML",
     "add_source": "Adicionar Fonte",
     "edit_source": "Editar Fonte",
@@ -55,11 +56,11 @@
     "acrs": "ACRs",
     "aliases": "Aliases",
     "builtIn": "Integrado",
-    "api": {
-      "roles": "Papéis de acesso",
-      "permissions": "Permissões",
-      "mapping": "Mapeamento",
-      "api_config": "Configurar propriedades da API"
+    "api_config": "Configurar propriedades da API",
+    "securityDropdown": {
+      "adminUiRoles": "Funções da interface do administrador",
+      "capabilities": "Capacidades",
+      "mapping": "Mapeamento"
     },
     "lock": "Trancar",
     "cache": "Cache",

--- a/admin-ui/app/routes/Apps/Gluu/GluuAppSidebar.js
+++ b/admin-ui/app/routes/Apps/Gluu/GluuAppSidebar.js
@@ -7,7 +7,6 @@ import GluuErrorFallBack from './GluuErrorFallBack'
 import { processMenus } from 'Plugins/PluginMenuResolver'
 import { useTranslation } from 'react-i18next'
 import HomeIcon from 'Components/SVG/menu/Home'
-import AdministratorIcon from 'Components/SVG/menu/Administrator'
 import OAuthIcon from 'Components/SVG/menu/OAuth'
 import UserClaimsIcon from 'Components/SVG/menu/UserClaims'
 import ServicesIcon from 'Components/SVG/menu/Services'
@@ -24,12 +23,13 @@ import getThemeColor from 'Context/theme/config'
 import CachedIcon from '@mui/icons-material/Cached'
 import LockIcon from '@mui/icons-material/Lock'
 import styles from './styles/GluuAppSidebar.style'
-import { auditLogoutLogs } from '../../../../plugins/user-management/redux/features/userSlice'
 
 function GluuAppSidebar() {
   const scopes = useSelector(({ authReducer }) =>
     authReducer.token ? authReducer.token.scopes : authReducer.permissions
   )
+  const health = useSelector(state => state.healthReducer.health)
+
   const { isUserLogout } = useSelector(state => state.userReducer)
   const [pluginMenus, setPluginMenus] = useState([])
   const { t } = useTranslation()
@@ -53,8 +53,8 @@ function GluuAppSidebar() {
 
   function getMenuIcon(name) {
     switch (name) {
-      case 'admin':
-        return <AdministratorIcon className="menu-icon" />
+      case 'home':
+        return <HomeIcon className="menu-icon" />
 
       case 'oauthserver':
         return <OAuthIcon className="menu-icon" />
@@ -65,16 +65,26 @@ function GluuAppSidebar() {
       case 'user_claims':
         return <UserClaimsIcon className="menu-icon" />
 
+      case 'scripts':
+        return (
+          <i
+            className="menu-icon fas fa-file-code"
+            style={{ fontSize: '28px' }}
+          />
+        )
+
       case 'usersmanagement':
-        return <UsersIcon className="menu-icon" style={{ top: '-2px' }} />
+        return <UsersIcon className="menu-icon" />
 
       case 'stmpmanagement':
-        return <StmpIcon className="menu-icon" style={{ top: '-2px' }} />
+        return <StmpIcon className="menu-icon" />
 
       case 'fidomanagement':
-        return <FidoIcon className="menu-icon" style={{ top: '-2px' }} />
+        return <FidoIcon className="menu-icon" />
+
       case 'scim':
-        return <ScimIcon className="menu-icon" style={{ top: '-2px' }} />
+        return <ScimIcon className="menu-icon" />
+
       case 'jans_link':
         return (
           <CachedIcon
@@ -118,42 +128,14 @@ function GluuAppSidebar() {
     return typeof plugin.children !== 'undefined' && plugin.children.length
   }
 
-  const handleLogout = () => {
-    dispatch(auditLogoutLogs({ message: 'User logged out mannually' }))
-  }
+  const filteringJansLock = pluginMenus.filter(
+    menu => menu.path !== '/jans-lock' || health?.['jans-lock'] === 'Running'
+  )
 
   return (
     <ErrorBoundary FallbackComponent={GluuErrorFallBack}>
       <SidebarMenu>
-        {/* -------- Home ---------*/}
-        <SidebarMenu.Item
-          icon={<HomeIcon className="menu-icon" />}
-          title={t('menus.home')}
-          textStyle={{ fontSize: '18px' }}
-          sidebarMenuActiveClass={sidebarMenuActiveClass}
-        >
-          <SidebarMenu.Item
-            title={t('menus.dashboard')}
-            to="/home/dashboard"
-            textStyle={{ fontSize: '15px', color: '#323b47' }}
-            exact
-          />
-          <SidebarMenu.Item
-            title={t('menus.health')}
-            to="/home/health"
-            textStyle={{ fontSize: '15px' }}
-            exact
-          />
-          <SidebarMenu.Item
-            title={t('menus.licenseDetails')}
-            to="/home/licenseDetails"
-            textStyle={{ fontSize: '15px' }}
-            exact
-          />
-        </SidebarMenu.Item>
-        {/* -------- Plugins ---------*/}
-
-        {pluginMenus.map((plugin, key) => (
+        {filteringJansLock.map((plugin, key) => (
           <SidebarMenu.Item
             key={key}
             icon={getMenuIcon(plugin.icon)}
@@ -193,21 +175,6 @@ function GluuAppSidebar() {
           </SidebarMenu.Item>
         ))}
 
-        {/* -------- Plugins ---------*/}
-        <SidebarMenu.Item
-          to="logout"
-          icon={
-            <i
-              className="fa fa-fw fa-sign-out mr-2"
-              style={{ fontSize: 28 }}
-            ></i>
-          }
-          title={t('menus.signout')}
-          handleClick={() => {
-            handleLogout()
-          }}
-          textStyle={{ fontSize: '18px' }}
-        />
         <div className={classes.waveContainer}>
           <Wave className={classes.wave} fill={themeColors.menu.background} />
           <div className={classes.powered}>Powered by Gluu</div>

--- a/admin-ui/app/routes/index.js
+++ b/admin-ui/app/routes/index.js
@@ -1,52 +1,52 @@
-import React, { useState, useEffect, lazy, Suspense } from "react";
-import { Route, Routes, Navigate } from "react-router-dom";
-import { useSelector } from "react-redux";
+import React, { useState, useEffect, lazy, Suspense } from 'react'
+import { Route, Routes, Navigate } from 'react-router-dom'
+import { useSelector } from 'react-redux'
 
-import NavbarOnly from "./Layouts/NavbarOnly";
-import SidebarDefault from "./Layouts/SidebarDefault";
-import SidebarA from "./Layouts/SidebarA";
-import SidebarWithNavbar from "./Layouts/SidebarWithNavbar";
+import NavbarOnly from './Layouts/NavbarOnly'
+import SidebarDefault from './Layouts/SidebarDefault'
+import SidebarA from './Layouts/SidebarA'
+import SidebarWithNavbar from './Layouts/SidebarWithNavbar'
 
 // ----------- Layout Imports ---------------
-import { processRoutes } from "Plugins/PluginMenuResolver";
-import { hasPermission } from "Utils/PermChecker";
-import GluuSuspenseLoader from "Routes/Apps/Gluu/GluuSuspenseLoader";
+import { processRoutes } from 'Plugins/PluginMenuResolver'
+import { hasPermission } from 'Utils/PermChecker'
+import GluuSuspenseLoader from 'Routes/Apps/Gluu/GluuSuspenseLoader'
 
-import { uuidv4 } from "Utils/Util";
-import ProtectedRoute from "./Pages/ProtectRoutes";
+import { uuidv4 } from 'Utils/Util'
+import ProtectedRoute from './Pages/ProtectRoutes'
 
-const DashboardPage = lazy(() => import("./Dashboards/DashboardPage"));
-const HealthPage = lazy(() => import("./Health/HealthPage"));
-const LicenseDetailsPage = lazy(() => import("./License/LicenseDetailsPage"));
-const ProfilePage = lazy(() => import("./Apps/Profile/ProfilePage"));
-const Gluu404Error = lazy(() => import("./Apps/Gluu/Gluu404Error"));
-const ByeBye = lazy(() => import("./Pages/ByeBye"));
-const GluuNavBar = lazy(() => import("./Apps/Gluu/GluuNavBar"));
+const DashboardPage = lazy(() => import('./Dashboards/DashboardPage'))
+const HealthPage = lazy(() => import('./Health/HealthPage'))
+const LicenseDetailsPage = lazy(() => import('./License/LicenseDetailsPage'))
+const ProfilePage = lazy(() => import('./Apps/Profile/ProfilePage'))
+const Gluu404Error = lazy(() => import('./Apps/Gluu/Gluu404Error'))
+const ByeBye = lazy(() => import('./Pages/ByeBye'))
+const GluuNavBar = lazy(() => import('./Apps/Gluu/GluuNavBar'))
 const DefaultSidebar = lazy(() =>
-  import("./../layout/components/DefaultSidebar")
-);
+  import('./../layout/components/DefaultSidebar')
+)
 
 //------ Route Definitions --------
 // eslint-disable-next-line no-unused-vars
 export const RoutedContent = () => {
-  const scopes = useSelector((state) =>
+  const scopes = useSelector(state =>
     state.token ? state.token.scopes : state.authReducer.permissions
-  );
-  const [pluginMenus, setPluginMenus] = useState([]);
+  )
+  const [pluginMenus, setPluginMenus] = useState([])
   useEffect(() => {
-    setPluginMenus(processRoutes());
-  }, []);
+    setPluginMenus(processRoutes())
+  }, [])
 
-  const { userinfo } = useSelector((state) => state.authReducer);
-  const config = useSelector((state) => state.authReducer.config);
+  const { userinfo } = useSelector(state => state.authReducer)
+  const config = useSelector(state => state.authReducer.config)
 
   useEffect(() => {
     if (!userinfo.jansAdminUIRole || userinfo.jansAdminUIRole.length === 0) {
-      const state = uuidv4();
-      const sessionEndpoint = `${config.endSessionEndpoint}?state=${state}&post_logout_redirect_uri=${config.postLogoutRedirectUri}`;
-      window.location.href = sessionEndpoint;
+      const state = uuidv4()
+      const sessionEndpoint = `${config.endSessionEndpoint}?state=${state}&post_logout_redirect_uri=${config.postLogoutRedirectUri}`
+      window.location.href = sessionEndpoint
     }
-  }, [userinfo]);
+  }, [userinfo])
 
   return (
     <Routes>
@@ -54,29 +54,14 @@ export const RoutedContent = () => {
         path="/home/dashboard"
         element={
           <ProtectedRoute>
-          <Suspense fallback={<GluuSuspenseLoader />}>
-            <DashboardPage />
-          </Suspense>
+            <Suspense fallback={<GluuSuspenseLoader />}>
+              <DashboardPage />
+            </Suspense>
           </ProtectedRoute>
         }
       />
       <Route path="/" element={<Navigate to="/home/dashboard" />} />
-      <Route
-        path="/home/health"
-        element={
-          <Suspense fallback={<GluuSuspenseLoader />}>
-            <HealthPage />
-          </Suspense>
-        }
-      />
-      <Route
-        path="/home/licenseDetails"
-        element={
-          <Suspense fallback={<GluuSuspenseLoader />}>
-            <LicenseDetailsPage />
-          </Suspense>
-        }
-      />
+
       {/*    Layouts     */}
       <Route path="/layouts/navbar" element={<NavbarOnly />} />
       <Route path="/layouts/sidebar" element={<SidebarDefault />} />
@@ -125,8 +110,8 @@ export const RoutedContent = () => {
       {/*    404    */}
       <Route path="*" element={<Navigate to="/error-404" />} />
     </Routes>
-  );
-};
+  )
+}
 
 //------ Custom Layout Parts --------
 export const RoutedNavbars = () => (
@@ -144,7 +129,7 @@ export const RoutedNavbars = () => (
       }
     />
   </Routes>
-);
+)
 
 export const RoutedSidebars = () => (
   <Routes>
@@ -157,4 +142,4 @@ export const RoutedSidebars = () => (
       }
     />
   </Routes>
-);
+)

--- a/admin-ui/app/styles/custom/sidebar.scss
+++ b/admin-ui/app/styles/custom/sidebar.scss
@@ -1,5 +1,5 @@
 .custom-sidebar-container {
-  background-color: #FCFCFC;
+  background-color: #fcfcfc;
   border-top-right-radius: 28px;
   border-top-left-radius: 28px;
 
@@ -37,7 +37,6 @@
   width: 28px;
   margin-right: 10px;
   position: relative;
-  top: -5px;
 }
 
 .sidebar-menu__entry {
@@ -55,45 +54,45 @@
 }
 
 .sidebar-menu-active-darkBlack {
-  background: #323C46!important;
-  color: #FFF!important;
+  background: #323c46 !important;
+  color: #fff !important;
 }
 
 .sidebar-menu-active-darkBlack:hover {
-  background: #323C46!important;
-  color: #FFF!important;
+  background: #000 !important;
+  color: #fff !important;
 }
 
 .sidebar-menu-active-darkBlue {
-  background: #323C46!important;
-  color: #FFF!important;
+  background: #323c46 !important;
+  color: #fff !important;
 }
 
 .sidebar-menu-active-darkBlue:hover {
-  background: #323C46!important;
-  color: #FFF!important;
+  background: #323c46 !important;
+  color: #fff !important;
 }
 
 .sidebar-menu-active-lightBlue {
-  background: #274561!important;
-  color: #FFF!important;
+  background: #274561 !important;
+  color: #fff !important;
 }
 
 .sidebar-menu-active-lightBlue:hover {
-  background: #274561!important;
-  color: #FFF!important;
+  background: #274561 !important;
+  color: #fff !important;
 }
 
 .sidebar-menu-active-lightGreen {
-  background: #02B774!important;
-  color: #FFF!important;
+  background: #02b774 !important;
+  color: #fff !important;
 }
 
 .sidebar-menu-active-lightGreen:hover {
-  background: #02B774!important;
-  color: #FFF!important;
+  background: #02b774 !important;
+  color: #fff !important;
 }
 
 .sidebar-active-icon {
-  color: #FFF!important;
+  color: #000 !important;
 }

--- a/admin-ui/app/utils/PermChecker.js
+++ b/admin-ui/app/utils/PermChecker.js
@@ -37,8 +37,10 @@ export const MAPPING_DELETE =
   'https://jans.io/oauth/jans-auth-server/config/adminui/user/rolePermissionMapping.delete'
 
 export const LICENSE_DETAILS_READ =
-  BASE_URL + '/config/adminui/license.readonly'
-export const LICENSE_DETAILS_WRITE = BASE_URL + '/config/adminui/license.write'
+  BASE_URL + '/jans-auth-server/config/adminui/license.readonly'
+
+export const LICENSE_DETAILS_WRITE =
+  BASE_URL + '/jans-auth-server/config/adminui/license.write'
 
 export const SCOPE_READ = BASE_URL + '/config/scopes.readonly'
 export const SCOPE_WRITE = BASE_URL + '/config/scopes.write'

--- a/admin-ui/plugins.config.json
+++ b/admin-ui/plugins.config.json
@@ -1,43 +1,58 @@
 [
   {
-    "key": "services",
-    "metadataFile": "./services/plugin-metadata"
+    "order": 1,
+    "key": "home",
+    "metadataFile": "./admin/plugin-metadata"
   },
+
   {
-    "key": "schema",
-    "metadataFile": "./schema/plugin-metadata"
-  },
-  {
+    "order": 2,
     "key": "auth-server",
     "metadataFile": "./auth-server/plugin-metadata"
   },
   {
-    "key": "admin",
-    "metadataFile": "./admin/plugin-metadata"
-  },
-  {
+    "order": 3,
     "key": "users",
     "metadataFile": "./user-management/plugin-metadata"
   },
   {
+    "order": 4,
+    "key": "scripts",
+    "metadataFile": "./scripts/plugin-metadata"
+  },
+  {
+    "order": 5,
+    "key": "user-claims",
+    "metadataFile": "./schema/plugin-metadata"
+  },
+  {
+    "order": 6,
+    "key": "services",
+    "metadataFile": "./services/plugin-metadata"
+  },
+  {
+    "order": 7,
     "key": "smtp",
     "metadataFile": "./smtp-management/plugin-metadata"
   },
   {
-    "key": "fido",
-    "metadataFile": "./fido/plugin-metadata"
-  },
-  {
-    "key": "jans-lock",
-    "metadataFile": "./jans-lock/plugin-metadata"
-  },
-
-  {
+    "order": 8,
     "key": "scim",
     "metadataFile": "./scim/plugin-metadata"
   },
   {
+    "order": 9,
+    "key": "fido",
+    "metadataFile": "./fido/plugin-metadata"
+  },
+  {
+    "order": 10,
     "key": "saml",
     "metadataFile": "./saml/plugin-metadata"
+  },
+  {
+    "order": 11,
+    "key": "jans-lock",
+    "metadataFile": "./jans-lock/plugin-metadata"
   }
 ]

--- a/admin-ui/plugins/PluginMenuResolver.js
+++ b/admin-ui/plugins/PluginMenuResolver.js
@@ -2,8 +2,8 @@ import plugins from '../plugins.config.json'
 export function processMenus() {
   let pluginMenus = []
   plugins
-    .map((item) => item.metadataFile)
-    .forEach((path) => {
+    .map(item => item.metadataFile)
+    .forEach(path => {
       pluginMenus = pluginMenus.concat(require(`${path}`).default.menus)
     })
 
@@ -14,30 +14,20 @@ export function processMenus() {
 export function processRoutes() {
   let pluginRoutes = []
   plugins
-    .map((item) => item.metadataFile)
-    .forEach((path) => {
+    .map(item => item.metadataFile)
+    .forEach(path => {
       pluginRoutes = pluginRoutes.concat(require(`${path}`).default.routes)
     })
   return pluginRoutes
 }
 
-const sortMenu = (menu) => {
+const sortMenu = menu => {
   menu = sortParentMenu(menu)
   return menu
 }
 
-const sortParentMenu = (menu) => {
-  menu.sort((a, b) => {
-    var titleA = a.title.toUpperCase()
-    var titleB = b.title.toUpperCase()
-    if (titleA < titleB) {
-      return -1
-    }
-    if (titleA > titleB) {
-      return 1
-    }
-    return 0
-  })
+const sortParentMenu = menu => {
+  menu.sort((a, b) => a?.order - b?.order)
 
   return menu
 }

--- a/admin-ui/plugins/admin/plugin-metadata.js
+++ b/admin-ui/plugins/admin/plugin-metadata.js
@@ -1,23 +1,18 @@
 import HealthPage from './components/Health/HealthPage'
-import ReportPage from './components/Reports/ReportPage'
 import UiRoleListPage from './components/Roles/UiRoleListPage'
 import UiPermListPage from './components/Permissions/UiPermListPage'
 import MappingPage from './components/Mapping/MappingPage'
-import ScriptListPage from './components/CustomScripts/ScriptListPage'
-import CustomScriptAddPage from './components/CustomScripts/CustomScriptAddPage'
-import CustomScriptEditPage from './components/CustomScripts/CustomScriptEditPage'
+
 import SettingsPage from './components/Settings/SettingsPage'
 import MauGraph from './components/MAU/MauGraph'
 import WebhookListPage from './components/Webhook/WebhookListPage'
 
-import scriptSaga from './redux/sagas/CustomScriptSaga'
 import apiRoleSaga from './redux/sagas/ApiRoleSaga'
 import apiPermissionSaga from './redux/sagas/ApiPermissionSaga'
 import mappingSaga from './redux/sagas/MappingSaga'
 import webhookSaga from './redux/sagas/WebhookSaga'
 import assetSaga from './redux/sagas/AssetSaga'
 
-import { reducer as scriptReducer } from 'Plugins/admin/redux/features/customScriptSlice'
 import { reducer as apiRoleReducer } from 'Plugins/admin/redux/features/apiRoleSlice'
 import { reducer as apiPermissionReducer } from 'Plugins/admin/redux/features/apiPermissionSlice'
 import { reducer as mappingReducer } from 'Plugins/admin/redux/features/mappingSlice'
@@ -27,167 +22,178 @@ import {
   ACR_READ,
   ROLE_READ,
   PERMISSION_READ,
-  SCRIPT_READ,
-  SCRIPT_WRITE,
   MAPPING_READ,
   WEBHOOK_READ,
   WEBHOOK_WRITE,
   ASSETS_READ,
   ASSETS_WRITE,
+  LICENSE_DETAILS_READ,
+  PROPERTIES_READ,
+  STAT_READ
 } from 'Utils/PermChecker'
 import WebhookAddPage from './components/Webhook/WebhookAddPage'
 import WebhookEditPage from './components/Webhook/WebhookEditPage'
 import JansAssetListPage from './components/Assets/JansAssetListPage'
 import JansAssetEditPage from './components/Assets/JansAssetEditPage'
 import JansAssetAddPage from './components/Assets/JansAssetAddPage'
+import DashboardPage from '../../app/routes/Dashboards/DashboardPage'
+import LicenseDetailsPage from '../../app/routes/License/LicenseDetailsPage'
 
-const PLUGIN_BASE_APTH = '/adm'
+const PLUGIN_BASE_PATH = '/adm'
 
 const pluginMetadata = {
   menus: [
     {
-      title: 'menus.adminui',
-      icon: 'admin',
+      title: 'menus.home',
+      icon: 'home',
       children: [
         {
-          title: 'menus.config-api',
-          children: [
-            {
-              title: 'menus.api.roles',
-              path: PLUGIN_BASE_APTH + '/roles',
-              permission: ROLE_READ,
-            },
-            {
-              title: 'menus.api.permissions',
-              path: PLUGIN_BASE_APTH + '/permissions',
-              permission: PERMISSION_READ,
-            },
-            {
-              title: 'menus.api.mapping',
-              path: PLUGIN_BASE_APTH + '/mapping',
-              permission: MAPPING_READ,
-            },
-          ],
+          title: 'menus.dashboard',
+          path: PLUGIN_BASE_PATH + '/dashboard',
+          permission: STAT_READ
         },
         {
-          title: 'menus.scripts',
-          path: PLUGIN_BASE_APTH + '/scripts',
-          permission: SCRIPT_READ,
+          title: 'menus.health',
+          path: PLUGIN_BASE_PATH + '/health',
+          permission: PROPERTIES_READ
+        },
+        {
+          title: 'menus.licenseDetails',
+          path: PLUGIN_BASE_PATH + '/licenseDetails',
+          permission: LICENSE_DETAILS_READ
         },
         {
           title: 'menus.maugraph',
-          path: PLUGIN_BASE_APTH + '/maugraph',
-          permission: ACR_READ,
+          path: PLUGIN_BASE_PATH + '/maugraph',
+          permission: ACR_READ
         },
         {
           title: 'menus.settings',
-          path: PLUGIN_BASE_APTH + '/settings',
-          permission: ACR_READ,
+          path: PLUGIN_BASE_PATH + '/settings',
+          permission: ACR_READ
         },
         {
+          title: 'menus.security',
+          children: [
+            {
+              title: 'menus.securityDropdown.adminUiRoles',
+              path: PLUGIN_BASE_PATH + '/roles',
+              permission: ROLE_READ
+            },
+            {
+              title: 'menus.securityDropdown.capabilities',
+              path: PLUGIN_BASE_PATH + '/capabilities',
+              permission: PERMISSION_READ
+            },
+            {
+              title: 'menus.securityDropdown.mapping',
+              path: PLUGIN_BASE_PATH + '/mapping',
+              permission: MAPPING_READ
+            }
+          ]
+        },
+
+        {
           title: 'menus.webhooks',
-          path: PLUGIN_BASE_APTH + '/webhook',
-          permission: WEBHOOK_READ,
+          path: PLUGIN_BASE_PATH + '/webhook',
+          permission: WEBHOOK_READ
         },
         {
           title: 'menus.assets',
-          path: PLUGIN_BASE_APTH + '/assets',
-          permission: ASSETS_READ,
-        },
-      ],
-    },
+          path: PLUGIN_BASE_PATH + '/assets',
+          permission: ASSETS_READ
+        }
+      ]
+    }
   ],
   routes: [
     {
-      component: MauGraph,
-      path: PLUGIN_BASE_APTH + '/maugraph',
-      permission: ACR_READ,
+      component: DashboardPage,
+      path: PLUGIN_BASE_PATH + '/dashboard',
+      permission: STAT_READ
     },
     {
       component: HealthPage,
-      path: PLUGIN_BASE_APTH + '/health',
-      permission: ACR_READ,
+      path: PLUGIN_BASE_PATH + '/health',
+      permission: PROPERTIES_READ
     },
     {
-      component: ReportPage,
-      path: PLUGIN_BASE_APTH + '/reports',
-      permission: ACR_READ,
+      component: LicenseDetailsPage,
+      path: PLUGIN_BASE_PATH + '/licenseDetails',
+      permission: LICENSE_DETAILS_READ
     },
     {
-      component: UiRoleListPage,
-      path: PLUGIN_BASE_APTH + '/roles',
-      permission: ROLE_READ,
-    },
-    {
-      component: UiPermListPage,
-      path: PLUGIN_BASE_APTH + '/permissions',
-      permission: PERMISSION_READ,
-    },
-    {
-      component: MappingPage,
-      path: PLUGIN_BASE_APTH + '/mapping',
-      permission: MAPPING_READ,
-    },
-    {
-      component: ScriptListPage,
-      path: PLUGIN_BASE_APTH + '/scripts',
-      permission: SCRIPT_READ,
-    },
-    {
-      component: CustomScriptAddPage,
-      path: PLUGIN_BASE_APTH + '/script/new',
-      permission: SCRIPT_WRITE,
-    },
-    {
-      component: CustomScriptEditPage,
-      path: PLUGIN_BASE_APTH + '/script/edit/:id',
-      permission: SCRIPT_READ,
+      component: MauGraph,
+      path: PLUGIN_BASE_PATH + '/maugraph',
+      permission: ACR_READ
     },
     {
       component: SettingsPage,
-      path: PLUGIN_BASE_APTH + '/settings',
-      permission: ACR_READ,
+      path: PLUGIN_BASE_PATH + '/settings',
+      permission: ACR_READ
+    },
+
+    {
+      component: UiRoleListPage,
+      path: PLUGIN_BASE_PATH + '/roles',
+      permission: ROLE_READ
     },
     {
+      component: UiPermListPage,
+      path: PLUGIN_BASE_PATH + '/capabilities',
+      permission: PERMISSION_READ
+    },
+    {
+      component: MappingPage,
+      path: PLUGIN_BASE_PATH + '/mapping',
+      permission: MAPPING_READ
+    },
+
+    {
       component: WebhookListPage,
-      path: PLUGIN_BASE_APTH + '/webhook',
-      permission: WEBHOOK_READ,
+      path: PLUGIN_BASE_PATH + '/webhook',
+      permission: WEBHOOK_READ
     },
     {
       component: WebhookAddPage,
-      path: PLUGIN_BASE_APTH + '/webhook/add',
-      permission: WEBHOOK_WRITE,
+      path: PLUGIN_BASE_PATH + '/webhook/add',
+      permission: WEBHOOK_WRITE
     },
     {
       component: WebhookEditPage,
-      path: PLUGIN_BASE_APTH + '/webhook/edit/:id',
-      permission: WEBHOOK_WRITE,
+      path: PLUGIN_BASE_PATH + '/webhook/edit/:id',
+      permission: WEBHOOK_WRITE
     },
     {
       component: JansAssetListPage,
-      path: PLUGIN_BASE_APTH + '/assets',
-      permission: ASSETS_READ,
+      path: PLUGIN_BASE_PATH + '/assets',
+      permission: ASSETS_READ
     },
     {
       component: JansAssetAddPage,
-      path: PLUGIN_BASE_APTH + '/asset/add',
-      permission: ASSETS_WRITE,
+      path: PLUGIN_BASE_PATH + '/asset/add',
+      permission: ASSETS_WRITE
     },
     {
       component: JansAssetEditPage,
-      path: PLUGIN_BASE_APTH + '/asset/edit/:id',
-      permission: ASSETS_WRITE,
-    },
+      path: PLUGIN_BASE_PATH + '/asset/edit/:id',
+      permission: ASSETS_WRITE
+    }
   ],
   reducers: [
-    { name: 'scriptReducer', reducer: scriptReducer },
     { name: 'apiRoleReducer', reducer: apiRoleReducer },
     { name: 'apiPermissionReducer', reducer: apiPermissionReducer },
     { name: 'mappingReducer', reducer: mappingReducer },
     { name: 'webhookReducer', reducer: webhookReducer },
     { name: 'assetReducer', reducer: assetReducer }
   ],
-  sagas: [scriptSaga(), apiRoleSaga(), apiPermissionSaga(), mappingSaga(), webhookSaga(), assetSaga()],
+  sagas: [
+    apiRoleSaga(),
+    apiPermissionSaga(),
+    mappingSaga(),
+    webhookSaga(),
+    assetSaga()
+  ]
 }
 
 export default pluginMetadata

--- a/admin-ui/plugins/auth-server/plugin-metadata.js
+++ b/admin-ui/plugins/auth-server/plugin-metadata.js
@@ -1,3 +1,4 @@
+import React, { Suspense, lazy } from 'react'
 import ScopeListPage from './components/Scopes/ScopeListPage'
 import ScopeAddPage from './components/Scopes/ScopeAddPage'
 import ScopeEditPage from './components/Scopes/ScopeEditPage'
@@ -36,8 +37,8 @@ import umaResourceSaga from './redux/sagas/UMAResourceSaga'
 import sessionSaga from './redux/sagas/SessionSaga'
 import agamaSaga from './redux/sagas/AgamaSaga'
 import authnSaga from './redux/sagas/AuthnSaga'
-import ssaSaga from './redux/sagas/SsaSaga' 
-import messageSaga from './redux/sagas/MessageSaga' 
+import ssaSaga from './redux/sagas/SsaSaga'
+import messageSaga from './redux/sagas/MessageSaga'
 import configApiSaga from './redux/sagas/configApiSaga'
 
 import {
@@ -60,16 +61,19 @@ import configApiReducer from 'Plugins/auth-server/redux/features/configApiSlice'
 import AuthNListPage from './components/AuthN/AuthNListPage'
 import { reducer as authNReducer } from './redux/features/authNSlice'
 import AuthNEditPage from './components/AuthN/AuthNEditPage'
-import SsaListPage from './components/Ssa/SsaListPage' 
+import SsaListPage from './components/Ssa/SsaListPage'
 import SsaAddPage from './components/Ssa/SsaAddPage'
-import React, { Suspense, lazy } from 'react'
 import LockPage from './components/Message/LockPage'
 import AuthNPage from './components/AuthN'
 
 const AgamaListPage = lazy(() => import('./components/Agama/AgamaListPage'))
 function AgamaListPageWrapper() {
-  return <Suspense fallback={<div>Loading...</div>}><AgamaListPage /></Suspense>
-} 
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <AgamaListPage />
+    </Suspense>
+  )
+}
 
 const PLUGIN_BASE_APTH = '/auth-server'
 
@@ -82,42 +86,42 @@ const pluginMetadata = {
         {
           title: 'menus.clients',
           path: PLUGIN_BASE_APTH + '/clients',
-          permission: CLIENT_READ,
+          permission: CLIENT_READ
         },
         {
           title: 'menus.scopes',
           path: PLUGIN_BASE_APTH + '/scopes',
-          permission: SCOPE_READ,
+          permission: SCOPE_READ
         },
         {
           title: 'menus.keys',
           path: PLUGIN_BASE_APTH + '/config/keys',
-          permission: JWKS_READ,
+          permission: JWKS_READ
         },
         {
           title: 'menus.properties',
           path: PLUGIN_BASE_APTH + '/config/properties',
-          permission: PROPERTIES_READ,
+          permission: PROPERTIES_READ
         },
         {
           title: 'menus.logging',
           path: PLUGIN_BASE_APTH + '/config/logging',
-          permission: LOGGING_READ,
+          permission: LOGGING_READ
         },
         {
           title: 'menus.ssa',
           path: PLUGIN_BASE_APTH + '/config/ssa',
-          permission: SSA_PORTAL,
+          permission: SSA_PORTAL
         },
         {
           title: 'menus.authn',
           path: PLUGIN_BASE_APTH + '/authn',
-          permission: SCOPE_READ,
+          permission: SCOPE_READ
         },
         {
-          title: 'menus.api.api_config',
+          title: 'menus.api_config',
           path: PLUGIN_BASE_APTH + '/config-api-configuration',
-          permission: API_CONFIG_READ,
+          permission: API_CONFIG_READ
         },
         // {
         //   title: 'menus.configuration',
@@ -126,107 +130,107 @@ const pluginMetadata = {
         {
           title: 'menus.sessions',
           path: PLUGIN_BASE_APTH + '/sessions',
-          permission: SESSION_READ,
-        },
+          permission: SESSION_READ
+        }
         // {
         //   title: 'menus.lock ',
         //   path: PLUGIN_BASE_APTH + '/lock',
         //   permission: MESSAGE_READ,
         // },
-      ],
-    },
+      ]
+    }
   ],
   routes: [
     {
       component: SessionListPage,
       path: PLUGIN_BASE_APTH + '/sessions',
-      permission: SESSION_READ,
+      permission: SESSION_READ
     },
     {
       component: ClientListPage,
       path: PLUGIN_BASE_APTH + '/clients',
-      permission: CLIENT_READ,
+      permission: CLIENT_READ
     },
     {
       component: ClientAddPage,
       path: PLUGIN_BASE_APTH + '/client/new',
-      permission: CLIENT_WRITE,
+      permission: CLIENT_WRITE
     },
     {
       component: ClientEditPage,
       path: PLUGIN_BASE_APTH + '/client/edit/:id',
-      permission: CLIENT_WRITE,
+      permission: CLIENT_WRITE
     },
     {
       component: ScopeListPage,
       path: PLUGIN_BASE_APTH + '/scopes',
-      permission: SCOPE_READ,
+      permission: SCOPE_READ
     },
     {
       component: AuthNEditPage,
       path: PLUGIN_BASE_APTH + '/authn/edit/:id',
-      permission: SCOPE_READ,
+      permission: SCOPE_READ
     },
     {
       component: AuthNPage,
       path: PLUGIN_BASE_APTH + '/authn',
-      permission: SCOPE_READ,
+      permission: SCOPE_READ
     },
     {
       component: ScopeAddPage,
       path: PLUGIN_BASE_APTH + '/scope/new',
-      permission: SCOPE_WRITE,
+      permission: SCOPE_WRITE
     },
     {
       component: ScopeEditPage,
       path: PLUGIN_BASE_APTH + '/scope/edit/:id',
-      permission: SCOPE_WRITE,
+      permission: SCOPE_WRITE
     },
     {
       component: PropertiesPage,
       path: PLUGIN_BASE_APTH + '/config/properties',
-      permission: ACR_READ,
+      permission: ACR_READ
     },
     {
       component: KeysPage,
       path: PLUGIN_BASE_APTH + '/config/keys',
-      permission: JWKS_READ,
+      permission: JWKS_READ
     },
     {
       component: LoggingPage,
       path: PLUGIN_BASE_APTH + '/config/logging',
-      permission: ACR_READ,
+      permission: ACR_READ
     },
     {
       component: ReportPage,
       path: PLUGIN_BASE_APTH + '/reports',
-      permission: ACR_READ,
+      permission: ACR_READ
     },
     {
       component: AgamaListPageWrapper,
       path: PLUGIN_BASE_APTH + '/agama',
-      permission: AGAMA_READ,
+      permission: AGAMA_READ
     },
     {
       component: SsaListPage,
       path: PLUGIN_BASE_APTH + '/config/ssa',
-      permission: SSA_PORTAL,
+      permission: SSA_PORTAL
     },
     {
       component: SsaAddPage,
       path: PLUGIN_BASE_APTH + '/config/ssa/new',
-      permission: SSA_PORTAL,
+      permission: SSA_PORTAL
     },
     {
       component: LockPage,
       path: PLUGIN_BASE_APTH + '/lock',
-      permission: MESSAGE_READ,
+      permission: MESSAGE_READ
     },
     {
       component: ConfigApiPage,
       path: PLUGIN_BASE_APTH + '/config-api-configuration',
-      permission: API_CONFIG_READ,
-    },
+      permission: API_CONFIG_READ
+    }
   ],
   reducers: [
     { name: 'scopeReducer', reducer: scopeReducer },
@@ -241,7 +245,7 @@ const pluginMetadata = {
     { name: 'authNReducer', reducer: authNReducer },
     { name: 'SsaReducer', reducer: ssaReducer },
     { name: 'messageReducer', reducer: messageReducer },
-    { name: 'configApiReducer', reducer: configApiReducer },
+    { name: 'configApiReducer', reducer: configApiReducer }
   ],
   sagas: [
     scopesSaga(),
@@ -257,7 +261,7 @@ const pluginMetadata = {
     ssaSaga(),
     messageSaga(),
     configApiSaga()
-  ],
+  ]
 }
 
 export default pluginMetadata

--- a/admin-ui/plugins/jans-lock/plugin-metadata.js
+++ b/admin-ui/plugins/jans-lock/plugin-metadata.js
@@ -1,20 +1,28 @@
 import { JANS_LOCK_READ } from 'Utils/PermChecker'
 import JansLock from './components/JansLock'
-const PLUGIN_BASE_PATH = '/jans-lock'
 import jansLockReducer from './redux/features/JansLockSlice'
 import jansLockSaga from './redux/sagas/JansLockSaga'
 
+const PLUGIN_BASE_PATH = '/jans-lock'
+
 const pluginMetadata = {
-  menus: [],
+  menus: [
+    {
+      title: 'titles.jans_lock',
+      icon: 'jans_lock',
+      path: PLUGIN_BASE_PATH,
+      permission: JANS_LOCK_READ
+    }
+  ],
   routes: [
     {
       component: JansLock,
       path: PLUGIN_BASE_PATH,
-      permission: JANS_LOCK_READ,
-    },
+      permission: JANS_LOCK_READ
+    }
   ],
   reducers: [{ name: 'jansLockReducer', reducer: jansLockReducer }],
-  sagas: [jansLockSaga()],
+  sagas: [jansLockSaga()]
 }
 
 export default pluginMetadata

--- a/admin-ui/plugins/scripts/plugin-metadata.js
+++ b/admin-ui/plugins/scripts/plugin-metadata.js
@@ -1,0 +1,40 @@
+import { SCRIPT_READ, SCRIPT_WRITE } from '../../app/utils/PermChecker'
+import { reducer as scriptReducer } from 'Plugins/admin/redux/features/customScriptSlice'
+import ScriptListPage from '../admin/components/CustomScripts/ScriptListPage'
+import CustomScriptAddPage from '../admin/components/CustomScripts/CustomScriptAddPage'
+import CustomScriptEditPage from '../admin/components/CustomScripts/CustomScriptEditPage'
+import scriptSaga from '../admin/redux/sagas/CustomScriptSaga'
+
+const PLUGIN_PATH = '/adm/scripts'
+
+const pluginMetadata = {
+  menus: [
+    {
+      title: 'menus.scripts',
+      icon: 'scripts',
+      path: PLUGIN_PATH,
+      permission: SCRIPT_READ
+    }
+  ],
+  routes: [
+    {
+      component: ScriptListPage,
+      path: PLUGIN_PATH,
+      permission: SCRIPT_READ
+    },
+    {
+      component: CustomScriptAddPage,
+      path: `${PLUGIN_PATH}/new`,
+      permission: SCRIPT_WRITE
+    },
+    {
+      component: CustomScriptEditPage,
+      path: `${PLUGIN_PATH}/edit/:id`,
+      permission: SCRIPT_READ
+    }
+  ],
+  reducers: [{ name: 'scriptReducer', reducer: scriptReducer }],
+  sagas: [scriptSaga()]
+}
+
+export default pluginMetadata


### PR DESCRIPTION
# feat(admin-ui): reordering Admin-UI's left menu

This PR restructures the Admin-UI left navigation menu for better usability and clarity:

- Combined the **Home** and **Admin** sections into a single **Home** section to reduce redundancy.
- Moved **Scripts** out of the Home section and placed it in the main sidebar, with an appropriate icon added.
- Made **Jans Lock** menu optional, showing it only if the server is installed and running.
- Removed the **Logout** option from the sidebar, as users can sign out via the profile menu in the upper-right corner.

Closes #2065 