### PR TITLE
feat(admin-ui): update label in Auth Server Properties to match OP metadata context.

### DIFF
--- a/admin-ui/app/locales/en/translation.json
+++ b/admin-ui/app/locales/en/translation.json
@@ -1145,7 +1145,7 @@
       "dpopTimeframe": "Demonstration of Proof-of-Possession (DPoP) timeout",
       "dpopJtiCacheTime": "Demonstration of Proof-of-Possession (DPoP) cache time",
       "allowIdTokenWithoutImplicitGrantType": "Specifies if a token without implicit grant types is allowed",
-      "discoveryDenyKeys": "List of configuration response claims which must not be displayed in discovery endpoint response",
+      "OpenID Configuration Response OP Metadata Suppression List": "List of configuration response claims which must not be displayed in discovery endpoint response",
       "blockWebviewAuthorizationEnabled": "Enable/Disable block authorizations that originate from Webview (Mobile apps).",
       "fapiCompatibility": "Boolean value specifying whether to turn on FAPI compatibility mode. If true AS behaves in a more strict mode.",
       "defaultAcr": "This field controls the default authentication mechanism that is presented to users from all applications that leverage Janssen Server for authentication.",

--- a/admin-ui/app/locales/fr/translation.json
+++ b/admin-ui/app/locales/fr/translation.json
@@ -1100,7 +1100,7 @@
       "dpopTimeframe": "Démonstration du délai d'expiration Proof-of-Possession (DPoP)",
       "dpopJtiCacheTime": "Démonstration du délai de cache Proof-of-Possession (DPoP)",
       "allowIdTokenWithoutImplicitGrantType": "Indique si un jeton sans types de subvention implicite est autorisé",
-      "discoveryDenyKeys": "Liste des revendications de réponse de configuration qui ne doivent pas être affichées dans la réponse de l'endpoint de découverte",
+      "OpenID Configuration Response OP Metadata Suppression List": "Liste des revendications de réponse de configuration qui ne doivent pas être affichées dans la réponse de l'endpoint de découverte",
       "blockWebviewAuthorizationEnabled": "Activer/Désactiver le blocage des autorisations provenant de Webview (applications mobiles).",
       "defaultAcr": "Ce champ contrôle le mécanisme d'authentification par défaut présenté aux utilisateurs de toutes les applications qui exploitent Janssen Server pour l'authentification.",
       "accessTokenLifetime": "Indique l'expiration du jeton d'accès spécifique au client.",

--- a/admin-ui/app/locales/pt/translation.json
+++ b/admin-ui/app/locales/pt/translation.json
@@ -1273,7 +1273,7 @@
       "dpopTimeframe": "Demonstração do intervalo de tempo Proof-of-Possession (DPoP)",
       "dpopJtiCacheTime": "Demonstração do tempo de cache Proof-of-Possession (DPoP)",
       "allowIdTokenWithoutImplicitGrantType": "Especifica se um token sem tipos de concessão implícitos é permitido",
-      "discoveryDenyKeys": "Lista das reivindicações de resposta de configuração que não devem ser exibidas na resposta do endpoint de descoberta",
+      "OpenID Configuration Response OP Metadata Suppression List": "Lista das reivindicações de resposta de configuração que não devem ser exibidas na resposta do endpoint de descoberta",
       "blockWebviewAuthorizationEnabled": "Ativar/Desativar a autorização de bloqueio que se originam do Webview (aplicativos móveis).",
       "defaultAcr": "Este campo controla o mecanismo de autenticação padrão apresentado aos usuários de todos os aplicativos que utilizam o Janssen Server para autenticação.",
       "accessTokenLifetime": "Especifica a expiração do token de acesso específico do cliente.",

--- a/admin-ui/plugins/auth-server/components/Configuration/ConfigPage.js
+++ b/admin-ui/plugins/auth-server/components/Configuration/ConfigPage.js
@@ -77,6 +77,20 @@ function ConfigPage() {
   }, [])
   useEffect(() => {}, [cedarPermissions])
 
+  const renamedFieldFromObject = (obj) => {
+    const { discoveryDenyKeys, ...rest } = obj
+
+    return {
+      ...rest,
+      'OpenID Configuration Response OP Metadata Suppression List': discoveryDenyKeys ?? [],
+    }
+  }
+  function isRenamedKey(propKey) {
+    const renamedKeys = ['OpenID Configuration Response OP Metadata Suppression List']
+
+    return renamedKeys.includes(propKey)
+  }
+
   const patchHandler = (patch) => {
     setPatches((existingPatches) => [...existingPatches, patch])
     const newPatches = patches
@@ -142,20 +156,23 @@ function ConfigPage() {
           </div>
         </CardHeader>
         <CardBody style={{ minHeight: 500 }}>
-          {Object.keys(configuration).map((propKey) => {
-            if (generateLabel(propKey).includes(finalSearch)) {
-              return (
-                <PropertyBuilder
-                  key={propKey}
-                  propKey={propKey}
-                  propValue={configuration[propKey]}
-                  lSize={lSize}
-                  handler={patchHandler}
-                  schema={schema[propKey]}
-                />
-              )
-            }
-          })}
+          {Object.keys(configuration).length > 0 &&
+            Object.entries(renamedFieldFromObject(configuration)).map(([propKey, propValue]) => {
+              if (generateLabel(propKey).includes(finalSearch)) {
+                return (
+                  <PropertyBuilder
+                    isRenamedKey={isRenamedKey(propKey)}
+                    key={propKey}
+                    propKey={propKey}
+                    propValue={propValue}
+                    lSize={lSize}
+                    handler={patchHandler}
+                    schema={schema[propKey]}
+                  />
+                )
+              }
+            })}
+
           {Object.keys(configuration).length > 0 &&
             missing_properties_data.map((propKey) => {
               if (generateLabel(propKey).includes(finalSearch)) {

--- a/admin-ui/plugins/auth-server/components/Configuration/JsonPropertyBuilder.js
+++ b/admin-ui/plugins/auth-server/components/Configuration/JsonPropertyBuilder.js
@@ -20,7 +20,23 @@ export function isObject(item) {
     return false
   }
 }
-function JsonPropertyBuilder({ propKey, propValue, lSize, path, handler, parentIsArray, schema }) {
+const migratingTextIfRenamed = (isRenamedKey, text) => {
+  if (isRenamedKey) {
+    return text
+  } else {
+    return generateLabel(text)
+  }
+}
+function JsonPropertyBuilder({
+  propKey,
+  propValue,
+  lSize,
+  path,
+  handler,
+  parentIsArray,
+  schema,
+  isRenamedKey,
+}) {
   const { t } = useTranslation()
   const [show, setShow] = useState(true)
   if (!path) {
@@ -69,7 +85,7 @@ function JsonPropertyBuilder({ propKey, propValue, lSize, path, handler, parentI
         name={propKey}
         lsize={lSize}
         rsize={lSize}
-        label={generateLabel(propKey)}
+        label={migratingTextIfRenamed(isRenamedKey, propKey)}
         isBoolean={true}
         handler={handler}
         value={propValue}
@@ -85,7 +101,7 @@ function JsonPropertyBuilder({ propKey, propValue, lSize, path, handler, parentI
         name={propKey}
         lsize={lSize}
         rsize={lSize}
-        label={generateLabel(propKey)}
+        label={migratingTextIfRenamed(isRenamedKey, propKey)}
         handler={handler}
         value={propValue}
         parentIsArray={parentIsArray}
@@ -101,7 +117,7 @@ function JsonPropertyBuilder({ propKey, propValue, lSize, path, handler, parentI
         lsize={lSize}
         type="number"
         rsize={lSize}
-        label={generateLabel(propKey)}
+        label={migratingTextIfRenamed(isRenamedKey, propKey)}
         handler={handler}
         value={propValue}
         parentIsArray={parentIsArray}
@@ -114,7 +130,7 @@ function JsonPropertyBuilder({ propKey, propValue, lSize, path, handler, parentI
       <GluuInlineInput
         id={propKey}
         name={propKey}
-        label={generateLabel(propKey)}
+        label={migratingTextIfRenamed(isRenamedKey, propKey)}
         value={propValue || []}
         lsize={lSize}
         rsize={lSize}


### PR DESCRIPTION
## feat(admin-ui): update label in Auth Server Properties to match OP metadata context (#2193)

### ✨ Summary

This PR updates the label in the Auth Server Properties screen to reflect a more accurate and standards-aligned description.

---

### ✅ Changes

- Renamed label from **Discovery Deny Keys** to **OpenID Configuration Response OP Metadata Suppression List**.
- Improves clarity for users working with OpenID Connect server metadata suppression settings.

---

### 🧱 Notes

- No backend changes required — only a UI label update.
- Helps administrators better understand the purpose of this configuration field.

---

### 🔗 Ticket

**Closes:** #2193  
**Title:** Change label in the Auth Server Properties
