### PR TITLE
feat(admin-ui): hide optional components from sidebar if not installed

### DIFF
--- a/admin-ui/app/routes/Apps/Gluu/styles/GluuAppSidebar.style.js
+++ b/admin-ui/app/routes/Apps/Gluu/styles/GluuAppSidebar.style.js
@@ -8,7 +8,7 @@ const styles = makeStyles()({
     top: 140,
     height: 70,
     borderBottomLeftRadius: 20,
-    borderBottomRightRadius: 20,
+    borderBottomRightRadius: 20
   },
   wave: {
     position: 'relative',
@@ -19,7 +19,15 @@ const styles = makeStyles()({
     textAlign: 'center',
     position: 'relative',
     top: -130,
-    fontWeight: 500,
+    fontWeight: 500
+  },
+  waveContainerFixed: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    zIndex: 10,
+    background: 'inherit'
   }
 })
 


### PR DESCRIPTION
## feat(admin-ui): hide optional components from sidebar if not installed

### Summary

This PR updates the Admin UI sidebar to conditionally hide optional components based on their installation status.

### Changes

- SCIM and FIDO components will only be shown in the sidebar if their corresponding servers are installed and running.
- Improves the clarity and relevance of the sidebar by hiding components that are not part of the current Jans installation.

### Details

The sidebar now checks the status of SCIM and FIDO servers via the health API, and hides their menu entries if the servers are not installed or not running.

### Related Issue

Closes #2087