### PR TITLE
feat(admin): adding uniformity in cancel and back buttons present in SMTP

### DIFF
--- a/admin-ui/app/routes/Apps/Gluu/GluuFormFooter.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/GluuFormFooter.tsx
@@ -49,7 +49,7 @@ const GluuFormFooter = ({
   showBack,
   backButtonLabel,
   onBack,
-  disableBack,
+  disableBack = false,
   showCancel,
   cancelButtonLabel,
   onCancel,

--- a/admin-ui/plugins/smtp-management/components/SmtpManagement/SmtpForm.tsx
+++ b/admin-ui/plugins/smtp-management/components/SmtpManagement/SmtpForm.tsx
@@ -5,7 +5,7 @@ import GluuSelectRow from 'Routes/Apps/Gluu/GluuSelectRow'
 import { SelectChangeEvent } from '@mui/material'
 import { useFormik } from 'formik'
 import GluuCommitDialog from 'Routes/Apps/Gluu/GluuCommitDialog'
-import GluuCommitFooter from 'Routes/Apps/Gluu/GluuCommitFooter'
+import GluuFormFooter from 'Routes/Apps/Gluu/GluuFormFooter'
 import { useTranslation } from 'react-i18next'
 import {
   enableTestButton,
@@ -55,6 +55,7 @@ function SmtpForm(props: Readonly<SmtpFormProps>) {
       toggle()
     },
     validationSchema,
+    validateOnMount: true,
   })
 
   useEffect(() => {
@@ -67,7 +68,17 @@ function SmtpForm(props: Readonly<SmtpFormProps>) {
     formik.resetForm()
   }
 
-  const submitForm = (userMessage: string) => {
+  const submitForm = async (userMessage: string) => {
+    const errors = await formik.validateForm()
+    if (Object.keys(errors).length > 0) {
+      // mark all fields as touched to reveal validation messages
+      const touched: Record<string, boolean> = {}
+      Object.keys(errors).forEach((k) => (touched[k] = true))
+      formik.setTouched(touched)
+      toast.error(t('messages.mandatory_fields_required'))
+      return
+    }
+
     toggle()
     const trimmedValues = trimObjectStrings(
       formik.values as unknown as Record<string, unknown>,
@@ -328,16 +339,28 @@ function SmtpForm(props: Readonly<SmtpFormProps>) {
           />
         </Col>
       </FormGroup>
+      {testButtonEnabled && (
+        <Row className="mb-2">
+          <Col>
+            <button type="button" className="btn btn-secondary" onClick={testSmtpConfig}>
+              {t('actions.test')}
+            </button>
+          </Col>
+        </Row>
+      )}
+
       <Row>
         <Col>
-          <GluuCommitFooter
-            saveHandler={toggle}
-            hideButtons={{ save: true, back: false }}
-            extraLabel={testButtonEnabled ? t('actions.test') : ''}
-            extraOnClick={testButtonEnabled ? testSmtpConfig : undefined}
-            disableBackButton={true}
-            cancelHandler={handleCancel}
-            type="submit"
+          <GluuFormFooter
+            showBack={true}
+            showCancel={true}
+            showApply={true}
+            onApply={toggle}
+            onCancel={handleCancel}
+            disableCancel={!formik.dirty}
+            disableApply={!formik.isValid || !formik.dirty}
+            applyButtonType="button"
+            isLoading={false}
           />
         </Col>
       </Row>


### PR DESCRIPTION
### feat(admin): adding uniformity in cancel and back buttons present in **SMTP**

#### Summary
This update introduces consistent behavior for **Cancel**, **Back**, and **Apply** buttons across Admin UI forms, including correct enabling and disabling based on form state.

#### Improvements
| Button | Updated Behavior |
|--------|------------------|
| **Cancel** | Resets all fields to their previous values without navigating away. Disabled until a change is made. |
| **Back** | Navigates to the previous page. If there is no navigation history, returns to Dashboard. Always enabled. |
| **Apply** | Saves the changes without leaving the page. Enabled only when the form has unsaved changes. |

#### Additional Enhancements
- Buttons now correctly detect dirty form states.
- Apply button is dynamically enabled and disabled based on whether changes exist.
- Cancel button is disabled until a field is modified.
- Prevents accidental navigation or state loss in multi step configuration pages.

#### Affected Modules
This change is applied across all forms where configuration changes are possible, including but not limited to:
- SMTP

Parent issue: **#2268**

### Testing Steps
1. Open suggested config form.
2. Modify any field.
3. Verify that:
   - Apply and Cancel buttons become enabled.
   - Apply saves configuration and stays on page.
   - Cancel reverts values and disables itself afterward.
4. Back button should navigate appropriately.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Enhanced form validation with improved error handling and field-level feedback on submit
  - Fixed form footer default behavior
  - Added real-time validation on form load

* **New Features**
  - Added test functionality for SMTP configuration verification
<!-- end of auto-generated comment: release notes by coderabbit.ai -->