### PR TITLE
fix(admin-ui): lock cedarling_wasm to v1.7.0 and improve Cedar init fallback handling

### DIFF
--- a/admin-ui/app/cedarling/types/index.ts
+++ b/admin-ui/app/cedarling/types/index.ts
@@ -75,6 +75,7 @@ export interface CedarPermissionsState {
   error: string | null
   initialized: null | boolean
   isInitializing: boolean
+  cedarFailedStatusAfterMaxTries: null | boolean
 }
 
 export interface SetCedarlingPermissionPayload {

--- a/admin-ui/app/layout/components/DefaultSidebar.tsx
+++ b/admin-ui/app/layout/components/DefaultSidebar.tsx
@@ -19,7 +19,9 @@ const GluuAppSidebar = lazy(() => import('Routes/Apps/Gluu/GluuAppSidebar'))
 const DefaultSidebar: React.FC<DefaultSidebarProps> = () => {
   const { t } = useTranslation()
 
-  const cedarlingInitialized = useSelector((state: RootState) => state.cedarPermissions.initialized)
+  const { initialized, cedarFailedStatusAfterMaxTries } = useSelector(
+    (state: RootState) => state.cedarPermissions,
+  )
 
   const cedarConditionalLoader = () => (
     <div
@@ -32,7 +34,11 @@ const DefaultSidebar: React.FC<DefaultSidebarProps> = () => {
         padding: '20px',
       }}
     >
-      {cedarlingInitialized ? <p>{t('titles.no_Cedar')}</p> : <GluuSuspenseLoader />}
+      {cedarFailedStatusAfterMaxTries && !initialized ? (
+        <p>{t('titles.no_Cedar')}</p>
+      ) : (
+        <GluuSuspenseLoader />
+      )}
     </div>
   )
 
@@ -60,7 +66,7 @@ const DefaultSidebar: React.FC<DefaultSidebarProps> = () => {
       <SidebarMobileFluid>
         {/* <SidebarTopA /> */}
         <SidebarSection fluid cover>
-          {cedarlingInitialized ? (
+          {initialized ? (
             <Suspense fallback={<GluuSuspenseLoader />}>
               <GluuAppSidebar />
             </Suspense>

--- a/admin-ui/app/locales/en/translation.json
+++ b/admin-ui/app/locales/en/translation.json
@@ -952,6 +952,7 @@
     "authentication_date": "Authentication Date",
     "creation_date": "Creation Date",
     "no_Cedar": "You do not have any authorized component to view",
+    "cedar_Init": "Cedarling is trying to initialize, please wait",
     "newPermission": "New Permission",
     "addingNewApiPermission": "Adding new API Permission",
     "followingPermissionRequiredToBeAdded": "Following permission required to be added!"

--- a/admin-ui/app/locales/fr/translation.json
+++ b/admin-ui/app/locales/fr/translation.json
@@ -842,6 +842,7 @@
     "add_agama_project": "Ajouter un projet Agama",
     "export_csv": "Exporter CSV",
     "no_Cedar": "Vous n'avez aucun composant autorisé à afficher",
+    "cedar_Init": "Cedarling est en cours d'initialisation, veuillez patienter",
     "newPermission": "Nouvelle Permission",
     "addingNewApiPermission": "Ajout d'une nouvelle autorisation API",
     "followingPermissionRequiredToBeAdded": "Une autorisation est requise pour être ajouté!"

--- a/admin-ui/app/locales/pt/translation.json
+++ b/admin-ui/app/locales/pt/translation.json
@@ -839,6 +839,7 @@
     "jans_kc_link": "Link KC Jans",
     "export_csv": "Exportar CSV",
     "no_Cedar": "Você não tem nenhum componente autorizado para visualizar",
+    "cedar_Init": "Cedarling está tentando inicializar, por favor aguarde",
     "newPermission": "Nova Permissão",
     "addingNewApiPermission": "Adicionando nova permissão de API",
     "followingPermissionRequiredToBeAdded": "É necessária a permissão seguinte para ser adicionado!"

--- a/admin-ui/app/redux/features/cedarPermissionsSlice.ts
+++ b/admin-ui/app/redux/features/cedarPermissionsSlice.ts
@@ -8,6 +8,7 @@ const initialState: CedarPermissionsState = {
   error: null,
   initialized: null,
   isInitializing: false,
+  cedarFailedStatusAfterMaxTries: null,
 }
 
 const cedarPermissionsSlice = createSlice({
@@ -27,10 +28,17 @@ const cedarPermissionsSlice = createSlice({
     setCedarlingInitializing: (state, action: PayloadAction<boolean>) => {
       state.isInitializing = action.payload
     },
+    setCedarFailedStatusAfterMaxTries: (state) => {
+      state.cedarFailedStatusAfterMaxTries = true
+    },
   },
 })
 
 reducerRegistry.register('cedarPermissions', cedarPermissionsSlice.reducer)
-export const { setCedarlingPermission, setCedarlingInitialized, setCedarlingInitializing } =
-  cedarPermissionsSlice.actions
+export const {
+  setCedarlingPermission,
+  setCedarlingInitialized,
+  setCedarlingInitializing,
+  setCedarFailedStatusAfterMaxTries,
+} = cedarPermissionsSlice.actions
 export default cedarPermissionsSlice.reducer


### PR DESCRIPTION
## fix(admin-ui): lock cedarling_wasm to v1.7.0 and improve Cedar init fallback handling (#2204)

### 🐞 Summary

This PR resolves a critical issue where the Admin UI fails to initialize the Cedarling engine due to incompatible changes in version `1.9.0` of the `@janssenproject/cedarling_wasm` package.

---

### ✅ Changes

- Locked `@janssenproject/cedarling_wasm` to **version `1.7.0`** to avoid breaking behavior introduced in `1.9.0`.
- Added retry mechanism that attempts to initialize Cedarling up to **10 times**.
- Gracefully handles failure with a safe fallback if initialization continues to fail.

---

### 🧱 Notes

- Prevents hard crashes in restricted or unstable environments (e.g., Solo).
- Ensures smoother startup experience and consistent UI behavior regardless of Cedarling state.
- Long-term solution will require coordination with upstream package maintainers.

---

### 🔗 Ticket

**Closes:** #2204  
**Title:** Lock cedarling_wasm to v1.7.0 and improve Cedar init fallback handling
