### PR TITLE
chore(cloud-native): install apache2 package as part of monolith image build

### DIFF
--- a/docker-flex-monolith/.gitignore
+++ b/docker-flex-monolith/.gitignore
@@ -1,3 +1,4 @@
 *-custom
 flex-deployed
 db-data
+*-log

--- a/docker-flex-monolith/Dockerfile
+++ b/docker-flex-monolith/Dockerfile
@@ -41,7 +41,7 @@ EXPOSE 443 8080 1636
 # flex-linux-setup
 # =====================
 
-ENV FLEX_SOURCE_VERSION=361fbe3889548245752756d3f484b7a20d215ba5
+ENV FLEX_SOURCE_VERSION=581ab7475d28436de002eadcbffbec6e139deb37
 
 # cleanup
 RUN rm -rf /tmp/jans

--- a/docker-flex-monolith/Dockerfile
+++ b/docker-flex-monolith/Dockerfile
@@ -17,7 +17,7 @@ RUN echo 'APT::Install-Suggests "0";' >> /etc/apt/apt.conf.d/00-docker \
 # @TODO: remove python-ldap3 after ldap support removed
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update \
-    && apt-get install -y python3 tini curl ca-certificates dbus systemd iproute2 gpg python3-pip python3-dev libpq-dev gcc python3-psycopg2 libaugeas-dev \
+    && apt-get install -y python3 tini curl ca-certificates dbus systemd iproute2 gpg python3-pip python3-dev libpq-dev gcc python3-psycopg2 libaugeas-dev apache2 \
     # install certbot
     && pip install ruamel.yaml certbot certbot-apache \
     # Cleaning up package lists \
@@ -41,7 +41,7 @@ EXPOSE 443 8080 1636
 # flex-linux-setup
 # =====================
 
-ENV FLEX_SOURCE_VERSION=ec9488d2ff477850943ad41984a4fe5016461e7c
+ENV FLEX_SOURCE_VERSION=361fbe3889548245752756d3f484b7a20d215ba5
 
 # cleanup
 RUN rm -rf /tmp/jans


### PR DESCRIPTION
The changeset adds `apache2` package pre-installed during image build.

Closes #2171 