### PR TITLE
feat: add cronjob schedule override

### DIFF
--- a/charts/gluu-all-in-one/templates/cronjobs.yaml
+++ b/charts/gluu-all-in-one/templates/cronjobs.yaml
@@ -20,7 +20,11 @@ metadata:
 {{- end }}
 {{- end }}
 spec:
+  {{- if ne (index .Values "auth-server-key-rotation" "cronJobSchedule")  "" }}
+  schedule: {{  index .Values "auth-server-key-rotation" "cronJobSchedule"  | quote }}
+   {{- else }}
   schedule: "@every {{ index .Values "auth-server-key-rotation" "keysLife" }}h"
+   {{- end }}
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/charts/gluu-all-in-one/values.yaml
+++ b/charts/gluu-all-in-one/values.yaml
@@ -315,6 +315,8 @@ auth-server-key-rotation:
     tag: 0.0.0-nightly
     # -- Image Pull Secrets
     pullSecrets: [ ]
+  # -- Auth server key rotation job schedule. It accepts any Cron syntax supported by Kubernetes. If empty, the schedule will run based on keysLife value.
+  cronJobSchedule: ""
   # -- Auth server key rotation keys life in hours
   keysLife: 48
   # -- Set key selection strategy used by Auth server

--- a/charts/gluu/charts/auth-server-key-rotation/templates/cronjobs.yaml
+++ b/charts/gluu/charts/auth-server-key-rotation/templates/cronjobs.yaml
@@ -20,7 +20,11 @@ metadata:
 {{- end }}
 {{- end }}
 spec:
+  {{- if ne .Values.cronJobSchedule  "" }}
+  schedule: {{  index .Values.cronJobSchedule | quote }}
+   {{- else }}
   schedule: "@every {{ .Values.keysLife }}h"
+   {{- end }}
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/charts/gluu/values.yaml
+++ b/charts/gluu/values.yaml
@@ -280,6 +280,8 @@ auth-server-key-rotation:
     tag: 0.0.0-nightly
     # -- Image Pull Secrets
     pullSecrets: [ ]
+  # -- Auth server key rotation job schedule. It accepts any Cron syntax supported by Kubernetes. If empty, the schedule will run based on keysLife value.
+  cronJobSchedule: ""
   # -- Auth server key rotation keys life in hours
   keysLife: 48
   # -- Set key selection strategy used by Auth server


### PR DESCRIPTION
closes #2111 


allows to override the cron job schedule for the auth key rotation job via values.yaml