### PR TITLE
ci(docs): replace replace-flex-version with the tag on stable doc builds

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -214,7 +214,7 @@ jobs:
            egrep -lRZ --exclude=CONTRIBUTING.md . | xargs -0 -l sed -i -e "s/replace-flex-version/0.0.0-nightly/g"
            egrep -lRZ --exclude=CONTRIBUTING.md . | xargs -0 -l sed -i -e "s/v0.0.0-nightly/nightly/g"
           else
-           egrep -lRZ --exclude=CONTRIBUTING.md . | xargs -0 -l sed -i -e "s/replace-janssen-version/${LATEST:1}/g"
+           egrep -lRZ --exclude=CONTRIBUTING.md . | xargs -0 -l sed -i -e "s/replace-flex-version/${LATEST:1}/g"
           fi
           git add . && git update-index --refresh
           cd ..

--- a/docs/install/vm-install/suse.md
+++ b/docs/install/vm-install/suse.md
@@ -56,7 +56,7 @@ wget https://github.com/GluuFederation/flex/releases/download/vreplace-flex-vers
     - Download the cosign bundle from the [Releases](https://github.com/GluuFederation/flex/releases/latest) page:
 
         ```bash title="Command"
-        wget https://github.com/GluuFederation/flex/releases/download/vreplace-janssen-version/flex_replace-flex-version-stable.bundle -P /tmp
+        wget https://github.com/GluuFederation/flex/releases/download/vreplace-flex-version/flex_replace-flex-version-stable.bundle -P /tmp
         ```
 
     - Verify the signature:


### PR DESCRIPTION
## Summary

`build-docs.yml`'s **stable** branch still ran `s/replace-janssen-version/${LATEST:1}/` — copied from jans — so flex's `replace-flex-version` doc placeholders were never substituted with the tag on a release (they stayed literal). Point it at `replace-flex-version`; the same sed also covers `replace-flex-version-stable` (via the prefix → `<ver>-stable`) and `vreplace-flex-version` (→ `v<ver>`).

Also fixed a stray `vreplace-janssen-version` in `docs/install/vm-install/suse.md` — it's a `GluuFederation/flex` release-download URL, so it should be `vreplace-flex-version`.

Verified with `LATEST=v6.2.0`: `--version=replace-flex-version` → `--version=6.2.0`, and `.../vreplace-flex-version/flex_replace-flex-version-stable.bundle` → `.../v6.2.0/flex_6.2.0-stable.bundle`. No `replace-janssen-version` remains in flex docs.
