### PR TITLE
chore(flex-linux-setup): add read/write scopes for fido metrics access to admin-ui if policy-store have appropriate polices

### DIFF
--- a/flex-linux-setup/flex_linux_setup/templates/adminUIResourceScopesMapping.ldif
+++ b/flex-linux-setup/flex_linux_setup/templates/adminUIResourceScopesMapping.ldif
@@ -473,6 +473,7 @@ inum: 9846cf37-e701-4c52-881f-3d433233bf58
 jansAccessType: READ
 jansResource: fido
 jansScope: https://jans.io/oauth/config/fido2.readonly
+jansScope: https://jans.io/oauth/config/fido2-metrics.readonly
 jansScope: https://jans.io/oauth/jans-auth-server/config/adminui/logging.write
 jansScope: https://jans.io/oauth/config/data.readonly
 objectClass: top
@@ -483,6 +484,7 @@ inum: 4a953049-ddf1-4d55-aa4f-760f08b584a0
 jansAccessType: WRITE
 jansResource: fido
 jansScope: https://jans.io/oauth/config/fido2.write
+jansScope: https://jans.io/oauth/config/fido2.admin
 jansScope: https://jans.io/oauth/jans-auth-server/config/adminui/logging.write
 objectClass: top
 objectClass: adminUIResourceScopesMapping


### PR DESCRIPTION
closes #2805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new FIDO2-related administrative permission scopes to enable granular access control for FIDO2 configuration management and metrics monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->