### PR TITLE
feat(cloud-native): add server-hostname environment variable in admin-ui

### DIFF
--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -45,7 +45,7 @@ RUN cd /tmp/jans \
     && cp ${JANS_SETUP_DIR}/schema/custom_schema.json /app/schema/ \
     && cp ${JANS_SETUP_DIR}/schema/opendj_types.json /app/schema/
 
-ENV FLEX_SOURCE_VERSION=ec9488d2ff477850943ad41984a4fe5016461e7c
+ENV FLEX_SOURCE_VERSION=b8cd454fc6356ae05952516a1ecf419b79515b47
 
 RUN mkdir -p /app/templates/admin-ui
 

--- a/docker-admin-ui/scripts/bootstrap.py
+++ b/docker-admin-ui/scripts/bootstrap.py
@@ -265,6 +265,7 @@ def resolve_conf_app(old_conf, new_conf):
 def render_env_config(manager):
     hostname = manager.config.get("hostname")
     ctx = {
+        "hostname": hostname,
         "config_api_base_url": os.environ.get("CN_CONFIG_API_BASE_URL", f"https://{hostname}"),
     }
 

--- a/docker-admin-ui/templates/admin-ui/env-config.js
+++ b/docker-admin-ui/templates/admin-ui/env-config.js
@@ -1,5 +1,9 @@
+const AUTH_SERVER_HOSTNAME = "%(hostname)s"
 const CONFIG_API_BASE_URL = "%(config_api_base_url)s/jans-config-api"
 const API_BASE_URL = "%(config_api_base_url)s/jans-config-api/admin-ui"
+const BASE_PATH = "/admin/"
 
+window.authServerHostname =  AUTH_SERVER_HOSTNAME
 window.configApiBaseUrl = CONFIG_API_BASE_URL
 window.apiBaseUrl = API_BASE_URL
+window.basePath = BASE_PATH


### PR DESCRIPTION
The changeset adds support for `AUTH_SERVER_HOSTNAME` env variable into admin-ui image.