### PR TITLE
adding uniformity in cancel and back buttons present in Scopes

### DIFF
--- a/admin-ui/plugins/auth-server/components/Scopes/helper/utils.ts
+++ b/admin-ui/plugins/auth-server/components/Scopes/helper/utils.ts
@@ -1,0 +1,72 @@
+import type { ScopeFormValues, ExtendedScope, ExtendedScopeAttributes } from '../types'
+
+export interface ScopePanelVisibility {
+  showClaimsPanel: boolean
+  showDynamicPanel: boolean
+  showSpontaneousPanel: boolean
+  showUmaPanel: boolean
+}
+
+const cloneScopeAttributes = (
+  attributes?: ExtendedScopeAttributes,
+): ExtendedScopeAttributes | undefined => {
+  if (!attributes) {
+    return undefined
+  }
+
+  return {
+    ...attributes,
+    spontaneousClientScopes: Array.isArray(attributes.spontaneousClientScopes)
+      ? [...attributes.spontaneousClientScopes]
+      : [],
+  }
+}
+
+export const buildScopeInitialValues = (scope: ExtendedScope): ScopeFormValues => {
+  return {
+    id: scope.id ?? '',
+    displayName: scope.displayName ?? '',
+    description: scope.description ?? '',
+    scopeType: scope.scopeType ?? '',
+    defaultScope: scope.defaultScope ?? false,
+    claims: scope.claims ? [...scope.claims] : [],
+    dynamicScopeScripts: scope.dynamicScopeScripts ? [...scope.dynamicScopeScripts] : [],
+    attributes: cloneScopeAttributes(scope.attributes),
+    umaAuthorizationPolicies: scope.umaAuthorizationPolicies
+      ? [...scope.umaAuthorizationPolicies]
+      : [],
+    iconUrl: scope.iconUrl ?? '',
+    action_message: '',
+  }
+}
+
+export const derivePanelVisibility = (scopeType?: string): ScopePanelVisibility => {
+  const normalizedType = scopeType ?? ''
+
+  return {
+    showClaimsPanel: normalizedType === 'openid',
+    showDynamicPanel: normalizedType === 'dynamic',
+    showSpontaneousPanel: normalizedType === 'spontaneous',
+    showUmaPanel: normalizedType === 'uma',
+  }
+}
+
+export const applyScopeTypeDefaults = (
+  values: ScopeFormValues,
+  scopeType: string,
+): ScopeFormValues => {
+  const clonedAttributes = cloneScopeAttributes(values.attributes)
+
+  if (clonedAttributes) {
+    clonedAttributes.spontaneousClientId = undefined
+    clonedAttributes.spontaneousClientScopes = []
+  }
+
+  return {
+    ...values,
+    scopeType,
+    dynamicScopeScripts: [],
+    claims: [],
+    attributes: clonedAttributes,
+  }
+}

--- a/admin-ui/plugins/auth-server/components/Scopes/helper/validations.ts
+++ b/admin-ui/plugins/auth-server/components/Scopes/helper/validations.ts
@@ -1,0 +1,7 @@
+import * as Yup from 'yup'
+
+export const getScopeValidationSchema = () =>
+  Yup.object({
+    displayName: Yup.string().min(2, 'displayName 2 characters').required('Required!'),
+    id: Yup.string().min(2, 'id 2 characters').required('Required!'),
+  })

--- a/admin-ui/plugins/auth-server/components/Scopes/types/componentTypes.ts
+++ b/admin-ui/plugins/auth-server/components/Scopes/types/componentTypes.ts
@@ -1,15 +1,8 @@
-/**
- * Component prop types for Scope components
- */
-
-import type { Scope, ExtendedScope, ScopeWithClients, ScopeScript, ScopeClaim } from './scopeTypes'
+import type { ExtendedScope, ScopeWithClients, ScopeScript, ScopeClaim } from './scopeTypes'
 import type { ModifiedFields } from './formTypes'
 
-/**
- * Props for ScopeDetailPage component
- */
 export interface ScopeDetailPageProps {
-  row: Scope
+  row: ScopeWithClients
 }
 
 export type ScopeListPageProps = Record<string, never>
@@ -18,9 +11,6 @@ export type ScopeAddPageProps = Record<string, never>
 
 export type ScopeEditPageProps = Record<string, never>
 
-/**
- * Props for ScopeForm component
- */
 export interface ScopeFormProps {
   scope: ExtendedScope
   scripts: ScopeScript[]
@@ -31,10 +21,6 @@ export interface ScopeFormProps {
   setModifiedFields: (fields: ModifiedFields) => void
 }
 
-/**
- * Row data for MaterialTable in ScopeListPage
- * Extends Scope with client information
- */
 export interface ScopeTableRow extends ScopeWithClients {
   tableData?: {
     id: number

--- a/admin-ui/plugins/auth-server/components/Scopes/types/formTypes.ts
+++ b/admin-ui/plugins/auth-server/components/Scopes/types/formTypes.ts
@@ -1,13 +1,5 @@
-/**
- * Form-specific types for Scopes
- */
+import type { Scope, ExtendedScopeAttributes } from './scopeTypes'
 
-import type { Scope, ScopeAttributes } from './scopeTypes'
-
-/**
- * Formik form values for ScopeForm
- * Represents the subset of Scope fields that are editable in the form
- */
 export interface ScopeFormValues {
   id?: string
   displayName?: string
@@ -16,31 +8,21 @@ export interface ScopeFormValues {
   defaultScope?: boolean
   claims?: string[]
   dynamicScopeScripts?: string[]
-  attributes?: ScopeAttributes
+  attributes?: ExtendedScopeAttributes
   umaAuthorizationPolicies?: string[]
   iconUrl?: string
+  action_message?: string
 }
 
-/**
- * Modified fields tracking for audit logging
- * Tracks which fields were changed during form editing
- */
 export interface ModifiedFields {
   [key: string]: string | boolean | string[] | undefined | null
 }
 
-/**
- * Form submission data with audit message
- */
 export interface ScopeFormSubmitData {
   scope: Scope
   modifiedFields?: ModifiedFields
 }
 
-/**
- * User action payload for API calls
- * Used with buildPayload utility
- */
 export interface UserActionPayload {
   action_message?: string
   scope?: Scope


### PR DESCRIPTION
### feat(admin): adding uniformity in cancel and back buttons present in **Scopes**

#### Summary
This update introduces consistent behavior for **Cancel**, **Back**, and **Apply** buttons across Admin UI forms, including correct enabling and disabling based on form state.

#### Improvements
| Button | Updated Behavior |
|--------|------------------|
| **Cancel** | Resets all fields to their previous values without navigating away. Disabled until a change is made. |
| **Back** | Navigates to the previous page. If there is no navigation history, returns to Dashboard. Always enabled. |
| **Apply** | Saves the changes without leaving the page. Enabled only when the form has unsaved changes. |

#### Additional Enhancements
- Buttons now correctly detect dirty form states.
- Apply button is dynamically enabled and disabled based on whether changes exist.
- Cancel button is disabled until a field is modified.
- Prevents accidental navigation or state loss in multi step configuration pages.

#### Affected Modules
This change is applied across all forms where configuration changes are possible, including but not limited to:
- Users

Parent issue: **#2268**

### Testing Steps
1. Open suggested config form.
2. Modify any field.
3. Verify that:
   - Apply and Cancel buttons become enabled.
   - Apply saves configuration and stays on page.
   - Cancel reverts values and disables itself afterward.
4. Back button should navigate appropriately.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added confirmation dialog for scope submissions to prevent accidental changes.
  * Enhanced panel visibility controls for different scope types with improved UI organization.

* **Bug Fixes**
  * Improved navigation handling and form state management during scope editing.

* **Refactor**
  * Optimized form submission workflow and scope attribute handling for better performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->