### PR TITLE
fix(admin-ui): apply theme color to 'No' button in Audit Log confirma…

### DIFF
--- a/admin-ui/app/routes/Apps/Gluu/GluuCommitDialog.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/GluuCommitDialog.tsx
@@ -217,7 +217,7 @@ const GluuCommitDialog = ({
                 {t('actions.accept')}
               </Button>
             )}
-            <Button onClick={closeModal}>
+            <Button color={`primary-${selectedTheme}`} onClick={closeModal}>
               <i className="fa fa-remove me-2"></i>
               {t('actions.no')}
             </Button>


### PR DESCRIPTION
# fix(admin-ui): apply theme color to 'No' button in Audit Log confirmation modal for consistent styling

## 📝 Description  
In the Audit Log confirmation modal, the **"No"** button was not following the theme color styling, creating a visual inconsistency with the **"Accept"** button and other UI elements. This update ensures that the "No" button adheres to the configured theme color for a unified appearance.  

## ✅ Expected Behavior  
The "No" button now follows the same theme color scheme as the rest of the Admin UI, maintaining visual consistency and improving overall UI cohesion.  

## 🔗 Ticket  
Closes: #2263
