### PR TITLE
fix: git package is not installed during execution of startflexmonolithdemo script

### DIFF
--- a/automation/startflexmonolithdemo.sh
+++ b/automation/startflexmonolithdemo.sh
@@ -31,7 +31,8 @@ sudo apt-get install \
   curl \
   gnupg \
   python3-pip \
-  lsb-release -y
+  lsb-release \
+  git -y
 sudo mkdir -p /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 echo \


### PR DESCRIPTION
The changeset adds `git` package before cloning Flex repository.

Closes #2458 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installation script to adjust package installation behavior for better control over interactive prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->