### PR TITLE
Update VM requirements for supported Linux versions

### DIFF
--- a/docs/install/vm-install/rhel.md
+++ b/docs/install/vm-install/rhel.md
@@ -29,7 +29,7 @@ sudo firewall-cmd --reload;
 sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm -E %rhel).noarch.rpm
 ```
 ```shell
-sudo yum -y module enable mod_auth_openidc;
+ sudo yum -y install mod_auth_openidc;
 ```
 - Please obtain an [SSA](../../install/flex/prerequisites.md#software-statement-assertions) to trial Flex, after which you are issued a JWT
   that you can use during installation. SSA should be stored in a text file on an accessible path.
@@ -40,7 +40,7 @@ sudo yum -y module enable mod_auth_openidc;
 - Download the release package from the Github Flex
   [Releases](https://github.com/gluufederation/flex/releases)
 ```shell
-wget https://github.com/GluuFederation/flex/releases/download/vreplace-flex-version/flex-replace-flex-version-stable.el8.x86_64.rpm -P /tmp
+wget https://github.com/GluuFederation/flex/releases/download/vreplace-flex-version/flex-replace-flex-version-stable.el9.x86_64.rpm -P /tmp
 ```
 - Go to `/tmp` directory:
 
@@ -56,14 +56,14 @@ wget https://github.com/GluuFederation/flex/releases/download/vreplace-flex-vers
     - Download the cosign bundle from the [Releases](https://github.com/gluufederation/flex/releases/latest) page:
 
         ```bash title="Command"
-        wget https://github.com/GluuFederation/flex/releases/download/vreplace-flex-version/flex_replace-flex-version-stable.bundle -P /tmp
+        wget https://github.com/GluuFederation/flex/releases/download/vreplace-flex-version/flex-el9-replace-flex-version-stable.bundle -P /tmp
         ```
 
     - Verify the signature:
 
         ```bash title="Command"
         cosign verify-blob \
-          --bundle flex_replace-flex-version-stable.bundle \
+          --bundle flex-el9-replace-flex-version-stable.bundle \
           --certificate-identity-regexp "https://github.com/GluuFederation/flex" \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
           flex-replace-flex-version-stable.el9.x86_64.rpm

--- a/docs/install/vm-install/suse.md
+++ b/docs/install/vm-install/suse.md
@@ -40,7 +40,7 @@ sudo SUSEConnect -p PackageHub/15.4/x86_64
 
 - Download the release package from the GitHub FLEX [Releases](https://github.com/gluufederation/flex/releases)
 ```shell
-wget https://github.com/GluuFederation/flex/releases/download/vreplace-flex-version/flex-replace-flex-version-stable.suse15.x86_64.rpm -P /tmp
+wget https://github.com/GluuFederation/flex/releases/download/vreplace-flex-version/flex-replace-flex-version-stable.suse16.x86_64.rpm -P /tmp
 ```
 - Go to `/tmp` directory:
 
@@ -63,7 +63,7 @@ wget https://github.com/GluuFederation/flex/releases/download/vreplace-flex-vers
 
         ```bash title="Command"
         cosign verify-blob \
-          --bundle flex_replace-flex-version-stable.bundle \
+          --bundle flex-suse16-replace-flex-version-stable.bundle \
           --certificate-identity-regexp "https://github.com/GluuFederation/flex" \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
           flex-replace-flex-version-stable.suse16.x86_64.rpm
@@ -92,7 +92,7 @@ wget https://github.com/GluuFederation/flex/releases/download/vreplace-flex-vers
 
 Use SUSE `zypper` to install
 ```shell
-sudo zypper install ~/flex-replace-flex-version-stable.suse15.x86_64.rpm
+sudo zypper install ~/flex-replace-flex-version-stable.suse16.x86_64.rpm
 ```
 
 ### Run the setup script

--- a/docs/install/vm-install/vm-requirements.md
+++ b/docs/install/vm-install/vm-requirements.md
@@ -10,7 +10,7 @@ Gluu Flex currently provides packages for these Linux distros:
     - SUSE Linux Enterprise Server (SLES) 16
     - openSUSE Leap 16
     - openSUSE Tumbleweed
-- RedHat Enterprise Linux (version: 9 and 10)
+- Red Hat Enterprise Linux (version: 9 and 10)
 
 !!! Note
     This document is intended exclusively for dev and staging environments. Use Flex [helm deployments](../helm-install/README.md) for production setups. You can consider referring to this [documentation](../helm-install/prerequisites/rancher.md) which utilizes Rancher and Helm deployments.

--- a/docs/install/vm-install/vm-requirements.md
+++ b/docs/install/vm-install/vm-requirements.md
@@ -10,7 +10,8 @@ Gluu Flex currently provides packages for these Linux distros:
     - SUSE Linux Enterprise Server (SLES) 16
     - openSUSE Leap 16
     - openSUSE Tumbleweed
-- Red Hat Enterprise Linux (version: 9 and 10)
+- Red Hat Enterprise Linux (version: 9)
+- Red Hat Enterprise Linux (version: 10)
 
 !!! Note
     This document is intended exclusively for dev and staging environments. Use Flex [helm deployments](../helm-install/README.md) for production setups. You can consider referring to this [documentation](../helm-install/prerequisites/rancher.md) which utilizes Rancher and Helm deployments.

--- a/docs/install/vm-install/vm-requirements.md
+++ b/docs/install/vm-install/vm-requirements.md
@@ -4,12 +4,13 @@
 
 Gluu Flex currently provides packages for these Linux distros:
 
-- Ubuntu (versions: 20.04 and 22.04)
+- Ubuntu (versions: 22.04 and 24.04)
+- Debian 13
 - SUSE Distributions
-    - SUSE Linux Enterprise Server (SLES) 15
-    - openSUSE Leap 15.5
+    - SUSE Linux Enterprise Server (SLES) 16
+    - openSUSE Leap 16
     - openSUSE Tumbleweed
-- RedHat Enterprise Linux (version: 8)
+- RedHat Enterprise Linux (version: 9 and 10)
 
 !!! Note
     This document is intended exclusively for dev and staging environments. Use Flex [helm deployments](../helm-install/README.md) for production setups. You can consider referring to this [documentation](../helm-install/prerequisites/rancher.md) which utilizes Rancher and Helm deployments.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation guides for newer OS targets: RHEL 9 (EL9) artifacts and bundles, SUSE 16 packages, and Ubuntu 22.04 & 24.04.
  * Revised VM requirements to list RHEL 9–10, Ubuntu 22.04/24.04, and SUSE 16 variants.
  * Adjusted install and package verification examples to reference the corresponding EL9/SUSE16 packages and verification bundle names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->