### PR TITLE
fix(admin-ui): unable to click Agama Flow tab in Auth Server (#2483)

### DIFF
--- a/admin-ui/app/routes/Apps/Gluu/GluuTabs.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/GluuTabs.tsx
@@ -159,7 +159,7 @@ export default function GluuTabs({ tabNames, tabToShow, withNavigation = false }
     }
 
     const activeTab = tabNames[activeIndex] ?? null
-    if (isNavigationTab(activeTab) && activeTab.path !== path.pathname) {
+    if (isNavigationTab(activeTab)) {
       navigateToRoute(activeTab.path, { replace: true })
     }
     setValue(activeIndex)


### PR DESCRIPTION
### fix(admin-ui): unable to click Agama Flow tab in Auth Server (#2483)

#### Summary
The Agama Flow tab in the Auth Server module is not clickable, preventing users from accessing the upload section for Agama flows.

#### Actual Behavior
- The Agama Flow tab is not interactive.
- Users cannot access the Agama Flow upload interface due to the browser rapid navigation and throttling issue

#### Expected Behavior
- The Agama Flow tab should be fully clickable.
- Users should be able to open the tab and upload Agama flows without errors.

#### Fix Summary
- Improved navigation handling to prevent rapid repeated navigation calls.
- Applied memoization and optimized component rendering to avoid unnecessary re-renders.
- Ensured smooth tab switching without triggering browser throttling protection.
- Verified that the Agama Flow tab now opens consistently across the project.

### Closes
Closes: #2483


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for tab controls and preserved accessible tab associations.
  * Better synchronization between tabs and browser URL, including auto-selecting a navigable tab when none matches.
  * More stable tab selection logic to prevent unexpected tab switches.

* **Enhancements**
  * Navigation is now more reliable and consistent when switching tabs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->