### PR TITLE
chore(cloud-native): upgrade cryptography library in OCI images

### DIFF
--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
+FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
 # ======
 # alpine
@@ -22,7 +22,7 @@ EXPOSE 8080
 
 RUN mkdir -p /app/static/rdbm /app/schema /app/templates/admin-ui
 
-ENV JANS_SOURCE_VERSION=69e5364246941660916bd41527642340aff4228e
+ENV JANS_SOURCE_VERSION=1b66569673d82976da013100f5c4eaae1854547e
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)

--- a/docker-admin-ui/requirements.txt
+++ b/docker-admin-ui/requirements.txt
@@ -1,3 +1,3 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
-grpcio==1.72.0
+grpcio==1.76.0
 /tmp/jans/jans-pycloudlib

--- a/docker-flex-all-in-one/Dockerfile
+++ b/docker-flex-all-in-one/Dockerfile
@@ -69,7 +69,7 @@ RUN ln -sf /app/flex_aio/admin_ui/entrypoint.sh /app/bin/admin-ui-entrypoint.sh
 # Assets sync
 # ===========
 
-ENV JANS_SOURCE_VERSION=69e5364246941660916bd41527642340aff4228e
+ENV JANS_SOURCE_VERSION=1b66569673d82976da013100f5c4eaae1854547e
 
 # note that as we're pulling from a monorepo (with multiple project in it)
 # we are using partial-clone and sparse-checkout to get the assets


### PR DESCRIPTION
Upgrade py3-cryptography library.

Closes #2699 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base image to the latest version for improved stability
  * Updated messaging library dependency to the latest version for enhanced compatibility and performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->