### PR TITLE
fix: 401 for uma resource api when we open newly created auth client

### DIFF
--- a/flex-linux-setup/flex_linux_setup/templates/adminUIResourceScopesMapping.ldif
+++ b/flex-linux-setup/flex_linux_setup/templates/adminUIResourceScopesMapping.ldif
@@ -134,6 +134,7 @@ jansScope: https://jans.io/oauth/config/scopes.readonly
 jansScope: https://jans.io/oauth/config/scripts.readonly
 jansScope: https://jans.io/oauth/jans-auth-server/config/adminui/logging.write
 jansScope: https://jans.io/oauth/config/data.readonly
+jansScope: https://jans.io/oauth/config/uma.readonly
 objectClass: top
 objectClass: adminUIResourceScopesMapping
 

--- a/flex-linux-setup/flex_linux_setup/templates/adminUIResourceScopesMapping.ldif
+++ b/flex-linux-setup/flex_linux_setup/templates/adminUIResourceScopesMapping.ldif
@@ -147,6 +147,7 @@ jansScope: https://jans.io/oauth/config/scripts.readonly
 jansScope: https://jans.io/oauth/jans-auth-server/config/properties.readonly
 jansScope: https://jans.io/oauth/jans-auth-server/config/adminui/webhook.readonly
 jansScope: https://jans.io/oauth/jans-auth-server/config/adminui/logging.write
+jansScope: https://jans.io/oauth/config/uma.write
 objectClass: top
 objectClass: adminUIResourceScopesMapping
 
@@ -157,6 +158,7 @@ jansResource: clients
 jansScope: https://jans.io/oauth/config/openid/clients.delete
 jansScope: https://jans.io/oauth/jans-auth-server/config/adminui/webhook.readonly
 jansScope: https://jans.io/oauth/jans-auth-server/config/adminui/logging.write
+jansScope: https://jans.io/oauth/config/uma.admin
 objectClass: top
 objectClass: adminUIResourceScopesMapping
 


### PR DESCRIPTION
closes #2750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added new scope mappings for User-Managed Access (UMA) operations. Three access permission levels are now supported: read-only access for retrieving and viewing configurations, write access for modifying configurations, and administrative access for full management control and advanced operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->