### PR TITLE
chore(admin-ui): update "Reset" label to "Reset License" in License section

### DIFF
--- a/admin-ui/app/locales/en/translation.json
+++ b/admin-ui/app/locales/en/translation.json
@@ -95,6 +95,7 @@
   },
   "fields": {
     "access_token_signing_alg": "JWS alg for signing",
+    "resetLicense": "Reset License",
     "asset_name": "Asset Name",
     "upload": "Select a file to upload",
     "jansService": "Related Services",

--- a/admin-ui/app/locales/fr/translation.json
+++ b/admin-ui/app/locales/fr/translation.json
@@ -165,6 +165,7 @@
   },
   "fields": {
     "asset_name": "Asset Name",
+    "resetLicense": "Réinitialiser la licence",
     "tag": "Étiqueter",
     "issuer": "Émetteur",
     "upload": "Select a file to upload",

--- a/admin-ui/app/locales/pt/translation.json
+++ b/admin-ui/app/locales/pt/translation.json
@@ -162,6 +162,7 @@
   },
   "fields": {
     "asset_name": "Asset Name",
+    "resetLicense": "Redefinir licença",
     "tag": "Marcação",
     "upload": "Select a file to upload",
     "jansService": "Related Services",

--- a/admin-ui/app/routes/License/LicenseDetailsPage.tsx
+++ b/admin-ui/app/routes/License/LicenseDetailsPage.tsx
@@ -154,7 +154,7 @@ function LicenseDetailsPage() {
                           onClick={toggle}
                         >
                           <i className="fa fa-undo-alt me-2"></i>
-                          {t('actions.reset')}
+                          {t('fields.resetLicense')}
                         </Button>
                       </div>
                     </Col>


### PR DESCRIPTION
## chore(admin-ui): update "Reset" label to "Reset License" in License section (#2222)

### ✨ Summary

This PR updates the label of the **"Reset"** button in the **License** section to **"Reset License"** for better clarity and usability.

---

### ✅ Changes

- Updated the button text in the License section (`Home → License`) from "Reset" → "Reset License".

---

### 🔗 Ticket

Closes: #2222
