### PR TITLE
fix(flex-linux-setup): fetch admin-ui-plugin from the jans GitHub release

### DIFF
--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -16,7 +16,6 @@ import uuid
 
 from pathlib import Path
 from urllib import request
-from urllib.parse import urljoin
 from xml.etree import ElementTree
 
 argsp = None
@@ -295,8 +294,6 @@ if not installed:
         base.argsp = arg_parser.get_parser()
         set_app_versions_from_arguments(base.argsp)
 
-maven_base_url = 'https://jenkins.jans.io/maven/io/jans/'
-
 node_installer = NodeInstaller()
 httpd_installer = HttpdInstaller()
 jans_installer = JansInstaller()
@@ -365,9 +362,9 @@ class flex_installer(JettyInstaller):
             self.source_files += [
                 ('https://nodejs.org/dist/{0}/node-{0}-linux-x64.tar.xz'.format(app_versions['NODE_VERSION']),
                  os.path.join(Config.dist_app_dir, 'node-{0}-linux-x64.tar.xz'.format(app_versions['NODE_VERSION']))),
-                (urljoin(maven_base_url,
-                         'jans-config-api/plugins/admin-ui-plugin/{0}{1}/admin-ui-plugin-{0}{1}-distribution.jar'.format(
-                             app_versions['JANS_APP_VERSION'], app_versions['JANS_BUILD'])),
+                (base.determine_jans_artifact_url(
+                         'maven/io/jans/jans-config-api/plugins/admin-ui-plugin/{0}/admin-ui-plugin-{0}-distribution.jar'.format(
+                             base.current_app.app_info['jans_version'])),
                  self.admin_ui_plugin_source_path),
                 (
                 'https://raw.githubusercontent.com/JanssenProject/jans/{}/jans-config-api/server/src/main/resources/log4j2.xml'.format(


### PR DESCRIPTION
## Summary

`jenkins.jans.io` was shut off when the Janssen project moved artifact publishing from Jenkins to GitHub (Packages + release assets). `flex-linux-setup` still downloaded the admin-ui-plugin distribution jar from `jenkins.jans.io/maven/...`, so the download 404'd and `admin-ui-plugin-<ver>-distribution.jar` went missing from `/opt/dist/jans/` in the flex packages.

## Change

Route that one download through jans-linux-setup's `base.determine_jans_artifact_url(...)` (the helper `flex_setup.py` already imports), which builds the GitHub release asset URL `.../releases/download/<tag>/admin-ui-plugin-<ver>-distribution.jar`. The version comes from `base.current_app.app_info['jans_version']` so the asset name and the release tag (`nightly` vs `v<version>`) both derive from the jans build being installed — exactly how jans-linux-setup fetches the auth-client and fido2 jars. The now-unused `maven_base_url` constant and `urljoin` import are removed.

The asset is published on the jans release (e.g. `admin-ui-plugin-2.2.0-distribution.jar` on `v2.2.0`).

> The `jenkins.gluu.org` admin-ui-binary references (`flex_setup.py` `adimin_ui_bin_url`, `docker-admin-ui`) are Gluu's separate Jenkins and intentionally left out of this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the installation artifact resolution process by consolidating URL construction logic. The setup script now uses a centralized version-aware method to determine artifact locations instead of manual composition. This ensures consistent version handling when downloading installation components, particularly the admin-ui plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->