### PR TITLE
feat: conditional gateway resource creation and customized section names

### DIFF
--- a/charts/gluu/charts/gateway-api/templates/gateway.yaml
+++ b/charts/gluu/charts/gateway-api/templates/gateway.yaml
@@ -1,6 +1,8 @@
 {{- $fullName := include "gateway-api.fullname" . -}}
 {{- $namespace := .Release.Namespace -}}
 
+{{- /* Conditional in case the Gateway resource is created and managed externally */}}
+{{- if .Values.gateway.enabled }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -57,3 +59,4 @@ spec:
       mode: Terminate
       certificateRefs:
       - name: {{ .Values.gateway.tlsSecretName }}
+{{- end }}

--- a/charts/gluu/charts/gateway-api/templates/route.yaml
+++ b/charts/gluu/charts/gateway-api/templates/route.yaml
@@ -1,5 +1,8 @@
 {{- $fullName := include "gateway-api.fullname" . -}}
 {{- $namespace := .Release.Namespace -}}
+{{- $gatewayNamespace := .Values.routes.gatewayNamespace | default $namespace -}}
+{{- $httpSection := .Values.routes.httpSectionName | default "http" -}}
+{{- $httpsSection := .Values.routes.httpsSectionName | default "https" -}}
 {{- $authSvc := index .Values.global "auth-server" "authServerServiceName" -}}
 {{- $configSvc := index .Values.global "config-api" "configApiServerServiceName" -}}
 {{- $fido2Svc := .Values.global.fido2.fido2ServiceName -}}
@@ -28,6 +31,7 @@ metadata:
 spec:
   parentRefs:
   - name: {{ .Values.gateway.name }}
+    namespace: {{ $gatewayNamespace }}
   hostnames:
   - {{ .Values.global.fqdn | quote }}
   rules:
@@ -246,7 +250,8 @@ metadata:
 spec:
   parentRefs:
   - name: {{ .Values.gateway.name }}
-    sectionName: https
+    namespace: {{ $gatewayNamespace }}
+    sectionName: {{ $httpsSection }}
   hostnames:
   - {{ .Values.global.fqdn | quote }}
   rules:
@@ -334,7 +339,8 @@ metadata:
 spec:
   parentRefs:
   - name: {{ .Values.gateway.name }}
-    sectionName: http
+    namespace: {{ $gatewayNamespace }}
+    sectionName: {{ $httpSection }}
   hostnames:
   - {{ .Values.global.fqdn | quote }}
   rules:
@@ -432,7 +438,8 @@ metadata:
 spec:
   parentRefs:
   - name: {{ .Values.gateway.name }}
-    sectionName: https
+    namespace: {{ $gatewayNamespace }}
+    sectionName: {{ $httpsSection }}
   hostnames:
   - {{ .Values.global.fqdn | quote }}
   rules:
@@ -496,7 +503,8 @@ metadata:
 spec:
   parentRefs:
   - name: {{ .Values.gateway.name }}
-    sectionName: https
+    namespace: {{ $gatewayNamespace }}
+    sectionName: {{ $httpsSection }}
   hostnames:
   - {{ .Values.global.fqdn | quote }}
   rules:

--- a/charts/gluu/charts/gateway-api/values.yaml
+++ b/charts/gluu/charts/gateway-api/values.yaml
@@ -3,6 +3,8 @@ fullnameOverride: ""
 
 # -- Configuration for Gateway resource
 gateway:
+  # -- Enable Gateway API and create a Gateway resource (if disabled, you will have to create and manage the Gateway resource externally).
+  enabled: true
   # -- Set the gatewayClassName corresponding to your installed controller.
   className: nginx
   # -- The name of the Gateway resource to be created
@@ -34,6 +36,11 @@ gateway:
     annotations: {}
 # -- Configuration for HTTPRoute and its related resources
 routes:
+  # -- Namespace where the Gateway resource resides. Set this ONLY if the Gateway is externally managed in a different namespace than this Helm release. If set, ensure the target namespace exists and your Gateway controller has the required cross-namespace RBAC permissions.
+  gatewayNamespace: ""
+  # -- Only set the httpSectionName and httpsSectionName if it doesn't work with the default values, according to your installed controller (e.g. some controller may require the listener name to be `default`).
+  httpSectionName: http
+  httpsSectionName: https
   # -- Specific labels for the HTTPRoute resource
   labels: {}
   # -- Specific annotations for the HTTPRoute resource

--- a/charts/gluu/values.yaml
+++ b/charts/gluu/values.yaml
@@ -1440,6 +1440,8 @@ global:
 gateway-api:
   # -- Configuration for Gateway resource
   gateway:
+    # -- Enable Gateway API and create a Gateway resource (if disabled, you will have to create and manage the Gateway resource externally).
+    enabled: true
     # -- Set the gatewayClassName corresponding to your installed controller.
     className: nginx
     # -- The name of the Gateway resource to be created
@@ -1471,6 +1473,11 @@ gateway-api:
       annotations: {}
   # -- Configuration for HTTPRoute and its related resources
   routes:
+    # -- Namespace where the Gateway resource resides. Set this ONLY if the Gateway is externally managed in a different namespace than this Helm release. If set, ensure the target namespace exists and your Gateway controller has the required cross-namespace RBAC permissions.
+    gatewayNamespace: ""
+    # -- Only set the httpSectionName and httpsSectionName if it doesn't work with the default values, according to your installed controller (e.g. some controller may require the listener name to be `default`).
+    httpSectionName: http
+    httpsSectionName: https
     # -- Specific labels for the HTTPRoute resource
     labels: {}
     # -- Specific annotations for the HTTPRoute resource


### PR DESCRIPTION
closes #2707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Gateway API support is now enabled by default, allowing automatic creation of Kubernetes Gateway resources
  * Added new configuration options to specify a gateway namespace and customize HTTP/HTTPS section names for routes
  * Routes now support referencing external gateways and gateways in different namespaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->