### PR TITLE
fix(admin-ui): White screen on AuthN page load #2093

### DIFF
--- a/admin-ui/plugins/auth-server/components/AuthN/index.js
+++ b/admin-ui/plugins/auth-server/components/AuthN/index.js
@@ -1,47 +1,45 @@
-import React from "react";
-import AuthNListPage from "./AuthNListPage";
-import { useTranslation } from "react-i18next";
-import GluuTabs from "Routes/Apps/Gluu/GluuTabs";
-import { Card } from "Components";
-import applicationStyle from "Routes/Apps/Gluu/styles/applicationstyle";
+import React from 'react'
+import AuthNListPage from './AuthNListPage'
+import { useTranslation } from 'react-i18next'
+import GluuTabs from 'Routes/Apps/Gluu/GluuTabs'
+import { Card } from 'Components'
+import applicationStyle from 'Routes/Apps/Gluu/styles/applicationstyle'
 
-import { useSelector } from "react-redux";
-import AgamaListPage from "../Agama/AgamaListPage";
-import AliasesListPage from "../Agama/AgamaAliasListPage";
+import { useSelector } from 'react-redux'
+import AgamaListPage from '../Agama/AgamaListPage'
+import AliasesListPage from '../Agama/AgamaAliasListPage'
 
 function AuthNPage() {
-  const { t } = useTranslation();
-  const isLoading = useSelector((state) => state.cacheRefreshReducer.loading);
+  const { t } = useTranslation()
 
   const tabNames = [
     {
-      name: t("menus.builtIn"),
-      path: "",
+      name: t('menus.builtIn'),
+      path: ''
     },
-    { name: t("menus.acrs"), path: "" },
+    { name: t('menus.acrs'), path: '' },
     {
-      name: t("menus.aliases"),
-      path: "",
+      name: t('menus.aliases'),
+      path: ''
     },
     {
-      name: t("menus.agama_flows"),
-      path: "",
-    },
- 
-  ];
-
-  const tabToShow = (tabName) => {
-    switch (tabName) {
-      case t("menus.builtIn"):
-        return <AuthNListPage isBuiltIn={true}/>;
-      case t("menus.acrs"):
-        return <AuthNListPage />;
-      case t("menus.agama_flows"):
-        return <AgamaListPage />;
-      case t("menus.aliases"):
-        return <AliasesListPage />;
+      name: t('menus.agama_flows'),
+      path: ''
     }
-  };
+  ]
+
+  const tabToShow = tabName => {
+    switch (tabName) {
+      case t('menus.builtIn'):
+        return <AuthNListPage isBuiltIn={true} />
+      case t('menus.acrs'):
+        return <AuthNListPage />
+      case t('menus.agama_flows'):
+        return <AgamaListPage />
+      case t('menus.aliases'):
+        return <AliasesListPage />
+    }
+  }
 
   return (
     <Card className="mb-3" style={applicationStyle.mainCard}>
@@ -51,7 +49,7 @@ function AuthNPage() {
         withNavigation={true}
       />
     </Card>
-  );
+  )
 }
 
-export default AuthNPage;
+export default AuthNPage


### PR DESCRIPTION
## fix(admin-ui): White screen on AuthN page load #2093

### Summary

This PR addresses a rendering failure causing a white screen on the AuthN page during load.

### Root Cause

The AuthN component contained an unused Redux selector subscribing to a loading state from the Jans-Link plugin, which has been removed. This stale subscription triggered errors in the Redux state update cycle, preventing component render.

### Fix

- Removed the obsolete "isLoading" state selector referencing Jans-Link from the AuthN component's Redux hooks.

### Outcome

AuthN page now successfully renders without interruption on load.

Closes #2093