### PR TITLE
fix(admin-ui): edit form not opening when preview section is expanded…

### DIFF
--- a/admin-ui/plugins/user-management/components/UserList.tsx
+++ b/admin-ui/plugins/user-management/components/UserList.tsx
@@ -147,8 +147,7 @@ function UserList(): JSX.Element {
     (row: UserTableRowData): void => {
       const userId = row.tableData?.uuid || row.inum
       if (!userId) return
-      const userData = { ...row }
-      delete userData.tableData
+      const { tableData, ...userData } = row
       navigateToRoute(ROUTES.USER_EDIT(userId), { state: { selectedUser: userData as CustomUser } })
     },
     [navigateToRoute],


### PR DESCRIPTION
### fix(admin-ui): edit form not opening when preview section is expanded on Users search page (#2528)

#### Summary
When the preview section was expanded on the Users search page, clicking the Edit action did not open the edit form. This prevented users from modifying user details unless the preview section was manually collapsed.

#### Fix Summary
- Corrected interaction handling between the preview panel and edit action.
- Ensured the edit form opens reliably regardless of preview section state.
- Fixed UI state conflicts that were blocking navigation to the edit view.
- Verified consistent behavior across expanded and collapsed preview states.

#### Result
Users can now open the edit form seamlessly even when the preview section is expanded.

### Closes
Closes: #2528


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized user data before opening the user edit page by removing transient table metadata, preventing accidental data leakage or unintended mutations during user edits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->