### PR TITLE
fix(admin-ui): material-table/core breaking Jenkins build due to recent upgrade

### DIFF
--- a/admin-ui/.gitignore
+++ b/admin-ui/.gitignore
@@ -4,6 +4,7 @@ dist
 # dependencies
 node_modules
 jans_config_api
+jans_config_api_orval
 package-lock.json
 yarn.lock
 plugins_repo

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -136,7 +136,7 @@
     "@emotion/styled": "^11.10.6",
     "@fortawesome/fontawesome-free": "^6.4.0",
     "@janssenproject/cedarling_wasm": "1.9.0",
-    "@material-table/core": "^6.4.4",
+    "@material-table/core": "6.4.4",
     "@mui/base": "^5.0.0-alpha.124",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.15.14",


### PR DESCRIPTION
## 🐛 fix(admin-ui): material-table/core breaking Jenkins build due to recent upgrade

### 🔧 Description
This PR fixes issue **#2392**, where the recent upgrade of `@material-table/core` caused Jenkins build failures.  
The problem was due to breaking changes or dependency mismatches introduced in the latest release of the library.

### 🧩 Fix Summary
- Reverted `@material-table/core` to the last stable version.
- Regenerated `package-lock.json` to ensure dependency consistency.
- Verified successful Admin UI build locally and on Jenkins.

### ✅ Testing Steps
1. Run a fresh installation using or `npm install`.
2. Trigger a Jenkins build.
3. Confirm that the build completes successfully without dependency errors.


### 🔗 Ticket
**Closes: #2392**
