### PR TITLE
fix: update Husky prepare script for proper git repository detection

### DIFF
--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -41,7 +41,7 @@
     "plugin:add": "node ./build/plugin-cli.js --addPlugin",
     "plugin:remove": "node ./build/plugin-cli.js --removePlugin",
     "plugin:clean": "node ./build/plugin-cli.js --cleanExceptDefault admin,auth-server --resetPluginConfig",
-    "prepare": "husky && husky install"
+    "prepare": "cd .. && npx husky install && git config core.hooksPath admin-ui/.husky"
   },
   "author": "gluu inc.",
   "license": "Apache",


### PR DESCRIPTION
## fix(admin-ui): update Husky prepare script for proper git detection

### Summary
Updated the `prepare` script in `package.json` to ensure Husky initializes correctly by detecting the Git repository. This prevents issues where hooks are not installed in some environments.