### PR TITLE
fix: use free bitnamilegacy images instead of paid commercial bitnami

### DIFF
--- a/automation/startflexdemo.sh
+++ b/automation/startflexdemo.sh
@@ -65,7 +65,7 @@ fi
 PERSISTENCE_TYPE="sql"
 if [[ $GLUU_PERSISTENCE == "MYSQL" ]]; then
   sudo microk8s.kubectl get po --kubeconfig="$KUBECONFIG"
-  sudo helm install my-release --set auth.rootPassword=Test1234#,auth.database=gluu -n gluu oci://registry-1.docker.io/bitnamicharts/mysql --kubeconfig="$KUBECONFIG"
+  sudo helm install my-release --set auth.rootPassword=Test1234#,auth.database=gluu,image.repository=bitnamilegacy/mysql,image.tag=9.4.0-debian-12-r1 -n gluu oci://registry-1.docker.io/bitnamicharts/mysql --kubeconfig="$KUBECONFIG"
   cat << EOF > override.yaml
 config:
   countryCode: US
@@ -84,7 +84,7 @@ EOF
 fi
 if [[ $GLUU_PERSISTENCE == "PGSQL" ]]; then
   sudo microk8s.kubectl get po --kubeconfig="$KUBECONFIG"
-  sudo helm install my-release --set auth.postgresPassword=Test1234#,auth.database=gluu -n gluu oci://registry-1.docker.io/bitnamicharts/postgresql --kubeconfig="$KUBECONFIG"
+  sudo helm install my-release --set auth.postgresPassword=Test1234#,auth.database=gluu,image.repository=bitnamilegacy/postgresql,image.tag=16.4.0-debian-12-r0 -n gluu oci://registry-1.docker.io/bitnamicharts/postgresql --kubeconfig="$KUBECONFIG"
   cat << EOF > override.yaml
 config:
   countryCode: US

--- a/automation/startopenabankingdemo.sh
+++ b/automation/startopenabankingdemo.sh
@@ -21,7 +21,7 @@ KUBECONFIG="$PWD"/config
 sudo microk8s.kubectl create namespace gluu --kubeconfig="$KUBECONFIG" || echo "namespace exists"
 sudo helm repo add bitnami https://charts.bitnami.com/bitnami
 sudo microk8s.kubectl get po --kubeconfig="$KUBECONFIG"
-sudo helm install my-release --set auth.rootPassword=Test1234#,auth.database=gluu -n gluu oci://registry-1.docker.io/bitnamicharts/mysql --kubeconfig="$KUBECONFIG"
+sudo helm install my-release --set auth.rootPassword=Test1234#,auth.database=gluu,image.repository=bitnamilegacy/mysql,image.tag=9.4.0-debian-12-r1 -n gluu oci://registry-1.docker.io/bitnamicharts/mysql --kubeconfig="$KUBECONFIG"
 EXT_IP=$(curl ipinfo.io/ip)
 sudo echo "$EXT_IP $GLUU_FQDN" >> /etc/hosts
 cat << EOF > override.yaml

--- a/docs/admin/recipes/getting-started-rancher.md
+++ b/docs/admin/recipes/getting-started-rancher.md
@@ -197,7 +197,7 @@ kubectl get secret cn -o json -n <namespace>
     - Pass in a custom password for the database. Here we used `Test1234#`. The admin user will be left as `root`. Notice we are installing in the `gluu` namespace. Run 
 
         ```
-        helm install my-release --set auth.rootPassword=Test1234#,auth.database=jans bitnami/mysql -n gluu
+        helm install my-release --set auth.rootPassword=Test1234#,auth.database=gluu,image.repository=bitnamilegacy/mysql,image.tag=9.4.0-debian-12-r1 -n gluu oci://registry-1.docker.io/bitnamicharts/mysql
         ```
 
     ### Successful Installation    

--- a/docs/install/helm-install/amazon-eks.md
+++ b/docs/install/helm-install/amazon-eks.md
@@ -105,7 +105,7 @@ tags:
         For testing purposes, you can deploy it on the EKS cluster using the following command:
 
         ```
-        helm install my-release --set auth.postgresPassword=Test1234#,auth.database=gluu -n gluu oci://registry-1.docker.io/bitnamicharts/postgresql
+        helm install my-release --set auth.postgresPassword=Test1234#,auth.database=gluu,image.repository=bitnamilegacy/postgresql,image.tag=16.4.0-debian-12-r0 -n gluu oci://registry-1.docker.io/bitnamicharts/postgresql
         ```
 
         Add the following yaml snippet to your `override.yaml` file:
@@ -132,7 +132,7 @@ tags:
         For testing purposes, you can deploy it on the EKS cluster using the following command:
 
         ```
-        helm install my-release --set auth.rootPassword=Test1234#,auth.database=gluu -n gluu oci://registry-1.docker.io/bitnamicharts/mysql
+        helm install my-release --set auth.rootPassword=Test1234#,auth.database=gluu,image.repository=bitnamilegacy/mysql,image.tag=9.4.0-debian-12-r1 -n gluu oci://registry-1.docker.io/bitnamicharts/mysql
         ```
 
         Add the following yaml snippet to your `override.yaml` file:

--- a/docs/install/helm-install/google-gke.md
+++ b/docs/install/helm-install/google-gke.md
@@ -98,7 +98,7 @@ tags:
         For testing purposes, you can deploy it on the GKE cluster using the following command:
 
         ```
-        helm install my-release --set auth.postgresPassword=Test1234#,auth.database=gluu -n gluu oci://registry-1.docker.io/bitnamicharts/postgresql
+        helm install my-release --set auth.postgresPassword=Test1234#,auth.database=gluu,image.repository=bitnamilegacy/postgresql,image.tag=16.4.0-debian-12-r0 -n gluu oci://registry-1.docker.io/bitnamicharts/postgresql
         ```
 
         Add the following yaml snippet to your `override.yaml` file:
@@ -125,7 +125,7 @@ tags:
         For testing purposes, you can deploy it on the GKE cluster using the following command:
 
         ```
-        helm install my-release --set auth.rootPassword=Test1234#,auth.database=gluu -n gluu oci://registry-1.docker.io/bitnamicharts/mysql
+        helm install my-release --set auth.rootPassword=Test1234#,auth.database=gluu,image.repository=bitnamilegacy/mysql,image.tag=9.4.0-debian-12-r1 -n gluu oci://registry-1.docker.io/bitnamicharts/mysql
         ```
 
         Add the following yaml snippet to your `override.yaml` file:

--- a/docs/install/helm-install/microsoft-azure.md
+++ b/docs/install/helm-install/microsoft-azure.md
@@ -102,7 +102,7 @@ tags:
         For testing purposes, you can deploy it on the AKS cluster using the following command:
 
         ```
-        helm install my-release --set auth.postgresPassword=Test1234#,auth.database=gluu -n gluu oci://registry-1.docker.io/bitnamicharts/postgresql
+        helm install my-release --set auth.postgresPassword=Test1234#,auth.database=gluu,image.repository=bitnamilegacy/postgresql,image.tag=16.4.0-debian-12-r0 -n gluu oci://registry-1.docker.io/bitnamicharts/postgresql
         ```
 
         Add the following yaml snippet to your `override.yaml` file:
@@ -130,7 +130,7 @@ tags:
         For testing purposes, you can deploy it on the AKS cluster using the following command:
 
         ```
-        helm install my-release --set auth.rootPassword=Test1234#,auth.database=gluu -n gluu oci://registry-1.docker.io/bitnamicharts/mysql
+        helm install my-release --set auth.rootPassword=Test1234#,auth.database=gluu,image.repository=bitnamilegacy/mysql,image.tag=9.4.0-debian-12-r1 -n gluu oci://registry-1.docker.io/bitnamicharts/mysql
         ```
 
         Add the following yaml snippet to your `override.yaml` file:


### PR DESCRIPTION
closes #2469 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation & Deployment Updates**
  * Updated MySQL container image to version 9.4.0-debian-12-r1 and PostgreSQL to version 16.4.0-debian-12-r0 across Helm deployment scripts and cloud platform installation guides.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->