### PR TITLE
fix: use stable link

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,5 @@ The Flex release schedule is closely tied to the upstream [Janssen Project](http
 - Flex Release = Janssen Project Release + 4 in the major version. For example, Flex 5.6.0 corresponds to Janssen Project release 1.6.0.
 - Flex releases typically occur 1-2 days after the corresponding Janssen Project release. 
 
-To stay informed about upcoming Flex releases, it's recommended to monitor the Janssen project [milestones](https://github.com/JanssenProject/jans/milestones) and [Flex end-of-life guidelines](https://docs.gluu.org/nightly/install/eol/) regularly. Please note that the QA team may update these milestones as testing progresses, so checking frequently is advised.
+To stay informed about upcoming Flex releases, it's recommended to monitor the Janssen project [milestones](https://github.com/JanssenProject/jans/milestones) and [Flex end-of-life guidelines](https://docs.gluu.org/stable/install/eol/) regularly. Please note that the QA team may update these milestones as testing progresses, so checking frequently is advised.
 


### PR DESCRIPTION
Use the `stable` link instead of `nightly`, so that it points to the most recent GA release. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Flex end-of-life guidelines documentation link to reference stable documentation instead of nightly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->