### PR TITLE
fix(admin-ui): add and enhance Cancel button functionality in SMTP Co…

### DIFF
--- a/admin-ui/app/routes/Apps/Gluu/GluuProperties.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/GluuProperties.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from 'react'
+import { useState, useContext, useEffect } from 'react'
 import { FormGroup, Col, Button, Accordion, AccordionHeader, AccordionBody } from 'Components'
 import GluuPropertyItem from './GluuPropertyItem'
 import { useTranslation } from 'react-i18next'
@@ -34,6 +34,12 @@ function GluuProperties({
   const { t, i18n } = useTranslation()
   const theme: any = useContext(ThemeContext)
   const selectedTheme = theme.state.theme
+
+  // Sync internal state with options prop when it changes
+  // This ensures the component properly resets when formik values are reset
+  useEffect(() => {
+    setProperties(options)
+  }, [options])
 
   const addProperty = () => {
     let item

--- a/admin-ui/app/routes/Apps/Gluu/GluuTypeAhead.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/GluuTypeAhead.tsx
@@ -79,7 +79,7 @@ function GluuTypeAhead({
           id={name}
           data-testid={name}
           multiple={multiple}
-          defaultSelected={value}
+          selected={value || []}
           options={options}
         />
         {!hideHelperMessage && (

--- a/admin-ui/plugins/fido/components/DynamicConfiguration.tsx
+++ b/admin-ui/plugins/fido/components/DynamicConfiguration.tsx
@@ -37,6 +37,14 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
     handleSubmit(formik.values)
   }, [handleSubmit, toggle, formik.values])
 
+  const handleCancel = useCallback(() => {
+    const initialValues = transformToFormValues(
+      fidoConfiguration,
+      fidoConstants.DYNAMIC,
+    ) as DynamicConfigFormValues
+    formik.resetForm({ values: initialValues })
+  }, [formik, fidoConfiguration])
+
   const handleFormSubmit = useCallback(
     (e: React.FormEvent<HTMLFormElement>) => {
       e.preventDefault()
@@ -315,7 +323,9 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
         <Col>
           <GluuCommitFooter
             saveHandler={toggle}
-            hideButtons={{ save: true, back: false }}
+            hideButtons={{ save: true, back: true }}
+            extraLabel="Cancel"
+            extraOnClick={handleCancel}
             type="submit"
             disabled={isSubmitting}
           />

--- a/admin-ui/plugins/fido/components/StaticConfiguration.tsx
+++ b/admin-ui/plugins/fido/components/StaticConfiguration.tsx
@@ -52,6 +52,14 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
     handleSubmit(formik.values)
   }, [handleSubmit, toggle, formik.values])
 
+  const handleCancel = useCallback(() => {
+    const initialValues = transformToFormValues(
+      staticConfiguration,
+      fidoConstants.STATIC,
+    ) as StaticConfigFormValues
+    formik.resetForm({ values: initialValues })
+  }, [formik, staticConfiguration])
+
   const requestedPartiesOptions = useMemo(() => {
     return (formik.values.requestedParties || []).map((item) => ({
       key: item.key || '',
@@ -343,7 +351,9 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
         <Col>
           <GluuCommitFooter
             saveHandler={toggle}
-            hideButtons={{ save: true, back: false }}
+            hideButtons={{ save: true, back: true }}
+            extraLabel="Cancel"
+            extraOnClick={handleCancel}
             type="submit"
             disabled={isSubmitting}
           />

--- a/admin-ui/plugins/services/Components/Configuration/CachePage.js
+++ b/admin-ui/plugins/services/Components/Configuration/CachePage.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import BlockUi from '../../../../app/components/BlockUi/BlockUi'
 import { Formik } from 'formik'
 import { Form, FormGroup, Card, Col, CardBody, InputGroup, CustomInput } from 'Components'
-import GluuFooter from 'Routes/Apps/Gluu/GluuFooter'
+import GluuCommitFooter from 'Routes/Apps/Gluu/GluuCommitFooter'
 import GluuLabel from 'Routes/Apps/Gluu/GluuLabel'
 import GluuTooltip from 'Routes/Apps/Gluu/GluuTooltip'
 import CacheInMemory from './CacheInMemory'
@@ -90,6 +90,12 @@ function CachePage() {
   function submitForm() {
     toggle()
     document.getElementsByClassName('LdapUserActionSubmitButton')[0].click()
+  }
+  function handleCancel(formik) {
+    return () => {
+      formik.resetForm()
+      setCacheProviderType(cacheData.cacheProviderType)
+    }
   }
 
   return (
@@ -187,7 +193,7 @@ function CachePage() {
                               type="select"
                               id="cacheProviderType"
                               name="cacheProviderType"
-                              defaultValue={cacheData.cacheProviderType}
+                              value={cacheProviderType}
                               onChange={(e) => {
                                 setCacheProviderType(e.target.value)
                                 formik.setFieldValue('cacheProviderType', e.target.value)
@@ -218,7 +224,13 @@ function CachePage() {
                     <CacheNative config={cacheNativeData} formik={formik} />
                   )}
                   <FormGroup row></FormGroup>
-                  <GluuFooter saveHandler={toggle} />
+                  <GluuCommitFooter
+                    saveHandler={toggle}
+                    hideButtons={{ save: true, back: true }}
+                    extraLabel="Cancel"
+                    extraOnClick={handleCancel(formik)}
+                    type="submit"
+                  />
                   <GluuCommitDialog
                     handler={toggle}
                     modal={modal}


### PR DESCRIPTION
# fix(admin-ui): add and enhance Cancel button functionality in SMTP Configuration screen

## 📝 Description  
The SMTP Configuration screen did not include a Cancel button, and users were unable to revert unsaved changes. This update introduces a functional Cancel button and aligns its behavior with other configuration pages in the Admin UI.

## ✅ Expected Behavior  
- A **Cancel** button is now available on the SMTP Configuration screen.  
- Clicking **Cancel** resets unsaved configuration values to their previous state instead of navigating away.  


## 🔗 Ticket  
Closes: #2271
