### PR TITLE
fix(admin-ui): resolve issue preventing deletion of capabilities

### DIFF
--- a/admin-ui/app/utils/PermissionMappingUtils.ts
+++ b/admin-ui/app/utils/PermissionMappingUtils.ts
@@ -1,0 +1,75 @@
+// Utilities for resolving permission keys, computing mapped roles, and building user-friendly messages
+
+export type ApiPermissionItem = {
+  inum?: string
+  permission?: string
+  [key: string]: unknown
+}
+
+export type RolePermissionMappingEntry = {
+  role: string
+  permissions: string[]
+}
+
+type ActionData =
+  | { inum?: string; permission?: string; [key: string]: unknown }
+  | string
+  | null
+  | undefined
+
+/**
+ * Resolve the permission key (string) from actionData and the list of apiPermissions.
+ * actionData may be an object with { inum, permission } or just an inum string.
+ */
+export function resolvePermissionKey(
+  actionData: ActionData,
+  apiPermissions: ApiPermissionItem[] | undefined,
+): string | undefined {
+  const isObject = (value: ActionData): value is { inum?: string; permission?: string } => {
+    return typeof value === 'object' && value !== null
+  }
+
+  const permissionFromAction = isObject(actionData) ? actionData.permission : undefined
+  if (permissionFromAction) return permissionFromAction
+
+  const permissionInum = isObject(actionData) ? actionData.inum : actionData
+  if (!permissionInum) return undefined
+
+  const found = Array.isArray(apiPermissions)
+    ? apiPermissions.find((p) => p?.inum === permissionInum)
+    : undefined
+  return found?.permission
+}
+
+/**
+ * Find roles that contain the given permission key using the role-permission mapping from the store.
+ */
+export function findRolesForPermission(
+  permissionKey: string | undefined,
+  rolePermissionMapping: RolePermissionMappingEntry[] | undefined,
+): string[] {
+  if (!permissionKey || !Array.isArray(rolePermissionMapping)) return []
+  return rolePermissionMapping
+    .filter((r) => Array.isArray(r?.permissions) && r.permissions.includes(permissionKey))
+    .map((r) => r.role)
+}
+
+export function buildMappingGuidanceMessage(
+  permissionKey: string | undefined,
+  mappedRoles: string[] | undefined,
+): string {
+  const rolesList = mappedRoles ? mappedRoles.join(', ') : ''
+  const rolesWord = mappedRoles ? (mappedRoles.length > 1 ? 'roles' : 'role') : ''
+  return ` This permission is mapped to ${rolesWord}: ${rolesList}. Please remove it from mapping menu.`
+}
+
+export function buildPermissionDeleteErrorMessage(
+  error: unknown,
+  actionData: ActionData,
+  apiPermissions: ApiPermissionItem[] | undefined,
+  rolePermissionMapping: RolePermissionMappingEntry[] | undefined,
+): string {
+  const permissionKey = resolvePermissionKey(actionData, apiPermissions)
+  const mappedRoles = findRolesForPermission(permissionKey, rolePermissionMapping)
+  return buildMappingGuidanceMessage(permissionKey, mappedRoles)
+}

--- a/admin-ui/plugins/admin/redux/api/PermissionApi.js
+++ b/admin-ui/plugins/admin/redux/api/PermissionApi.js
@@ -33,8 +33,10 @@ export default class PermissionApi {
   }
 
   deletePermission = (data) => {
+    const options = {}
+    options['adminPermission'] = data
     return new Promise((resolve, reject) => {
-      this.api.deleteAdminuiPermission(encodeURIComponent(data.permission), (error, data) => {
+      this.api.deleteAdminuiPermission(options, (error, data) => {
         handleResponse(error, reject, resolve, data)
       })
     })

--- a/admin-ui/plugins/admin/redux/sagas/ApiPermissionSaga.js
+++ b/admin-ui/plugins/admin/redux/sagas/ApiPermissionSaga.js
@@ -16,6 +16,7 @@ import { updateToast } from 'Redux/features/toastSlice'
 
 const JansConfigApi = require('jans_config_api')
 import { initAudit } from 'Redux/sagas/SagaUtils'
+import { buildPermissionDeleteErrorMessage } from 'Utils/PermissionMappingUtils'
 
 function* newFunction() {
   const token = yield select((state) => state.authReducer.token.access_token)
@@ -121,7 +122,17 @@ export function* deletePermission({ payload }) {
     })
     return data
   } catch (e) {
-    yield put(updateToast(true, 'error'))
+    const actionData = payload?.action?.action_data
+    const apiPermissions = yield select((state) => state.apiPermissionReducer.items || [])
+    const rolePermissionMapping = yield select((state) => state.mappingReducer.items || [])
+    const finalMessage = buildPermissionDeleteErrorMessage(
+      e,
+      actionData,
+      apiPermissions,
+      rolePermissionMapping,
+    )
+
+    yield put(updateToast(true, 'error', finalMessage))
     yield put(deletePermissionResponse({ inum: null }))
     if (isFourZeroOneError(e)) {
       const jwt = yield select((state) => state.authReducer.userinfo_jwt)

--- a/admin-ui/plugins/auth-server/redux/sagas/LoggingSaga.js
+++ b/admin-ui/plugins/auth-server/redux/sagas/LoggingSaga.js
@@ -43,7 +43,6 @@ export function* editLogging({ payload }) {
     delete audit.payload
 
     console.log(audit)
-    debugger
 
     const api = yield* newFunction()
     const data = yield call(api.editLoggingConfig, payload.data)


### PR DESCRIPTION
# fix(admin-ui): resolve issue preventing deletion of capabilities

## 📝 Description  
Fixes a bug in the Admin UI where deleting capabilities resulted in an error. This occurred when attempting to remove both newly created and existing capabilities. The deletion process now works as expected.  

## 🔄 Changes Made  
- Fixed capability deletion logic in Admin UI.  
- Ensured compatibility with backend endpoint requirements. 
- Add logic for checking permission mapped in the roles for proper error handling.
- Improved error handling for invalid capability identifiers. 

## ✅ Expected Behavior  
- Users should now be able to successfully delete both new and existing capabilities without errors.  

## 🔗 Ticket  
Closes: #2270
