### PR TITLE
feat: change admin-ui configuration field from useRemotePolicyStore to cedarlingPolicyStoreRetrievalPoint

### DIFF
--- a/flex-linux-setup/flex_linux_setup/templates/auiConfiguration.json
+++ b/flex-linux-setup/flex_linux_setup/templates/auiConfiguration.json
@@ -38,7 +38,7 @@
     "cedarlingLogType":"off",
     "auiPolicyStoreUrl": "",
     "auiDefaultPolicyStorePath": "./custom/config/adminUI/policy-store.json",
-    "useRemotePolicyStore": false
+    "cedarlingPolicyStoreRetrievalPoint": "default"
   },
   "licenseConfig": {
     "ssa": "%(ssa)s",


### PR DESCRIPTION
closes #2426 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated policy store retrieval configuration mechanism. Replaced a boolean flag with a string-based retrieval point configuration, now set to default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->