### PR TITLE
fix(admin-ui): correct Cancel button behavior in Cache page under Ser…

### DIFF
--- a/admin-ui/app/utils/Util.ts
+++ b/admin-ui/app/utils/Util.ts
@@ -1,7 +1,6 @@
 import customColors from '@/customColors'
 
-// @ts-nocheck
-export function uuidv4() {
+export function uuidv4(): string {
   // Use Web Crypto API if available
   if (typeof crypto !== 'undefined' && crypto.randomUUID) {
     return crypto.randomUUID()
@@ -16,7 +15,7 @@ export function uuidv4() {
 }
 
 // Predefined color palette for consistent colors
-const colorPalette = [
+const colorPalette: string[] = [
   customColors.logo,
   customColors.white,
   customColors.black,
@@ -27,22 +26,22 @@ const colorPalette = [
   customColors.lightBlue,
 ]
 
-export function getNewColor(index = 0) {
+export function getNewColor(index = 0): string {
   // Use modulo to cycle through the palette
   return colorPalette[index % colorPalette.length]
 }
 
-export const getClientScopeByInum = (str) => {
+export const getClientScopeByInum = (str: string): string => {
   const inum = str.split(',')[0]
   const value = inum.split('=')[1]
   return value
 }
 
-export function getYearMonth(date) {
+export function getYearMonth(date: Date): string {
   return date.getFullYear() + getMonth(date)
 }
 
-export function getMonth(aDate) {
+export function getMonth(aDate: Date): string {
   const value = String(aDate.getMonth() + 1)
   if (value.length > 1) {
     return value
@@ -51,7 +50,7 @@ export function getMonth(aDate) {
   }
 }
 
-export function formatDate(date) {
+export function formatDate(date?: string): string {
   if (!date) {
     return '-'
   }
@@ -62,4 +61,18 @@ export function formatDate(date) {
     return date
   }
   return '-'
+}
+
+export const trimObjectStrings = <T extends Record<string, unknown>>(obj: T): T => {
+  const trimmed: Record<string, unknown> = {}
+  for (const key in obj) {
+    if (typeof obj[key] === 'string') {
+      trimmed[key] = (obj[key] as string).trim()
+    } else if (obj[key] && typeof obj[key] === 'object' && !Array.isArray(obj[key])) {
+      trimmed[key] = trimObjectStrings(obj[key] as Record<string, unknown>)
+    } else {
+      trimmed[key] = obj[key]
+    }
+  }
+  return trimmed as T
 }

--- a/admin-ui/plugins/services/Components/Configuration/CachePage.js
+++ b/admin-ui/plugins/services/Components/Configuration/CachePage.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import BlockUi from '../../../../app/components/BlockUi/BlockUi'
 import { Formik } from 'formik'
 import { Form, FormGroup, Card, Col, CardBody, InputGroup, CustomInput } from 'Components'
-import GluuFooter from 'Routes/Apps/Gluu/GluuFooter'
+import GluuCommitFooter from 'Routes/Apps/Gluu/GluuCommitFooter'
 import GluuLabel from 'Routes/Apps/Gluu/GluuLabel'
 import GluuTooltip from 'Routes/Apps/Gluu/GluuTooltip'
 import CacheInMemory from './CacheInMemory'
@@ -90,6 +90,12 @@ function CachePage() {
   function submitForm() {
     toggle()
     document.getElementsByClassName('LdapUserActionSubmitButton')[0].click()
+  }
+  function handleCancel(formik) {
+    return () => {
+      formik.resetForm()
+      setCacheProviderType(cacheData.cacheProviderType)
+    }
   }
 
   return (
@@ -187,7 +193,7 @@ function CachePage() {
                               type="select"
                               id="cacheProviderType"
                               name="cacheProviderType"
-                              defaultValue={cacheData.cacheProviderType}
+                              value={cacheProviderType}
                               onChange={(e) => {
                                 setCacheProviderType(e.target.value)
                                 formik.setFieldValue('cacheProviderType', e.target.value)
@@ -218,7 +224,13 @@ function CachePage() {
                     <CacheNative config={cacheNativeData} formik={formik} />
                   )}
                   <FormGroup row></FormGroup>
-                  <GluuFooter saveHandler={toggle} />
+                  <GluuCommitFooter
+                    saveHandler={toggle}
+                    hideButtons={{ save: true, back: true }}
+                    extraLabel="Cancel"
+                    extraOnClick={handleCancel(formik)}
+                    type="submit"
+                  />
                   <GluuCommitDialog
                     handler={toggle}
                     modal={modal}


### PR DESCRIPTION
# fix(admin-ui): correct Cancel button behavior in Cache page under Services module to reset form values properly

## 📝 Description  
The Cancel button in the **Cache** page of the Services module was not resetting form fields to their previous values. This update ensures that clicking **Cancel** restores all fields to their last saved state, maintaining consistent behavior across configuration pages.  

## ✅ Expected Behavior  
- Clicking **Cancel** on the Cache page now resets all unsaved changes to their prior values.  
- The behavior is consistent with other configuration pages like **SCIM**, **SMTP**, **SAML**, and **Jans Lock**.  

## 🔗 Ticket  
Closes: #2370
