### PR TITLE
ci(docker): build on unified release tags + wait for dep images like jans

### DIFF
--- a/.github/workflows/docker_build_image.yml
+++ b/.github/workflows/docker_build_image.yml
@@ -38,6 +38,7 @@ jobs:
     permissions:
       packages: write
       id-token: write
+      actions: read   # the all-in-one step polls sibling job conclusions via the API
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 8
@@ -94,6 +95,8 @@ jobs:
       - name: Prepare
         if: steps.build_docker_image.outputs.build || github.event_name == 'tags'
         id: prep
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
           MAIN_VERSION=$(python3 -c "from dockerfile_parse import DockerfileParser ; dfparser = DockerfileParser('./docker-${{ matrix.docker-images }}') ; print(dfparser.labels['org.opencontainers.image.version'])")
@@ -106,6 +109,9 @@ jobs:
           BUILD=true
           if [[ $GITHUB_REF == refs/tags/docker-${{ matrix.docker-images }}-* ]]; then
             VERSION=${GITHUB_REF#refs/tags/docker-${{ matrix.docker-images }}-v}
+          elif [[ $GITHUB_REF == refs/tags/v* ]]; then
+            # Unified release tag (e.g. v6.2.0): build every image at its Dockerfile version.
+            VERSION=${MAIN_VERSION}
           elif [[ $GITHUB_REF == refs/tags/* ]]; then
             echo "A tag not matching the image triggered the build. I will not continue."
             BUILD=""
@@ -135,27 +141,29 @@ jobs:
           fi
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
           echo "build=${BUILD}" >> $GITHUB_OUTPUT
-          if [[ "flex-all-in-one" =~ "${{ matrix.docker-images }}" ]]; then
-            echo "Waiting for all images to be built before building the all-in-one image"
-            TEMP_IMG="admin-ui persistence-loader"
-            for img in $TEMP_IMG; do
-              max_retries=30
-              retry_count=0
-              while true; do
-                echo "Attempting to pull $img image"
-                if docker pull ghcr.io/$REPOSITORY/$img:$VERSION; then
-                  echo "$img image pulled successfully"
-                  break
-                else
-                  retry_count=$((retry_count + 1))
-                  if [ $retry_count -ge $max_retries ]; then
-                    echo "Failed to pull $img image after $max_retries attempts"
-                    exit 1
-                  fi
-                  echo "Failed to pull $img image, retrying in 20 seconds (attempt $retry_count/$max_retries)"
-                  sleep 20
+          # flex-all-in-one is built on top of admin-ui + persistence-loader, so it must wait for
+          # those matrix jobs to finish publishing first -- poll their conclusions and fail fast if
+          # one failed (more reliable than polling the registry for an image that may never appear).
+          if [[ "${{ matrix.docker-images }}" == "flex-all-in-one" && "${{ github.event_name }}" != "pull_request" ]]; then
+            REQUIRED_IMAGES="admin-ui persistence-loader"
+            for img in $REQUIRED_IMAGES; do
+              echo "Waiting for docker ($img) to complete..."
+              CONCLUSION=""
+              for attempt in $(seq 1 60); do
+                CONCLUSION=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
+                  --paginate --jq ".jobs[] | select(.name == \"docker ($img)\") | .conclusion" 2>/dev/null || echo "")
+                if [[ "$CONCLUSION" == "success" || "$CONCLUSION" == "skipped" ]]; then
+                  echo "  docker ($img): $CONCLUSION"; break
+                elif [[ "$CONCLUSION" == "failure" || "$CONCLUSION" == "cancelled" || "$CONCLUSION" == "timed_out" ]]; then
+                  echo "  docker ($img) failed with: $CONCLUSION. Aborting all-in-one build."
+                  exit 1
                 fi
+                sleep 30
               done
+              if [[ "$CONCLUSION" != "success" && "$CONCLUSION" != "skipped" ]]; then
+                echo "  docker ($img) timed out waiting. Aborting all-in-one build."
+                exit 1
+              fi
             done
           fi
 


### PR DESCRIPTION
## Summary

Fixes the docker publish on a tag release — the run that went green but built/published nothing ([28161595588](https://github.com/GluuFederation/flex/actions/runs/28161595588)).

**1. Build on the unified `v*` release tag.** `Prepare` only proceeded for per-image `docker-<img>-v*` tags; a unified `v6.2.0` tag hit the catch-all `elif refs/tags/* → BUILD=""`, so `prep.outputs.build` was empty and the build/push steps were skipped (the job still reported success). Added a `refs/tags/v*` case that builds every image at its Dockerfile version — the OCI `image.version` label (`6.2.0-1`).

**2. flex-all-in-one waits for its dependency images, like jans.** Replaced the `docker pull` poll with jans's mechanism: poll the sibling matrix jobs' conclusions (`docker (admin-ui)`, `docker (persistence-loader)`) via `gh api .../jobs` — proceed on `success`/`skipped`, **fail fast** if a dependency job fails/cancels/times out. Added `actions: read` + `GH_TOKEN` so the poll can read job status.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image build handling for unified release tags, so versioned Docker images are tagged more consistently.
  * Made multi-image build coordination more reliable by waiting for related builds to finish before continuing, reducing failed or incomplete image releases.
  * Added safer build permissions and token handling to support the updated release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->