### PR TITLE
fix(flex-linux-setup): download apps approprieately

### DIFF
--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -191,9 +191,7 @@ if not jans_installer_downloaded:
     set_app_versions_from_arguments(base.argsp)
 
     downloads.base.current_app.app_info = base.readJsonFile(os.path.join(__STATIC_SETUP_DIR__, 'app_info.json'))
-    downloads.download_sqlalchemy()
-    downloads.download_cryptography()
-    downloads.download_pyjwt()
+    downloads.download_apps()
 
 install_components = {
     'admin_ui': argsp.install_admin_ui,


### PR DESCRIPTION
Closes #2898 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the app setup download step so required application packages are fetched together, improving installation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->