### PR TITLE
fix(cloud-native): copy flex_schema.json explicitly

### DIFF
--- a/docker-flex-all-in-one/Dockerfile
+++ b/docker-flex-all-in-one/Dockerfile
@@ -57,7 +57,7 @@ COPY --from=jans-aio-src /var/log/adminui /var/log/adminui
 COPY --from=jans-aio-src /usr/share/java /usr/share/java
 
 # override persistence-loader assets
-COPY --from=flex-persistence-loader-src /app/schema /app/schema
+COPY --from=flex-persistence-loader-src /app/schema/flex_schema.json /app/schema/flex_schema.json
 
 COPY --from=flex-admin-ui-src /opt/flex/admin-ui /opt/flex/admin-ui
 COPY --from=flex-admin-ui-src /app/templates/admin-ui /app/templates/admin-ui


### PR DESCRIPTION
The changeset copy required `flex_schema.json` explicitly to avoid other existing files being overwritten.

Closes #2655 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to narrow schema asset handling, now copying only the required configuration file instead of the entire schema directory. This change reduces assets included in builds and may affect configurations that previously relied on other files within the schema directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->