### PR TITLE
feat(admin-ui): add test files for all hooks across the system (#2895)

### DIFF
--- a/admin-ui/app/routes/Apps/Profile/hooks/__tests__/useProfileDetails.test.tsx
+++ b/admin-ui/app/routes/Apps/Profile/hooks/__tests__/useProfileDetails.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react'
+import { renderHook, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import { useProfileDetails } from '../useProfileDetails'
+import type { LogAuditParams } from 'Utils/AuditLogger'
+import type { ProfileDetails } from '../../types'
+
+type RawUser = {
+  displayName?: string
+  givenName?: string
+  mail?: string
+  status?: string
+  inum?: string
+  customAttributes?: Array<{ name?: string; values?: Array<string | number> }>
+}
+
+type SelectFn = (user: RawUser) => ProfileDetails
+
+type QueryOptions = {
+  enabled?: boolean
+  select?: SelectFn
+}
+
+const mockUseGetUserByInum = jest.fn()
+const mockLogAuditUserAction = jest.fn()
+
+jest.mock('JansConfigApi', () => ({
+  useGetUserByInum: (inum: string, opts: { query: QueryOptions }) =>
+    mockUseGetUserByInum(inum, opts),
+}))
+
+jest.mock('@/utils/AuditLogger', () => ({
+  logAuditUserAction: (params: LogAuditParams) => mockLogAuditUserAction(params),
+}))
+
+const sampleUser: RawUser = {
+  displayName: 'Jane Doe',
+  givenName: 'Jane',
+  mail: 'jane@example.com',
+  status: 'active',
+  inum: 'inum-123',
+  customAttributes: [
+    { name: 'sn', values: ['Doe'] },
+    { name: 'jansAdminUIRole', values: ['admin', 'manager'] },
+  ],
+}
+
+const buildStore = () =>
+  configureStore({
+    reducer: combineReducers({
+      authReducer: (
+        state = { userinfo: { inum: 'a-1', name: 'admin' }, config: { clientId: 'client-1' } },
+      ) => state,
+    }),
+  })
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>{children}</Provider>
+    </QueryClientProvider>
+  )
+  return Wrapper
+}
+
+// Helper that mimics how React Query applies the `select` transform to raw data.
+const mockQueryReturn = (raw: RawUser | undefined, loading = false) => {
+  mockUseGetUserByInum.mockImplementation((_inum: string, opts: { query: QueryOptions }) => {
+    const selected = raw !== undefined && opts.query.select ? opts.query.select(raw) : raw
+    return { data: selected, isLoading: loading }
+  })
+}
+
+describe('useProfileDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLogAuditUserAction.mockResolvedValue(undefined)
+  })
+
+  it('transforms the raw user into profile details', () => {
+    mockQueryReturn(sampleUser)
+    const store = buildStore()
+    const { result } = renderHook(() => useProfileDetails('inum-123', true), {
+      wrapper: createWrapper(store),
+    })
+
+    expect(result.current.profileDetails?.displayName).toBe('Jane Doe')
+    expect(result.current.profileDetails?.mail).toBe('jane@example.com')
+    expect(result.current.profileDetails?.customAttributes).toHaveLength(2)
+  })
+
+  it('derives the surname from the "sn" attribute', () => {
+    mockQueryReturn(sampleUser)
+    const store = buildStore()
+    const { result } = renderHook(() => useProfileDetails('inum-123', true), {
+      wrapper: createWrapper(store),
+    })
+
+    expect(result.current.surname).toBe('Doe')
+  })
+
+  it('capitalizes and joins role values', () => {
+    mockQueryReturn(sampleUser)
+    const store = buildStore()
+    const { result } = renderHook(() => useProfileDetails('inum-123', true), {
+      wrapper: createWrapper(store),
+    })
+
+    expect(result.current.roles).toBe('Admin, Manager')
+  })
+
+  it('returns "-" for roles when none are present', () => {
+    mockQueryReturn({ ...sampleUser, customAttributes: [{ name: 'sn', values: ['Doe'] }] })
+    const store = buildStore()
+    const { result } = renderHook(() => useProfileDetails('inum-123', true), {
+      wrapper: createWrapper(store),
+    })
+
+    expect(result.current.roles).toBe('-')
+  })
+
+  it('passes enabled=false to the query when no inum is provided', () => {
+    mockQueryReturn(undefined)
+    const store = buildStore()
+    renderHook(() => useProfileDetails(undefined, true), { wrapper: createWrapper(store) })
+
+    const [, opts] = mockUseGetUserByInum.mock.calls[0]
+    expect(opts.query.enabled).toBe(false)
+  })
+
+  it('reflects the loading state from the query', () => {
+    mockQueryReturn(undefined, true)
+    const store = buildStore()
+    const { result } = renderHook(() => useProfileDetails('inum-123', true), {
+      wrapper: createWrapper(store),
+    })
+
+    expect(result.current.loading).toBe(true)
+  })
+
+  it('logs an audit action once details are available', async () => {
+    mockQueryReturn(sampleUser)
+    const store = buildStore()
+    renderHook(() => useProfileDetails('inum-123', true), { wrapper: createWrapper(store) })
+
+    await waitFor(() => {
+      expect(mockLogAuditUserAction).toHaveBeenCalledTimes(1)
+    })
+    expect(mockLogAuditUserAction.mock.calls[0][0]).toMatchObject({
+      payload: { pattern: 'inum-123' },
+    })
+  })
+
+  it('does not log an audit action when there are no profile details', () => {
+    mockQueryReturn(undefined)
+    const store = buildStore()
+    renderHook(() => useProfileDetails('inum-123', true), { wrapper: createWrapper(store) })
+
+    expect(mockLogAuditUserAction).not.toHaveBeenCalled()
+  })
+})

--- a/admin-ui/app/routes/Apps/Profile/hooks/__tests__/useProfileDetails.test.tsx
+++ b/admin-ui/app/routes/Apps/Profile/hooks/__tests__/useProfileDetails.test.tsx
@@ -131,6 +131,15 @@ describe('useProfileDetails', () => {
     expect(opts.query.enabled).toBe(false)
   })
 
+  it('passes enabled=false to the query when disabled despite a valid inum', () => {
+    mockQueryReturn(sampleUser)
+    const store = buildStore()
+    renderHook(() => useProfileDetails('inum-123', false), { wrapper: createWrapper(store) })
+
+    const [, opts] = mockUseGetUserByInum.mock.calls[0]
+    expect(opts.query.enabled).toBe(false)
+  })
+
   it('reflects the loading state from the query', () => {
     mockQueryReturn(undefined, true)
     const store = buildStore()

--- a/admin-ui/app/routes/Dashboards/hooks/__tests__/useDashboardLockStats.test.tsx
+++ b/admin-ui/app/routes/Dashboards/hooks/__tests__/useDashboardLockStats.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react'
+import { renderHook } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import { useDashboardLockStats } from '../useDashboardLockStats'
+import type { LockStatEntry } from '../../types'
+
+type SelectFn = (data: LockStatEntry[] | undefined) => LockStatEntry[]
+
+type QueryOptions = {
+  enabled?: boolean
+  select?: SelectFn
+  retry?: boolean
+}
+
+const mockUseGetLockStat = jest.fn()
+
+jest.mock('JansConfigApi', () => ({
+  useGetLockStat: (params: undefined, opts: { query: QueryOptions }) =>
+    mockUseGetLockStat(params, opts),
+}))
+
+const buildStore = (hasSession = true) =>
+  configureStore({
+    reducer: combineReducers({
+      authReducer: (state = { hasSession }) => state,
+    }),
+  })
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>{children}</Provider>
+    </QueryClientProvider>
+  )
+  return Wrapper
+}
+
+// Applies the hook-provided `select` transform to raw data, the way React Query would.
+const mockQueryReturn = (raw: LockStatEntry[] | undefined) => {
+  mockUseGetLockStat.mockImplementation((_params: undefined, opts: { query: QueryOptions }) => {
+    const data = opts.query.select ? opts.query.select(raw) : raw
+    return { data, isLoading: false, isError: false }
+  })
+}
+
+describe('useDashboardLockStats', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns an empty data array and zeroed stats when there is no data', () => {
+    mockQueryReturn(undefined)
+    const store = buildStore(true)
+    const { result } = renderHook(() => useDashboardLockStats(), {
+      wrapper: createWrapper(store),
+    })
+
+    expect(result.current.data).toHaveLength(0)
+    expect(result.current.latestStats).toEqual({
+      monthly_active_users: 0,
+      monthly_active_clients: 0,
+    })
+  })
+
+  it('returns the single entry values directly', () => {
+    mockQueryReturn([{ monthly_active_users: 10, monthly_active_clients: 5, month: '2026-01' }])
+    const store = buildStore(true)
+    const { result } = renderHook(() => useDashboardLockStats(), {
+      wrapper: createWrapper(store),
+    })
+
+    expect(result.current.data).toHaveLength(1)
+    expect(result.current.latestStats).toEqual({
+      monthly_active_users: 10,
+      monthly_active_clients: 5,
+    })
+  })
+
+  it('sums values across multiple entries', () => {
+    mockQueryReturn([
+      { monthly_active_users: 10, monthly_active_clients: 5, month: '2026-01' },
+      { monthly_active_users: 20, monthly_active_clients: 15, month: '2026-02' },
+    ])
+    const store = buildStore(true)
+    const { result } = renderHook(() => useDashboardLockStats(), {
+      wrapper: createWrapper(store),
+    })
+
+    expect(result.current.latestStats).toEqual({
+      monthly_active_users: 30,
+      monthly_active_clients: 20,
+    })
+  })
+
+  it('treats missing numeric fields as zero when summing', () => {
+    mockQueryReturn([
+      { monthly_active_users: 7, month: '2026-01' },
+      { monthly_active_clients: 3, month: '2026-02' },
+    ])
+    const store = buildStore(true)
+    const { result } = renderHook(() => useDashboardLockStats(), {
+      wrapper: createWrapper(store),
+    })
+
+    expect(result.current.latestStats).toEqual({
+      monthly_active_users: 7,
+      monthly_active_clients: 3,
+    })
+  })
+
+  it('enables the query only when there is a session and enabled is true', () => {
+    mockQueryReturn(undefined)
+    const store = buildStore(true)
+    renderHook(() => useDashboardLockStats(), { wrapper: createWrapper(store) })
+
+    const [, opts] = mockUseGetLockStat.mock.calls[0]
+    expect(opts.query.enabled).toBe(true)
+    expect(opts.query.retry).toBe(false)
+  })
+
+  it('disables the query when there is no session', () => {
+    mockQueryReturn(undefined)
+    const store = buildStore(false)
+    renderHook(() => useDashboardLockStats(), { wrapper: createWrapper(store) })
+
+    const [, opts] = mockUseGetLockStat.mock.calls[0]
+    expect(opts.query.enabled).toBe(false)
+  })
+
+  it('disables the query when the enabled option is false', () => {
+    mockQueryReturn(undefined)
+    const store = buildStore(true)
+    renderHook(() => useDashboardLockStats({ enabled: false }), {
+      wrapper: createWrapper(store),
+    })
+
+    const [, opts] = mockUseGetLockStat.mock.calls[0]
+    expect(opts.query.enabled).toBe(false)
+  })
+})

--- a/admin-ui/app/routes/License/hooks/__tests__/useLicenseDetails.test.tsx
+++ b/admin-ui/app/routes/License/hooks/__tests__/useLicenseDetails.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
 import { useLicenseDetails } from '../useLicenseDetails'
 import type { LicenseResponse } from 'JansConfigApi'
+import type { UserActionPayload } from '@/redux/api/types/BackendApi'
 
 type SelectFn = (data: LicenseResponse | undefined) => LicenseResponse | undefined
 
@@ -13,14 +14,36 @@ type QueryOptions = {
   select?: SelectFn
 }
 
+type DeleteMutationOptions = {
+  mutation?: {
+    onSuccess?: () => void | Promise<void>
+    onError?: (error: Error) => void
+  }
+}
+
 const mockUseGetAdminuiLicense = jest.fn()
 const mockMutate = jest.fn()
 const mockRefetch = jest.fn()
+const mockPostUserAction = jest.fn()
+const mockIsFourZeroThreeError = jest.fn()
+
+let capturedDeleteOptions: DeleteMutationOptions | undefined
 
 jest.mock('JansConfigApi', () => ({
   useGetAdminuiLicense: (opts: { query: QueryOptions }) => mockUseGetAdminuiLicense(opts),
-  useLicenseConfigDelete: () => ({ mutate: mockMutate, isPending: false }),
+  useLicenseConfigDelete: (opts: DeleteMutationOptions) => {
+    capturedDeleteOptions = opts
+    return { mutate: mockMutate, isPending: false }
+  },
   getGetAdminuiLicenseQueryKey: () => ['adminui', 'license'],
+}))
+
+jest.mock('@/redux/api/backend-api', () => ({
+  postUserAction: (userAction: UserActionPayload) => mockPostUserAction(userAction),
+}))
+
+jest.mock('@/utils/TokenController', () => ({
+  isFourZeroThreeError: (error: Error) => mockIsFourZeroThreeError(error),
 }))
 
 jest.mock('react-i18next', () => ({
@@ -62,6 +85,9 @@ const mockQueryReturn = (raw: LicenseResponse | undefined, isLoading = false) =>
 describe('useLicenseDetails', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    capturedDeleteOptions = undefined
+    mockIsFourZeroThreeError.mockReturnValue(false)
+    mockPostUserAction.mockResolvedValue({ status: 200 })
   })
 
   it('strips surrounding quotes from the license fields', () => {
@@ -112,6 +138,79 @@ describe('useLicenseDetails', () => {
     })
 
     expect(mockMutate).toHaveBeenCalledTimes(1)
+  })
+
+  it('invalidates the license query and toasts success on a successful reset', async () => {
+    const invalidateSpy = jest
+      .spyOn(QueryClient.prototype, 'invalidateQueries')
+      .mockResolvedValue(undefined)
+    const onResetSuccess = jest.fn()
+    mockQueryReturn(rawLicense)
+    const store = buildStore(true)
+    const dispatchSpy = jest.spyOn(store, 'dispatch')
+    renderHook(() => useLicenseDetails({ onResetSuccess }), { wrapper: createWrapper(store) })
+
+    await act(async () => {
+      await capturedDeleteOptions?.mutation?.onSuccess?.()
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['adminui', 'license'] })
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'toast/updateToast',
+        payload: expect.objectContaining({
+          showToast: true,
+          type: 'success',
+          message: 'messages.license_reset_success',
+        }),
+      }),
+    )
+    expect(onResetSuccess).toHaveBeenCalledTimes(1)
+
+    invalidateSpy.mockRestore()
+  })
+
+  it('toasts an error with the error message on a non-403 reset failure', () => {
+    mockIsFourZeroThreeError.mockReturnValue(false)
+    mockQueryReturn(rawLicense)
+    const store = buildStore(true)
+    const dispatchSpy = jest.spyOn(store, 'dispatch')
+    renderHook(() => useLicenseDetails(), { wrapper: createWrapper(store) })
+
+    act(() => {
+      capturedDeleteOptions?.mutation?.onError?.(new Error('boom'))
+    })
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'toast/updateToast',
+        payload: expect.objectContaining({
+          showToast: true,
+          type: 'error',
+          message: 'boom',
+        }),
+      }),
+    )
+  })
+
+  it('dispatches a session-expired logout audit on a 403 reset failure', () => {
+    mockIsFourZeroThreeError.mockReturnValue(true)
+    mockQueryReturn(rawLicense)
+    const store = buildStore(true)
+    const dispatchSpy = jest.spyOn(store, 'dispatch')
+    renderHook(() => useLicenseDetails(), { wrapper: createWrapper(store) })
+
+    act(() => {
+      capturedDeleteOptions?.mutation?.onError?.(new Error('forbidden'))
+    })
+
+    const dispatchedTypes = dispatchSpy.mock.calls.map(([action]) =>
+      typeof action === 'object' && action !== null && 'type' in action ? action.type : undefined,
+    )
+    expect(dispatchedTypes).toContain('session/auditLogoutLogs')
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'toast/updateToast' }),
+    )
   })
 
   it('disables the query when there is no session', () => {

--- a/admin-ui/app/routes/License/hooks/__tests__/useLicenseDetails.test.tsx
+++ b/admin-ui/app/routes/License/hooks/__tests__/useLicenseDetails.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import { useLicenseDetails } from '../useLicenseDetails'
+import type { LicenseResponse } from 'JansConfigApi'
+
+type SelectFn = (data: LicenseResponse | undefined) => LicenseResponse | undefined
+
+type QueryOptions = {
+  enabled?: boolean
+  select?: SelectFn
+}
+
+const mockUseGetAdminuiLicense = jest.fn()
+const mockMutate = jest.fn()
+const mockRefetch = jest.fn()
+
+jest.mock('JansConfigApi', () => ({
+  useGetAdminuiLicense: (opts: { query: QueryOptions }) => mockUseGetAdminuiLicense(opts),
+  useLicenseConfigDelete: () => ({ mutate: mockMutate, isPending: false }),
+  getGetAdminuiLicenseQueryKey: () => ['adminui', 'license'],
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const rawLicense: LicenseResponse = {
+  companyName: '"Acme Corp"',
+  customerFirstName: '"Jane"',
+  customerLastName: '"Doe"',
+  customerEmail: '"jane@example.com"',
+}
+
+const buildStore = (hasSession = true) =>
+  configureStore({
+    reducer: combineReducers({
+      authReducer: (state = { hasSession, userinfo: { inum: 'a-1', name: 'admin' } }) => state,
+      toastReducer: (state = { showToast: false }) => state,
+    }),
+  })
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>{children}</Provider>
+    </QueryClientProvider>
+  )
+  return Wrapper
+}
+
+const mockQueryReturn = (raw: LicenseResponse | undefined, isLoading = false) => {
+  mockUseGetAdminuiLicense.mockImplementation((opts: { query: QueryOptions }) => {
+    const data = raw !== undefined && opts.query.select ? opts.query.select(raw) : raw
+    return { data, isLoading, refetch: mockRefetch }
+  })
+}
+
+describe('useLicenseDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('strips surrounding quotes from the license fields', () => {
+    mockQueryReturn(rawLicense)
+    const store = buildStore(true)
+    const { result } = renderHook(() => useLicenseDetails(), { wrapper: createWrapper(store) })
+
+    expect(result.current.item.companyName).toBe('Acme Corp')
+    expect(result.current.item.customerFirstName).toBe('Jane')
+    expect(result.current.item.customerLastName).toBe('Doe')
+    expect(result.current.item.customerEmail).toBe('jane@example.com')
+  })
+
+  it('falls back to an empty item when there is no data', () => {
+    mockQueryReturn(undefined)
+    const store = buildStore(true)
+    const { result } = renderHook(() => useLicenseDetails(), { wrapper: createWrapper(store) })
+
+    expect(result.current.item).toEqual({})
+  })
+
+  it('exposes the shared query key, refetch and reset helpers', () => {
+    mockQueryReturn(rawLicense)
+    const store = buildStore(true)
+    const { result } = renderHook(() => useLicenseDetails(), { wrapper: createWrapper(store) })
+
+    expect(result.current.queryKey).toEqual(['adminui', 'license'])
+    expect(result.current.refetch).toBe(mockRefetch)
+    expect(typeof result.current.resetLicense).toBe('function')
+    expect(result.current.isResetting).toBe(false)
+  })
+
+  it('reflects the query loading state', () => {
+    mockQueryReturn(undefined, true)
+    const store = buildStore(true)
+    const { result } = renderHook(() => useLicenseDetails(), { wrapper: createWrapper(store) })
+
+    expect(result.current.loading).toBe(true)
+  })
+
+  it('triggers the delete mutation when resetLicense is called', () => {
+    mockQueryReturn(rawLicense)
+    const store = buildStore(true)
+    const { result } = renderHook(() => useLicenseDetails(), { wrapper: createWrapper(store) })
+
+    act(() => {
+      result.current.resetLicense('reset reason')
+    })
+
+    expect(mockMutate).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the query when there is no session', () => {
+    mockQueryReturn(undefined)
+    const store = buildStore(false)
+    renderHook(() => useLicenseDetails(), { wrapper: createWrapper(store) })
+
+    const [opts] = mockUseGetAdminuiLicense.mock.calls[0]
+    expect(opts.query.enabled).toBe(false)
+  })
+})

--- a/admin-ui/app/utils/hooks/__tests__/useDebounce.test.ts
+++ b/admin-ui/app/utils/hooks/__tests__/useDebounce.test.ts
@@ -1,0 +1,75 @@
+import { renderHook, act } from '@testing-library/react'
+import { useDebounce } from '@/utils/hooks/useDebounce'
+
+describe('useDebounce', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('returns the initial value immediately', () => {
+    const { result } = renderHook(() => useDebounce('initial', 500))
+    expect(result.current).toBe('initial')
+  })
+
+  it('does not update before the delay elapses', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 500), {
+      initialProps: { value: 'a' },
+    })
+
+    rerender({ value: 'b' })
+    act(() => {
+      jest.advanceTimersByTime(499)
+    })
+    expect(result.current).toBe('a')
+  })
+
+  it('updates to the latest value once the delay elapses', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 500), {
+      initialProps: { value: 'a' },
+    })
+
+    rerender({ value: 'b' })
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
+    expect(result.current).toBe('b')
+  })
+
+  it('resets the timer when the value changes again before the delay', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 500), {
+      initialProps: { value: 'a' },
+    })
+
+    rerender({ value: 'b' })
+    act(() => {
+      jest.advanceTimersByTime(300)
+    })
+    // Change again before the first debounce fires — timer restarts.
+    rerender({ value: 'c' })
+    act(() => {
+      jest.advanceTimersByTime(300)
+    })
+    expect(result.current).toBe('a')
+
+    act(() => {
+      jest.advanceTimersByTime(200)
+    })
+    expect(result.current).toBe('c')
+  })
+
+  it('works with non-string values', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 200), {
+      initialProps: { value: 1 },
+    })
+
+    rerender({ value: 2 })
+    act(() => {
+      jest.advanceTimersByTime(200)
+    })
+    expect(result.current).toBe(2)
+  })
+})

--- a/admin-ui/app/utils/hooks/__tests__/useFirstAuthorizedPath.test.tsx
+++ b/admin-ui/app/utils/hooks/__tests__/useFirstAuthorizedPath.test.tsx
@@ -115,10 +115,7 @@ describe('useFirstAuthorizedPath', () => {
     await waitFor(() => {
       expect(result.current.loading).toBe(false)
     })
-    expect(mockFilterMenusByHealth).toHaveBeenCalledWith(
-      menus,
-      expect.arrayContaining([fido2]),
-    )
+    expect(mockFilterMenusByHealth).toHaveBeenCalledWith(menus, expect.arrayContaining([fido2]))
   })
 
   it('returns a null path when no leaf path can be resolved', async () => {

--- a/admin-ui/app/utils/hooks/__tests__/useFirstAuthorizedPath.test.tsx
+++ b/admin-ui/app/utils/hooks/__tests__/useFirstAuthorizedPath.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import { renderHook, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import { useFirstAuthorizedPath } from '../useFirstAuthorizedPath'
+import type { MenuItem } from '@/components/Sidebar'
+
+type HealthService = { name: string; status?: string }
+
+const mockAuthorizeHelper = jest.fn()
+const mockUseHealthStatus = jest.fn()
+const mockUseFido2HealthStatus = jest.fn()
+const mockProcessMenus = jest.fn()
+const mockFilterMenusByHealth = jest.fn()
+const mockFilterMenusByAuth = jest.fn()
+const mockFindFirstLeafPath = jest.fn()
+
+jest.mock('@/cedarling/hooks/useCedarling', () => ({
+  useCedarling: () => ({ authorizeHelper: mockAuthorizeHelper }),
+}))
+
+jest.mock('Plugins/admin/components/Health/hooks', () => ({
+  useHealthStatus: () => mockUseHealthStatus(),
+  useFido2HealthStatus: () => mockUseFido2HealthStatus(),
+}))
+
+jest.mock('Plugins/PluginMenuResolver', () => ({
+  processMenus: () => mockProcessMenus(),
+}))
+
+jest.mock('@/utils/menuFilters', () => ({
+  filterMenusByHealth: (menus: MenuItem[], services: HealthService[]) =>
+    mockFilterMenusByHealth(menus, services),
+  filterMenusByAuth: (menus: MenuItem[], helper: typeof mockAuthorizeHelper) =>
+    mockFilterMenusByAuth(menus, helper),
+  findFirstLeafPath: (menus: MenuItem[]) => mockFindFirstLeafPath(menus),
+}))
+
+const buildStore = (initialized = true) =>
+  configureStore({
+    reducer: combineReducers({
+      cedarPermissions: (state = { initialized }) => state,
+    }),
+  })
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  )
+  return Wrapper
+}
+
+const menus: MenuItem[] = [{ title: 'Home', path: '/home' }]
+
+describe('useFirstAuthorizedPath', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseHealthStatus.mockReturnValue({ allServices: [{ name: 'oxauth', status: 'up' }] })
+    mockUseFido2HealthStatus.mockReturnValue({ data: undefined })
+    mockProcessMenus.mockResolvedValue(menus)
+    mockFilterMenusByHealth.mockImplementation((m: MenuItem[]) => m)
+    mockFilterMenusByAuth.mockResolvedValue(menus)
+    mockFindFirstLeafPath.mockReturnValue('/home')
+  })
+
+  it('starts in a loading state with a null path', () => {
+    const store = buildStore(false)
+    const { result } = renderHook(() => useFirstAuthorizedPath(), {
+      wrapper: createWrapper(store),
+    })
+
+    expect(result.current.loading).toBe(true)
+    expect(result.current.path).toBeNull()
+  })
+
+  it('resolves the first authorized leaf path once initialized and services are ready', async () => {
+    const store = buildStore(true)
+    const { result } = renderHook(() => useFirstAuthorizedPath(), {
+      wrapper: createWrapper(store),
+    })
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+    expect(result.current.path).toBe('/home')
+    expect(mockFilterMenusByAuth).toHaveBeenCalledWith(menus, mockAuthorizeHelper)
+  })
+
+  it('does not resolve while cedar permissions are not initialized', async () => {
+    const store = buildStore(false)
+    renderHook(() => useFirstAuthorizedPath(), { wrapper: createWrapper(store) })
+
+    await Promise.resolve()
+    expect(mockProcessMenus).not.toHaveBeenCalled()
+  })
+
+  it('does not resolve while no services are ready', async () => {
+    mockUseHealthStatus.mockReturnValue({ allServices: [] })
+    mockUseFido2HealthStatus.mockReturnValue({ data: undefined })
+    const store = buildStore(true)
+    renderHook(() => useFirstAuthorizedPath(), { wrapper: createWrapper(store) })
+
+    await Promise.resolve()
+    expect(mockProcessMenus).not.toHaveBeenCalled()
+  })
+
+  it('includes fido2 health data in the combined services passed to the health filter', async () => {
+    const fido2 = { name: 'fido2', status: 'up' }
+    mockUseFido2HealthStatus.mockReturnValue({ data: fido2 })
+    const store = buildStore(true)
+    const { result } = renderHook(() => useFirstAuthorizedPath(), {
+      wrapper: createWrapper(store),
+    })
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+    expect(mockFilterMenusByHealth).toHaveBeenCalledWith(
+      menus,
+      expect.arrayContaining([fido2]),
+    )
+  })
+
+  it('returns a null path when no leaf path can be resolved', async () => {
+    mockFindFirstLeafPath.mockReturnValue(null)
+    const store = buildStore(true)
+    const { result } = renderHook(() => useFirstAuthorizedPath(), {
+      wrapper: createWrapper(store),
+    })
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+    expect(result.current.path).toBeNull()
+  })
+})

--- a/admin-ui/app/utils/hooks/__tests__/useWebhookDialogAction.test.tsx
+++ b/admin-ui/app/utils/hooks/__tests__/useWebhookDialogAction.test.tsx
@@ -1,0 +1,206 @@
+import React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import useWebhookDialogAction from '../useWebhookDialogAction'
+
+type WebhookEntry = { inum?: string; displayName?: string; jansEnabled?: boolean }
+
+type QueryOptions = {
+  enabled?: boolean
+  refetchOnWindowFocus?: boolean
+  staleTime?: number
+}
+
+const mockHasCedarReadPermission = jest.fn()
+const mockAuthorizeHelper = jest.fn()
+const mockUseGetWebhooksByFeatureId = jest.fn()
+
+jest.mock('@/cedarling/hooks/useCedarling', () => ({
+  useCedarling: () => ({
+    hasCedarReadPermission: (id: string) => mockHasCedarReadPermission(id),
+    authorizeHelper: mockAuthorizeHelper,
+  }),
+}))
+
+jest.mock('@/context/theme/themeContext', () => ({
+  useTheme: () => ({ state: { theme: 'light' } }),
+}))
+
+jest.mock('@/context/theme/config', () => ({
+  __esModule: true,
+  default: () => ({
+    fontColor: '#000',
+    borderColor: '#ccc',
+    badges: { statusActive: '#0f0', filledBadgeText: '#fff' },
+  }),
+}))
+
+jest.mock('@/routes/Apps/Gluu/styles/GluuCommitDialog.style', () => ({
+  useStyles: () => ({ classes: {} }),
+}))
+
+jest.mock('@/utils/styles/WebhookTriggerModal.style', () => ({
+  useWebhookTriggerModalStyles: () => ({ classes: {} }),
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+jest.mock('JansConfigApi', () => ({
+  useGetWebhooksByFeatureId: (feature: string, opts: { query: QueryOptions }) =>
+    mockUseGetWebhooksByFeatureId(feature, opts),
+}))
+
+const buildStore = () =>
+  configureStore({
+    reducer: combineReducers({
+      webhookReducer: (
+        state = { webhookModal: false, triggerWebhookInProgress: false },
+      ) => state,
+    }),
+  })
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>{children}</Provider>
+    </QueryClientProvider>
+  )
+  return Wrapper
+}
+
+const mockQueryReturn = (
+  data: WebhookEntry[] | undefined,
+  { isFetching = false, isFetched = true } = {},
+) => {
+  mockUseGetWebhooksByFeatureId.mockReturnValue({
+    data,
+    isFetching,
+    isFetched,
+  })
+}
+
+describe('useWebhookDialogAction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockHasCedarReadPermission.mockReturnValue(true)
+    mockQueryReturn([{ inum: 'wh-1', displayName: 'Hook 1', jansEnabled: true }])
+  })
+
+  it('returns the expected action shape', () => {
+    const store = buildStore()
+    const { result } = renderHook(() => useWebhookDialogAction({ feature: 'feat-1', modal: true }), {
+      wrapper: createWrapper(store),
+    })
+
+    expect(typeof result.current.onCloseModal).toBe('function')
+    expect(typeof result.current.webhookTriggerModal).toBe('function')
+    expect(typeof result.current.webhookCheckComplete).toBe('boolean')
+    expect(typeof result.current.willShowWebhookModal).toBe('boolean')
+    expect(result.current.isLoadingWebhooks).toBe(false)
+  })
+
+  it('dispatches reset actions when onCloseModal is called', () => {
+    const store = buildStore()
+    const dispatchSpy = jest.spyOn(store, 'dispatch')
+    const { result } = renderHook(() => useWebhookDialogAction({ feature: 'feat-1', modal: true }), {
+      wrapper: createWrapper(store),
+    })
+
+    dispatchSpy.mockClear()
+    act(() => {
+      result.current.onCloseModal()
+    })
+
+    const types = dispatchSpy.mock.calls.map((call) => (call[0] as { type: string }).type)
+    expect(types).toContain('webhook/setWebhookModal')
+    expect(types).toContain('webhook/completeTriggerWebhook')
+    expect(types).toContain('webhook/setWebhookTriggerResults')
+    expect(types).toContain('webhook/setFeatureToTrigger')
+  })
+
+  it('calls authorizeHelper for the webhook scopes', () => {
+    const store = buildStore()
+    renderHook(() => useWebhookDialogAction({ feature: 'feat-1', modal: true }), {
+      wrapper: createWrapper(store),
+    })
+
+    expect(mockAuthorizeHelper).toHaveBeenCalled()
+  })
+
+  it('enables the webhooks query when permitted, modal open, and feature present', () => {
+    const store = buildStore()
+    renderHook(() => useWebhookDialogAction({ feature: 'feat-1', modal: true }), {
+      wrapper: createWrapper(store),
+    })
+
+    const [feature, opts] = mockUseGetWebhooksByFeatureId.mock.calls[0]
+    expect(feature).toBe('feat-1')
+    expect(opts.query.enabled).toBe(true)
+  })
+
+  it('disables the webhooks query when read permission is denied', () => {
+    mockHasCedarReadPermission.mockReturnValue(false)
+    const store = buildStore()
+    renderHook(() => useWebhookDialogAction({ feature: 'feat-1', modal: true }), {
+      wrapper: createWrapper(store),
+    })
+
+    const [, opts] = mockUseGetWebhooksByFeatureId.mock.calls[0]
+    expect(opts.query.enabled).toBe(false)
+  })
+
+  it('flags willShowWebhookModal when enabled webhooks exist and read is permitted', () => {
+    const store = buildStore()
+    const { result } = renderHook(
+      () => useWebhookDialogAction({ feature: 'feat-1', modal: true }),
+      { wrapper: createWrapper(store) },
+    )
+
+    expect(result.current.willShowWebhookModal).toBe(true)
+  })
+
+  it('does not flag willShowWebhookModal when there are no enabled webhooks', () => {
+    mockQueryReturn([{ inum: 'wh-1', displayName: 'Hook 1', jansEnabled: false }])
+    const store = buildStore()
+    const { result } = renderHook(
+      () => useWebhookDialogAction({ feature: 'feat-1', modal: true }),
+      { wrapper: createWrapper(store) },
+    )
+
+    expect(result.current.willShowWebhookModal).toBe(false)
+  })
+
+  it('treats the check as incomplete when the modal is closed', () => {
+    const store = buildStore()
+    const { result } = renderHook(
+      () => useWebhookDialogAction({ feature: 'feat-1', modal: false }),
+      { wrapper: createWrapper(store) },
+    )
+
+    expect(result.current.webhookCheckComplete).toBe(false)
+  })
+
+  it('completes the check immediately when there is no feature', () => {
+    const store = buildStore()
+    const { result } = renderHook(() => useWebhookDialogAction({ modal: true }), {
+      wrapper: createWrapper(store),
+    })
+
+    expect(result.current.webhookCheckComplete).toBe(true)
+  })
+
+  it('renders no portal content from webhookTriggerModal when the modal is not open', () => {
+    const store = buildStore()
+    const { result } = renderHook(() => useWebhookDialogAction({ feature: 'feat-1', modal: true }), {
+      wrapper: createWrapper(store),
+    })
+
+    const rendered = result.current.webhookTriggerModal({ closeModal: jest.fn() })
+    expect(rendered).toBeNull()
+  })
+})

--- a/admin-ui/app/utils/hooks/__tests__/useWebhookDialogAction.test.tsx
+++ b/admin-ui/app/utils/hooks/__tests__/useWebhookDialogAction.test.tsx
@@ -57,9 +57,7 @@ jest.mock('JansConfigApi', () => ({
 const buildStore = () =>
   configureStore({
     reducer: combineReducers({
-      webhookReducer: (
-        state = { webhookModal: false, triggerWebhookInProgress: false },
-      ) => state,
+      webhookReducer: (state = { webhookModal: false, triggerWebhookInProgress: false }) => state,
     }),
   })
 
@@ -93,9 +91,12 @@ describe('useWebhookDialogAction', () => {
 
   it('returns the expected action shape', () => {
     const store = buildStore()
-    const { result } = renderHook(() => useWebhookDialogAction({ feature: 'feat-1', modal: true }), {
-      wrapper: createWrapper(store),
-    })
+    const { result } = renderHook(
+      () => useWebhookDialogAction({ feature: 'feat-1', modal: true }),
+      {
+        wrapper: createWrapper(store),
+      },
+    )
 
     expect(typeof result.current.onCloseModal).toBe('function')
     expect(typeof result.current.webhookTriggerModal).toBe('function')
@@ -107,9 +108,12 @@ describe('useWebhookDialogAction', () => {
   it('dispatches reset actions when onCloseModal is called', () => {
     const store = buildStore()
     const dispatchSpy = jest.spyOn(store, 'dispatch')
-    const { result } = renderHook(() => useWebhookDialogAction({ feature: 'feat-1', modal: true }), {
-      wrapper: createWrapper(store),
-    })
+    const { result } = renderHook(
+      () => useWebhookDialogAction({ feature: 'feat-1', modal: true }),
+      {
+        wrapper: createWrapper(store),
+      },
+    )
 
     dispatchSpy.mockClear()
     act(() => {
@@ -196,9 +200,12 @@ describe('useWebhookDialogAction', () => {
 
   it('renders no portal content from webhookTriggerModal when the modal is not open', () => {
     const store = buildStore()
-    const { result } = renderHook(() => useWebhookDialogAction({ feature: 'feat-1', modal: true }), {
-      wrapper: createWrapper(store),
-    })
+    const { result } = renderHook(
+      () => useWebhookDialogAction({ feature: 'feat-1', modal: true }),
+      {
+        wrapper: createWrapper(store),
+      },
+    )
 
     const rendered = result.current.webhookTriggerModal({ closeModal: jest.fn() })
     expect(rendered).toBeNull()

--- a/admin-ui/plugins/admin/components/Assets/hooks/__tests__/useAssetAudit.test.ts
+++ b/admin-ui/plugins/admin/components/Assets/hooks/__tests__/useAssetAudit.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react'
 import { useAssetAudit } from '../useAssetAudit'
 import type { AssetAuditLogActionPayload } from '../../types'
+import type { JsonValue } from 'Routes/Apps/Gluu/types/common'
 
 const mockPostUserAction = jest.fn()
 const mockAddAdditionalData = jest.fn()
@@ -10,9 +11,15 @@ jest.mock('Redux/api/backend-api', () => ({
   postUserAction: (payload: object) => mockPostUserAction(payload),
 }))
 
+type AuditAccumulator = Record<string, JsonValue>
+
 jest.mock('Utils/TokenController', () => ({
-  addAdditionalData: (audit: object, actionType: string, resource: string, extra: object) =>
-    mockAddAdditionalData(audit, actionType, resource, extra),
+  addAdditionalData: (
+    audit: AuditAccumulator,
+    actionType: string,
+    resource: string,
+    extra: object,
+  ) => mockAddAdditionalData(audit, actionType, resource, extra),
 }))
 
 jest.mock('@/audit', () => ({
@@ -39,6 +46,15 @@ describe('useAssetAudit', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockPostUserAction.mockResolvedValue(undefined)
+    // Mirror the real addAdditionalData, which enriches the audit object in
+    // place (action type/resource/payload) before it is posted.
+    mockAddAdditionalData.mockImplementation(
+      (audit: AuditAccumulator, actionType: string, resource: string, extra: AuditAccumulator) => {
+        audit.action_type = actionType
+        audit.resource = resource
+        audit.action = extra.action
+      },
+    )
   })
 
   it('exposes initAudit and logAction functions', () => {
@@ -78,6 +94,20 @@ describe('useAssetAudit', () => {
       },
     })
     expect(mockPostUserAction).toHaveBeenCalledTimes(1)
+    // The posted object must be the audit AFTER enrichment, not the bare init.
+    expect(mockPostUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client_id: 'client-1',
+        status: 'success',
+        performedBy: { user_inum: 'inum-1', userId: 'admin' },
+        action_type: 'CREATE',
+        resource: 'asset',
+        action: {
+          action_message: 'created asset',
+          action_data: { fileName: 'logo.png', enabled: true },
+        },
+      }),
+    )
   })
 
   it('truncates long strings in action data', async () => {

--- a/admin-ui/plugins/admin/components/Assets/hooks/__tests__/useAssetAudit.test.ts
+++ b/admin-ui/plugins/admin/components/Assets/hooks/__tests__/useAssetAudit.test.ts
@@ -1,0 +1,140 @@
+import { renderHook, act } from '@testing-library/react'
+import { useAssetAudit } from '../useAssetAudit'
+import type { AssetAuditLogActionPayload } from '../../types'
+
+const mockPostUserAction = jest.fn()
+const mockAddAdditionalData = jest.fn()
+const mockLoggerError = jest.fn()
+
+jest.mock('Redux/api/backend-api', () => ({
+  postUserAction: (payload: object) => mockPostUserAction(payload),
+}))
+
+jest.mock('Utils/TokenController', () => ({
+  addAdditionalData: (audit: object, actionType: string, resource: string, extra: object) =>
+    mockAddAdditionalData(audit, actionType, resource, extra),
+}))
+
+jest.mock('@/audit', () => ({
+  useAuditContext: jest.fn(() => ({
+    client_id: 'client-1',
+    ip_address: '127.0.0.1',
+    userinfo: { inum: 'inum-1', name: 'admin' },
+  })),
+  createSuccessAuditInit: jest.fn(() => ({
+    client_id: 'client-1',
+    ip_address: '127.0.0.1',
+    status: 'success',
+    performedBy: { user_inum: 'inum-1', userId: 'admin' },
+  })),
+}))
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    error: (message: string, detail: Error | string) => mockLoggerError(message, detail),
+  },
+}))
+
+describe('useAssetAudit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPostUserAction.mockResolvedValue(undefined)
+  })
+
+  it('exposes initAudit and logAction functions', () => {
+    const { result } = renderHook(() => useAssetAudit())
+    expect(typeof result.current.initAudit).toBe('function')
+    expect(typeof result.current.logAction).toBe('function')
+  })
+
+  it('initAudit returns the success audit init shape', () => {
+    const { result } = renderHook(() => useAssetAudit())
+    const audit = result.current.initAudit()
+    expect(audit).toEqual(
+      expect.objectContaining({
+        client_id: 'client-1',
+        status: 'success',
+        performedBy: { user_inum: 'inum-1', userId: 'admin' },
+      }),
+    )
+  })
+
+  it('adds additional data with sanitized action data and posts the audit', async () => {
+    const { result } = renderHook(() => useAssetAudit())
+    const payload: AssetAuditLogActionPayload = {
+      action_message: 'created asset',
+      action_data: { fileName: 'logo.png', enabled: true },
+    }
+
+    await act(async () => {
+      await result.current.logAction('CREATE', 'asset', payload)
+    })
+
+    expect(mockAddAdditionalData).toHaveBeenCalledTimes(1)
+    expect(mockAddAdditionalData).toHaveBeenCalledWith(expect.any(Object), 'CREATE', 'asset', {
+      action: {
+        action_message: 'created asset',
+        action_data: { fileName: 'logo.png', enabled: true },
+      },
+    })
+    expect(mockPostUserAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('truncates long strings in action data', async () => {
+    const { result } = renderHook(() => useAssetAudit())
+    const longString = 'x'.repeat(600)
+
+    await act(async () => {
+      await result.current.logAction('CREATE', 'asset', {
+        action_data: { description: longString },
+      })
+    })
+
+    const additionalDataCall = mockAddAdditionalData.mock.calls[0]
+    const actionData = additionalDataCall[3].action.action_data
+    expect(actionData.description).toContain('... [truncated]')
+    expect(actionData.description.length).toBeLessThan(longString.length)
+  })
+
+  it('sanitizes File values into a descriptor object', async () => {
+    const { result } = renderHook(() => useAssetAudit())
+    const file = new File(['abc'], 'photo.png', { type: 'image/png' })
+
+    await act(async () => {
+      await result.current.logAction('CREATE', 'asset', {
+        action_data: { document: file },
+      })
+    })
+
+    const actionData = mockAddAdditionalData.mock.calls[0][3].action.action_data
+    expect(actionData.document).toEqual(
+      expect.objectContaining({ type: 'file', name: 'photo.png' }),
+    )
+  })
+
+  it('passes undefined action_data when payload has none', async () => {
+    const { result } = renderHook(() => useAssetAudit())
+
+    await act(async () => {
+      await result.current.logAction('UPDATE', 'asset', { action_message: 'no data' })
+    })
+
+    const actionArg = mockAddAdditionalData.mock.calls[0][3].action
+    expect(actionArg.action_data).toBeUndefined()
+  })
+
+  it('logs an error and does not throw when postUserAction rejects', async () => {
+    const failure = new Error('post failed')
+    mockPostUserAction.mockRejectedValueOnce(failure)
+    const { result } = renderHook(() => useAssetAudit())
+
+    await act(async () => {
+      await expect(
+        result.current.logAction('DELETION', 'asset', { action_data: { inum: 'a-1' } }),
+      ).resolves.toBeUndefined()
+    })
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1)
+    expect(mockLoggerError).toHaveBeenCalledWith('[Asset audit] postUserAction failed', failure)
+  })
+})

--- a/admin-ui/plugins/admin/components/Assets/hooks/__tests__/useAssetMutations.test.tsx
+++ b/admin-ui/plugins/admin/components/Assets/hooks/__tests__/useAssetMutations.test.tsx
@@ -1,0 +1,190 @@
+import React from 'react'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import {
+  useCreateAssetWithAudit,
+  useUpdateAssetWithAudit,
+  useDeleteAssetWithAudit,
+} from '../useAssetMutations'
+import type { AssetFormData } from '../../types'
+
+const mockCustomInstance = jest.fn()
+const mockDeleteMutateAsync = jest.fn()
+const mockLogAction = jest.fn()
+const mockInvalidate = jest.fn()
+
+jest.mock('Orval', () => ({
+  ...jest.requireActual('Orval'),
+  customInstance: (config: { url: string; method: string; data: FormData }) =>
+    mockCustomInstance(config),
+}))
+
+jest.mock('JansConfigApi', () => ({
+  useDeleteAsset: () => ({
+    mutateAsync: (vars: { inum: string }) => mockDeleteMutateAsync(vars),
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+  getGetAllAssetsQueryKey: () => ['/api/v1/jans-assets'],
+}))
+
+jest.mock('../useAssetAudit', () => ({
+  useAssetAudit: () => ({
+    logAction: (actionType: string, resource: string, payload: object) =>
+      mockLogAction(actionType, resource, payload),
+  }),
+}))
+
+jest.mock('@/utils/queryUtils', () => ({
+  invalidateQueriesByKey: (queryClient: object, queryKey: readonly string[]) =>
+    mockInvalidate(queryClient, queryKey),
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const buildStore = () =>
+  configureStore({
+    reducer: combineReducers({
+      authReducer: (state = { hasSession: true }) => state,
+      toastReducer: (state = { showToast: false, message: '', type: 'success' }) => state,
+      noReducer: (state = {}) => state,
+    }),
+  })
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>{children}</Provider>
+    </QueryClientProvider>
+  )
+}
+
+const formData: AssetFormData = {
+  fileName: 'logo.png',
+  description: 'company logo',
+  document: 'inline-content',
+  service: 'jans-auth',
+  enabled: true,
+}
+
+describe('useAssetMutations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCustomInstance.mockResolvedValue({ inum: 'asset-1' })
+    mockDeleteMutateAsync.mockResolvedValue({})
+    mockLogAction.mockResolvedValue(undefined)
+    mockInvalidate.mockResolvedValue(undefined)
+  })
+
+  describe('useCreateAssetWithAudit', () => {
+    it('uploads via POST, logs the audit and invalidates the list', async () => {
+      const onSuccess = jest.fn()
+      const store = buildStore()
+      const { result } = renderHook(() => useCreateAssetWithAudit({ onSuccess }), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await result.current.createAsset(formData, 'created')
+      })
+
+      expect(mockCustomInstance).toHaveBeenCalledWith(
+        expect.objectContaining({ url: '/api/v1/jans-assets/upload', method: 'POST' }),
+      )
+      expect(mockLogAction).toHaveBeenCalledWith(
+        'CREATE',
+        'asset',
+        expect.objectContaining({ action_message: 'created', action_data: formData }),
+      )
+      expect(mockInvalidate).toHaveBeenCalled()
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
+
+    it('dispatches an error toast and calls onError when upload fails', async () => {
+      mockCustomInstance.mockRejectedValueOnce({
+        response: { data: { responseMessage: 'upload boom' } },
+      })
+      const onError = jest.fn()
+      const store = buildStore()
+      const dispatchSpy = jest.spyOn(store, 'dispatch')
+      const { result } = renderHook(() => useCreateAssetWithAudit({ onError }), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await expect(result.current.createAsset(formData)).rejects.toBeDefined()
+      })
+
+      await waitFor(() => {
+        expect(dispatchSpy).toHaveBeenCalled()
+      })
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(mockLogAction).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('useUpdateAssetWithAudit', () => {
+    it('uploads via PUT and logs an UPDATE audit', async () => {
+      const store = buildStore()
+      const { result } = renderHook(() => useUpdateAssetWithAudit(), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await result.current.updateAsset({ ...formData, inum: 'asset-1' }, 'updated')
+      })
+
+      expect(mockCustomInstance).toHaveBeenCalledWith(
+        expect.objectContaining({ url: '/api/v1/jans-assets/upload', method: 'PUT' }),
+      )
+      expect(mockLogAction).toHaveBeenCalledWith('UPDATE', 'asset', expect.any(Object))
+    })
+  })
+
+  describe('useDeleteAssetWithAudit', () => {
+    it('deletes by inum, logs a DELETION audit and shows a success toast', async () => {
+      const onSuccess = jest.fn()
+      const store = buildStore()
+      const dispatchSpy = jest.spyOn(store, 'dispatch')
+      const { result } = renderHook(() => useDeleteAssetWithAudit({ onSuccess }), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await result.current.deleteAsset('asset-1', 'removed')
+      })
+
+      expect(mockDeleteMutateAsync).toHaveBeenCalledWith({ inum: 'asset-1' })
+      expect(mockLogAction).toHaveBeenCalledWith(
+        'DELETION',
+        'asset',
+        expect.objectContaining({ action_data: { inum: 'asset-1' } }),
+      )
+      expect(dispatchSpy).toHaveBeenCalled()
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
+
+    it('dispatches an error toast and calls onError when delete fails', async () => {
+      mockDeleteMutateAsync.mockRejectedValueOnce(new Error('delete boom'))
+      const onError = jest.fn()
+      const store = buildStore()
+      const dispatchSpy = jest.spyOn(store, 'dispatch')
+      const { result } = renderHook(() => useDeleteAssetWithAudit({ onError }), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await expect(result.current.deleteAsset('asset-1')).rejects.toBeDefined()
+      })
+
+      expect(dispatchSpy).toHaveBeenCalled()
+      expect(onError).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/admin-ui/plugins/admin/components/Assets/hooks/__tests__/useAssetMutations.test.tsx
+++ b/admin-ui/plugins/admin/components/Assets/hooks/__tests__/useAssetMutations.test.tsx
@@ -166,6 +166,7 @@ describe('useAssetMutations', () => {
         'asset',
         expect.objectContaining({ action_data: { inum: 'asset-1' } }),
       )
+      expect(mockInvalidate).toHaveBeenCalledWith(expect.any(Object), ['/api/v1/jans-assets'])
       expect(dispatchSpy).toHaveBeenCalled()
       expect(onSuccess).toHaveBeenCalledTimes(1)
     })

--- a/admin-ui/plugins/admin/components/Assets/hooks/__tests__/useAssetQueries.test.tsx
+++ b/admin-ui/plugins/admin/components/Assets/hooks/__tests__/useAssetQueries.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useAssetServices } from '../useAssetQueries'
+
+type AssetServicesOptions = { query: { enabled: boolean } }
+
+const mockUseGetAssetServices = jest.fn()
+
+jest.mock('JansConfigApi', () => ({
+  useGetAssetServices: (options: AssetServicesOptions) => mockUseGetAssetServices(options),
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useAssetServices', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseGetAssetServices.mockReturnValue({ data: ['svc-a'], isLoading: false })
+  })
+
+  it('enables the query by default', () => {
+    const { result } = renderHook(() => useAssetServices(), { wrapper: createWrapper() })
+    expect(mockUseGetAssetServices.mock.calls[0][0].query.enabled).toBe(true)
+    expect(result.current.data).toEqual(['svc-a'])
+  })
+
+  it('respects an explicit enabled option', () => {
+    renderHook(() => useAssetServices({ enabled: false }), { wrapper: createWrapper() })
+    expect(mockUseGetAssetServices.mock.calls[0][0].query.enabled).toBe(false)
+  })
+
+  it('passes the shared query defaults through', () => {
+    renderHook(() => useAssetServices(), { wrapper: createWrapper() })
+    const queryOptions = mockUseGetAssetServices.mock.calls[0][0].query
+    expect(queryOptions.refetchOnWindowFocus).toBe(false)
+    expect(queryOptions.staleTime).toBeGreaterThan(0)
+  })
+})

--- a/admin-ui/plugins/admin/components/Health/hooks/__tests__/useFido2HealthStatus.test.tsx
+++ b/admin-ui/plugins/admin/components/Health/hooks/__tests__/useFido2HealthStatus.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { renderHook, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import { useFido2HealthStatus } from '../useFido2HealthStatus'
+
+const mockGet = jest.fn()
+
+jest.mock('Orval', () => ({
+  ...jest.requireActual('Orval'),
+  AXIOS_INSTANCE: {
+    get: (url: string, config?: { signal?: AbortSignal }) => mockGet(url, config),
+  },
+}))
+
+const buildStore = (hasSession = true) =>
+  configureStore({
+    reducer: combineReducers({
+      authReducer: (state = { hasSession }) => state,
+      noReducer: (state = {}) => state,
+    }),
+  })
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>{children}</Provider>
+    </QueryClientProvider>
+  )
+}
+
+describe('useFido2HealthStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGet.mockResolvedValue({ data: { status: 'running' } })
+  })
+
+  it('fetches the fido2 health endpoint and transforms the response', async () => {
+    const store = buildStore(true)
+    const { result } = renderHook(() => useFido2HealthStatus(), { wrapper: createWrapper(store) })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    expect(mockGet).toHaveBeenCalledWith('/fido2/metrics/health', expect.any(Object))
+    expect(result.current.data).toEqual(
+      expect.objectContaining({ name: 'fido2-metrics', status: 'up' }),
+    )
+    expect(result.current.data?.lastChecked).toBeInstanceOf(Date)
+  })
+
+  it('normalizes an unknown status to the default status', async () => {
+    mockGet.mockResolvedValue({ data: { status: 'mystery' } })
+    const store = buildStore(true)
+    const { result } = renderHook(() => useFido2HealthStatus(), { wrapper: createWrapper(store) })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    expect(result.current.data?.status).toBe('unknown')
+  })
+
+  it('surfaces an error message from the response', async () => {
+    mockGet.mockResolvedValue({ data: { status: 'down', error: 'service offline' } })
+    const store = buildStore(true)
+    const { result } = renderHook(() => useFido2HealthStatus(), { wrapper: createWrapper(store) })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    expect(result.current.data).toEqual(
+      expect.objectContaining({ status: 'down', error: 'service offline' }),
+    )
+  })
+
+  it('does not fetch when there is no session', () => {
+    const store = buildStore(false)
+    renderHook(() => useFido2HealthStatus(), { wrapper: createWrapper(store) })
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when explicitly disabled', () => {
+    const store = buildStore(true)
+    renderHook(() => useFido2HealthStatus({ enabled: false }), { wrapper: createWrapper(store) })
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+})

--- a/admin-ui/plugins/admin/components/Health/hooks/__tests__/useHealthStatus.test.tsx
+++ b/admin-ui/plugins/admin/components/Health/hooks/__tests__/useHealthStatus.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react'
+import { renderHook } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import { useHealthStatus } from '../useHealthStatus'
+import type { JsonNode } from 'JansConfigApi'
+import type { ServiceHealth } from '../../types'
+
+type ServiceStatusSelect = (data: JsonNode | undefined) => ServiceHealth[]
+type ServiceStatusOptions = { query: { enabled: boolean; select: ServiceStatusSelect } }
+
+const mockUseGetServiceStatus = jest.fn()
+
+jest.mock('JansConfigApi', () => ({
+  useGetServiceStatus: (params: undefined, options: ServiceStatusOptions) =>
+    mockUseGetServiceStatus(params, options),
+}))
+
+const buildStore = (hasSession = true) =>
+  configureStore({
+    reducer: combineReducers({
+      authReducer: (state = { hasSession }) => state,
+      noReducer: (state = {}) => state,
+    }),
+  })
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  return ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  )
+}
+
+// Mimic react-query by running the caller-provided `select` over the raw payload.
+const buildQueryResult = (rawData: JsonNode | undefined, options: ServiceStatusOptions) => ({
+  data: rawData === undefined ? undefined : options.query.select(rawData),
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+  error: null,
+  refetch: jest.fn(),
+})
+
+describe('useHealthStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('transforms, normalizes, sorts and excludes services', () => {
+    const raw: JsonNode = {
+      'jans-auth': 'running',
+      'jans-config-api': 'down',
+      'jans-fido2': 'degraded',
+      'jans-link': 'running',
+    }
+    mockUseGetServiceStatus.mockImplementation((_params, options: ServiceStatusOptions) =>
+      buildQueryResult(raw, options),
+    )
+
+    const store = buildStore(true)
+    const { result } = renderHook(() => useHealthStatus(), { wrapper: createWrapper(store) })
+
+    // jans-link is excluded from the health page list
+    const names = result.current.services.map((s) => s.name)
+    expect(names).not.toContain('jans-link')
+    // up sorts before degraded which sorts before down
+    expect(result.current.services[0].status).toBe('up')
+    expect(result.current.services[result.current.services.length - 1].status).toBe('down')
+    // allServices still contains the excluded entry
+    expect(result.current.allServices.map((s) => s.name)).toContain('jans-link')
+  })
+
+  it('counts healthy and total services from the filtered list', () => {
+    const raw: JsonNode = {
+      'jans-auth': 'running',
+      'jans-config-api': 'running',
+      'jans-fido2': 'down',
+    }
+    mockUseGetServiceStatus.mockImplementation((_params, options: ServiceStatusOptions) =>
+      buildQueryResult(raw, options),
+    )
+
+    const store = buildStore(true)
+    const { result } = renderHook(() => useHealthStatus(), { wrapper: createWrapper(store) })
+
+    expect(result.current.totalCount).toBe(3)
+    expect(result.current.healthyCount).toBe(2)
+  })
+
+  it('enables the query only when a session is present', () => {
+    mockUseGetServiceStatus.mockImplementation((_params, options: ServiceStatusOptions) =>
+      buildQueryResult(undefined, options),
+    )
+
+    const store = buildStore(false)
+    renderHook(() => useHealthStatus(), { wrapper: createWrapper(store) })
+
+    expect(mockUseGetServiceStatus.mock.calls[0][1].query.enabled).toBe(false)
+  })
+
+  it('returns empty collections when there is no data', () => {
+    mockUseGetServiceStatus.mockImplementation((_params, options: ServiceStatusOptions) =>
+      buildQueryResult(undefined, options),
+    )
+
+    const store = buildStore(true)
+    const { result } = renderHook(() => useHealthStatus(), { wrapper: createWrapper(store) })
+
+    expect(result.current.services).toHaveLength(0)
+    expect(result.current.allServices).toHaveLength(0)
+    expect(result.current.totalCount).toBe(0)
+    expect(result.current.healthyCount).toBe(0)
+  })
+})

--- a/admin-ui/plugins/admin/components/MAU/hooks/__tests__/useMauStats.test.tsx
+++ b/admin-ui/plugins/admin/components/MAU/hooks/__tests__/useMauStats.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react'
+import { renderHook } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import { useMauStats } from '../useMauStats'
+import { createDate } from '@/utils/dayjsUtils'
+import type { JsonNode, GetStatParams } from 'JansConfigApi'
+import type { MauStatEntry, MauDateRange } from '../../types'
+
+type StatSelect = (data: JsonNode[]) => MauStatEntry[]
+type StatOptions = { query: { enabled: boolean; select: StatSelect } }
+
+const mockUseGetStat = jest.fn()
+
+jest.mock('JansConfigApi', () => ({
+  useGetStat: (params: GetStatParams, options: StatOptions) => mockUseGetStat(params, options),
+}))
+
+const buildStore = (hasSession = true) =>
+  configureStore({
+    reducer: combineReducers({
+      authReducer: (state = { hasSession }) => state,
+      noReducer: (state = {}) => state,
+    }),
+  })
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  return ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  )
+}
+
+const dateRange: MauDateRange = {
+  startDate: createDate('2024-01-15'),
+  endDate: createDate('2024-02-15'),
+}
+
+const rawTwoMonths: JsonNode[] = [
+  {
+    month: 202401,
+    monthly_active_users: 10,
+    token_count_per_granttype: {
+      client_credentials: { access_token: 5 },
+      authorization_code: { access_token: 3, id_token: 2 },
+    },
+  },
+  {
+    month: 202402,
+    monthly_active_users: 20,
+    token_count_per_granttype: {
+      client_credentials: { access_token: 5 },
+      authorization_code: { access_token: 3, id_token: 2 },
+    },
+  },
+]
+
+describe('useMauStats', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('formats the date range into start_month and end_month params', () => {
+    mockUseGetStat.mockImplementation((_params, options: StatOptions) => ({
+      data: options.query.select(rawTwoMonths),
+    }))
+
+    const store = buildStore(true)
+    renderHook(() => useMauStats(dateRange), { wrapper: createWrapper(store) })
+
+    expect(mockUseGetStat.mock.calls[0][0]).toEqual({
+      start_month: '202401',
+      end_month: '202402',
+    })
+  })
+
+  it('transforms the API response and computes the summary', () => {
+    mockUseGetStat.mockImplementation((_params, options: StatOptions) => ({
+      data: options.query.select(rawTwoMonths),
+    }))
+
+    const store = buildStore(true)
+    const { result } = renderHook(() => useMauStats(dateRange), { wrapper: createWrapper(store) })
+
+    expect(result.current.data).toHaveLength(2)
+    expect(result.current.summary.totalMau).toBe(30)
+    // 2 * (5 + 3 + 2) = 20
+    expect(result.current.summary.totalTokens).toBe(20)
+    expect(result.current.summary.clientCredentialsTokens).toBe(10)
+    // second-half mau (20) vs first-half mau (10) => +100%
+    expect(result.current.summary.mauChange).toBe(100)
+  })
+
+  it('returns a zeroed summary when data is empty', () => {
+    mockUseGetStat.mockImplementation(() => ({ data: [] }))
+
+    const store = buildStore(true)
+    const { result } = renderHook(() => useMauStats(dateRange), { wrapper: createWrapper(store) })
+
+    expect(result.current.data).toHaveLength(0)
+    expect(result.current.summary.totalMau).toBe(0)
+    expect(result.current.summary.mauChange).toBe(0)
+  })
+
+  it('is disabled when there is no session', () => {
+    mockUseGetStat.mockImplementation(() => ({ data: undefined }))
+
+    const store = buildStore(false)
+    renderHook(() => useMauStats(dateRange), { wrapper: createWrapper(store) })
+
+    expect(mockUseGetStat.mock.calls[0][1].query.enabled).toBe(false)
+  })
+
+  it('is disabled when explicitly disabled', () => {
+    mockUseGetStat.mockImplementation(() => ({ data: undefined }))
+
+    const store = buildStore(true)
+    renderHook(() => useMauStats(dateRange, { enabled: false }), {
+      wrapper: createWrapper(store),
+    })
+
+    expect(mockUseGetStat.mock.calls[0][1].query.enabled).toBe(false)
+  })
+
+  it('is enabled with a session and a valid date range', () => {
+    mockUseGetStat.mockImplementation((_params, options: StatOptions) => ({
+      data: options.query.select(rawTwoMonths),
+    }))
+
+    const store = buildStore(true)
+    renderHook(() => useMauStats(dateRange), { wrapper: createWrapper(store) })
+
+    expect(mockUseGetStat.mock.calls[0][1].query.enabled).toBe(true)
+  })
+})

--- a/admin-ui/plugins/admin/components/Mapping/hooks/__tests__/useMappingApi.test.tsx
+++ b/admin-ui/plugins/admin/components/Mapping/hooks/__tests__/useMappingApi.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useMappingData } from '../useMappingApi'
+
+type QueryOptions = { query: { enabled: boolean } }
+
+const mockMapping = jest.fn()
+const mockRoles = jest.fn()
+const mockPermissions = jest.fn()
+
+jest.mock('JansConfigApi', () => ({
+  useGetAllAdminuiRolePermissions: (options: QueryOptions) => mockMapping(options),
+  useGetAllAdminuiRoles: (options: QueryOptions) => mockRoles(options),
+  useGetAllAdminuiPermissions: (options: QueryOptions) => mockPermissions(options),
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+const baseQuery = {
+  data: undefined,
+  isLoading: false,
+  isError: false,
+  error: null,
+  refetch: jest.fn().mockResolvedValue(undefined),
+}
+
+describe('useMappingData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockMapping.mockReturnValue({ ...baseQuery, data: [{ role: 'admin' }] })
+    mockRoles.mockReturnValue({ ...baseQuery, data: [{ role: 'admin' }] })
+    mockPermissions.mockReturnValue({ ...baseQuery, data: [{ permission: 'read' }] })
+  })
+
+  it('returns combined data from all three queries', () => {
+    const { result } = renderHook(() => useMappingData(), { wrapper: createWrapper() })
+    expect(result.current.mapping).toEqual([{ role: 'admin' }])
+    expect(result.current.roles).toEqual([{ role: 'admin' }])
+    expect(result.current.permissions).toEqual([{ permission: 'read' }])
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isError).toBe(false)
+  })
+
+  it('defaults missing data to empty arrays', () => {
+    mockMapping.mockReturnValue({ ...baseQuery, data: undefined })
+    mockRoles.mockReturnValue({ ...baseQuery, data: undefined })
+    mockPermissions.mockReturnValue({ ...baseQuery, data: undefined })
+
+    const { result } = renderHook(() => useMappingData(), { wrapper: createWrapper() })
+    expect(result.current.mapping).toHaveLength(0)
+    expect(result.current.roles).toHaveLength(0)
+    expect(result.current.permissions).toHaveLength(0)
+  })
+
+  it('passes the enabled flag through to every query', () => {
+    renderHook(() => useMappingData(false), { wrapper: createWrapper() })
+    expect(mockMapping.mock.calls[0][0].query.enabled).toBe(false)
+    expect(mockRoles.mock.calls[0][0].query.enabled).toBe(false)
+    expect(mockPermissions.mock.calls[0][0].query.enabled).toBe(false)
+  })
+
+  it('enables queries by default', () => {
+    renderHook(() => useMappingData(), { wrapper: createWrapper() })
+    expect(mockMapping.mock.calls[0][0].query.enabled).toBe(true)
+  })
+
+  it('aggregates loading and error state across queries', () => {
+    mockRoles.mockReturnValue({ ...baseQuery, isLoading: true })
+    mockPermissions.mockReturnValue({ ...baseQuery, isError: true, error: new Error('boom') })
+
+    const { result } = renderHook(() => useMappingData(), { wrapper: createWrapper() })
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(Error)
+  })
+
+  it('refetch triggers all three underlying refetches', async () => {
+    const { result } = renderHook(() => useMappingData(), { wrapper: createWrapper() })
+    await act(async () => {
+      await result.current.refetch()
+    })
+    expect(mockMapping.mock.results[0].value.refetch).toHaveBeenCalled()
+    expect(mockRoles.mock.results[0].value.refetch).toHaveBeenCalled()
+    expect(mockPermissions.mock.results[0].value.refetch).toHaveBeenCalled()
+  })
+})

--- a/admin-ui/plugins/admin/components/Mapping/hooks/__tests__/useMappingApi.test.tsx
+++ b/admin-ui/plugins/admin/components/Mapping/hooks/__tests__/useMappingApi.test.tsx
@@ -27,15 +27,32 @@ const baseQuery = {
   isLoading: false,
   isError: false,
   error: null,
-  refetch: jest.fn().mockResolvedValue(undefined),
 }
+
+// A distinct refetch spy per query so each refetch assertion verifies its own
+// query instance rather than a single shared mock (which would false-positive).
+const mockMappingRefetch = jest.fn().mockResolvedValue(undefined)
+const mockRolesRefetch = jest.fn().mockResolvedValue(undefined)
+const mockPermissionsRefetch = jest.fn().mockResolvedValue(undefined)
 
 describe('useMappingData', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockMapping.mockReturnValue({ ...baseQuery, data: [{ role: 'admin' }] })
-    mockRoles.mockReturnValue({ ...baseQuery, data: [{ role: 'admin' }] })
-    mockPermissions.mockReturnValue({ ...baseQuery, data: [{ permission: 'read' }] })
+    mockMapping.mockReturnValue({
+      ...baseQuery,
+      data: [{ role: 'admin' }],
+      refetch: mockMappingRefetch,
+    })
+    mockRoles.mockReturnValue({
+      ...baseQuery,
+      data: [{ role: 'admin' }],
+      refetch: mockRolesRefetch,
+    })
+    mockPermissions.mockReturnValue({
+      ...baseQuery,
+      data: [{ permission: 'read' }],
+      refetch: mockPermissionsRefetch,
+    })
   })
 
   it('returns combined data from all three queries', () => {
@@ -85,8 +102,8 @@ describe('useMappingData', () => {
     await act(async () => {
       await result.current.refetch()
     })
-    expect(mockMapping.mock.results[0].value.refetch).toHaveBeenCalled()
-    expect(mockRoles.mock.results[0].value.refetch).toHaveBeenCalled()
-    expect(mockPermissions.mock.results[0].value.refetch).toHaveBeenCalled()
+    expect(mockMappingRefetch).toHaveBeenCalledTimes(1)
+    expect(mockRolesRefetch).toHaveBeenCalledTimes(1)
+    expect(mockPermissionsRefetch).toHaveBeenCalledTimes(1)
   })
 })

--- a/admin-ui/plugins/admin/components/Webhook/hooks/__tests__/useGetWebhook.test.tsx
+++ b/admin-ui/plugins/admin/components/Webhook/hooks/__tests__/useGetWebhook.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useGetWebhook } from '../useGetWebhook'
+import type { WebhookEntry, PagedWebhookResult } from '../../types'
+
+type WebhookSelect = (data: PagedWebhookResult) => WebhookEntry | undefined
+type WebhookParams = { limit: number; startIndex: number; pattern: string }
+type WebhookOptions = { query: { enabled: boolean; select: WebhookSelect } }
+
+const mockUseGetAllWebhooks = jest.fn()
+
+jest.mock('JansConfigApi', () => ({
+  useGetAllWebhooks: (params: WebhookParams, options: WebhookOptions) =>
+    mockUseGetAllWebhooks(params, options),
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+const webhooks: WebhookEntry[] = [
+  { inum: 'w-1', displayName: 'first', url: 'https://example.com/first' },
+  { inum: 'w-2', displayName: 'second', url: 'https://example.com/second' },
+]
+
+describe('useGetWebhook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('queries with the webhook id as the search pattern and is enabled', () => {
+    mockUseGetAllWebhooks.mockImplementation((_params, options: WebhookOptions) => ({
+      data: options.query.select({ entries: webhooks }),
+      status: 'success',
+      isFetching: false,
+    }))
+
+    const { result } = renderHook(() => useGetWebhook('w-2'), { wrapper: createWrapper() })
+
+    expect(mockUseGetAllWebhooks.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ limit: 100, startIndex: 0, pattern: 'w-2' }),
+    )
+    expect(mockUseGetAllWebhooks.mock.calls[0][1].query.enabled).toBe(true)
+    expect(result.current.webhook).toEqual(
+      expect.objectContaining({ inum: 'w-2', displayName: 'second' }),
+    )
+  })
+
+  it('returns undefined when no entry matches the id', () => {
+    mockUseGetAllWebhooks.mockImplementation((_params, options: WebhookOptions) => ({
+      data: options.query.select({ entries: webhooks }),
+      status: 'success',
+      isFetching: false,
+    }))
+
+    const { result } = renderHook(() => useGetWebhook('missing'), { wrapper: createWrapper() })
+    expect(result.current.webhook).toBeUndefined()
+  })
+
+  it('handles a response with no entries', () => {
+    mockUseGetAllWebhooks.mockImplementation((_params, options: WebhookOptions) => ({
+      data: options.query.select({}),
+      status: 'success',
+      isFetching: false,
+    }))
+
+    const { result } = renderHook(() => useGetWebhook('w-1'), { wrapper: createWrapper() })
+    expect(result.current.webhook).toBeUndefined()
+  })
+
+  it('is disabled when no webhook id is provided', () => {
+    mockUseGetAllWebhooks.mockReturnValue({ data: undefined, status: 'pending', isFetching: false })
+    renderHook(() => useGetWebhook(undefined), { wrapper: createWrapper() })
+    expect(mockUseGetAllWebhooks.mock.calls[0][1].query.enabled).toBe(false)
+    expect(mockUseGetAllWebhooks.mock.calls[0][0].pattern).toBe('')
+  })
+
+  it('reports isPending while the status is pending', () => {
+    mockUseGetAllWebhooks.mockReturnValue({ data: undefined, status: 'pending', isFetching: false })
+    const { result } = renderHook(() => useGetWebhook('w-1'), { wrapper: createWrapper() })
+    expect(result.current.isPending).toBe(true)
+  })
+
+  it('reports isPending while fetching even when status is not pending', () => {
+    mockUseGetAllWebhooks.mockReturnValue({ data: undefined, status: 'success', isFetching: true })
+    const { result } = renderHook(() => useGetWebhook('w-1'), { wrapper: createWrapper() })
+    expect(result.current.isPending).toBe(true)
+  })
+})

--- a/admin-ui/plugins/admin/components/Webhook/hooks/__tests__/useWebhookAudit.test.ts
+++ b/admin-ui/plugins/admin/components/Webhook/hooks/__tests__/useWebhookAudit.test.ts
@@ -1,0 +1,102 @@
+import { renderHook, act } from '@testing-library/react'
+import { useWebhookAudit } from '../useWebhookAudit'
+import type { WebhookAuditLogActionPayload } from '../../types'
+
+const mockPostUserAction = jest.fn()
+const mockAddAdditionalData = jest.fn()
+const mockLoggerError = jest.fn()
+
+jest.mock('Redux/api/backend-api', () => ({
+  postUserAction: (payload: object) => mockPostUserAction(payload),
+}))
+
+jest.mock('Utils/TokenController', () => ({
+  addAdditionalData: (audit: object, actionType: string, resource: string, extra: object) =>
+    mockAddAdditionalData(audit, actionType, resource, extra),
+}))
+
+jest.mock('@/audit', () => ({
+  useAuditContext: jest.fn(() => ({
+    client_id: 'client-1',
+    ip_address: '127.0.0.1',
+    userinfo: { inum: 'inum-1', name: 'admin' },
+  })),
+  createSuccessAuditInit: jest.fn(() => ({
+    client_id: 'client-1',
+    ip_address: '127.0.0.1',
+    status: 'success',
+    performedBy: { user_inum: 'inum-1', userId: 'admin' },
+  })),
+}))
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    error: (message: string, detail: Error | string) => mockLoggerError(message, detail),
+  },
+}))
+
+describe('useWebhookAudit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPostUserAction.mockResolvedValue(undefined)
+  })
+
+  it('exposes initAudit and logAction functions', () => {
+    const { result } = renderHook(() => useWebhookAudit())
+    expect(typeof result.current.initAudit).toBe('function')
+    expect(typeof result.current.logAction).toBe('function')
+  })
+
+  it('initAudit returns the success audit init shape', () => {
+    const { result } = renderHook(() => useWebhookAudit())
+    const audit = result.current.initAudit()
+    expect(audit).toEqual(
+      expect.objectContaining({
+        client_id: 'client-1',
+        status: 'success',
+        performedBy: { user_inum: 'inum-1', userId: 'admin' },
+      }),
+    )
+  })
+
+  it('adds additional data with the provided payload and posts the audit', async () => {
+    const { result } = renderHook(() => useWebhookAudit())
+    const payload: WebhookAuditLogActionPayload = {
+      action_message: 'created webhook',
+      action_data: { displayName: 'hook', url: 'https://example.com' },
+    }
+
+    await act(async () => {
+      await result.current.logAction('CREATE', 'webhook', payload)
+    })
+
+    expect(mockAddAdditionalData).toHaveBeenCalledTimes(1)
+    expect(mockAddAdditionalData).toHaveBeenCalledWith(
+      expect.any(Object),
+      'CREATE',
+      'webhook',
+      {
+        action: {
+          action_message: 'created webhook',
+          action_data: { displayName: 'hook', url: 'https://example.com' },
+        },
+      },
+    )
+    expect(mockPostUserAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs an error and does not throw when postUserAction rejects', async () => {
+    const failure = new Error('post failed')
+    mockPostUserAction.mockRejectedValueOnce(failure)
+    const { result } = renderHook(() => useWebhookAudit())
+
+    await act(async () => {
+      await expect(
+        result.current.logAction('DELETION', 'webhook', { action_data: { inum: 'w-1' } }),
+      ).resolves.toBeUndefined()
+    })
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1)
+    expect(mockLoggerError).toHaveBeenCalledWith('[Webhook audit] postUserAction failed', failure)
+  })
+})

--- a/admin-ui/plugins/admin/components/Webhook/hooks/__tests__/useWebhookAudit.test.ts
+++ b/admin-ui/plugins/admin/components/Webhook/hooks/__tests__/useWebhookAudit.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react'
 import { useWebhookAudit } from '../useWebhookAudit'
 import type { WebhookAuditLogActionPayload } from '../../types'
+import type { JsonValue } from 'Routes/Apps/Gluu/types/common'
 
 const mockPostUserAction = jest.fn()
 const mockAddAdditionalData = jest.fn()
@@ -10,9 +11,15 @@ jest.mock('Redux/api/backend-api', () => ({
   postUserAction: (payload: object) => mockPostUserAction(payload),
 }))
 
+type AuditAccumulator = Record<string, JsonValue>
+
 jest.mock('Utils/TokenController', () => ({
-  addAdditionalData: (audit: object, actionType: string, resource: string, extra: object) =>
-    mockAddAdditionalData(audit, actionType, resource, extra),
+  addAdditionalData: (
+    audit: AuditAccumulator,
+    actionType: string,
+    resource: string,
+    extra: object,
+  ) => mockAddAdditionalData(audit, actionType, resource, extra),
 }))
 
 jest.mock('@/audit', () => ({
@@ -39,6 +46,15 @@ describe('useWebhookAudit', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockPostUserAction.mockResolvedValue(undefined)
+    // Mirror the real addAdditionalData, which enriches the audit object in
+    // place (action type/resource/payload) before it is posted.
+    mockAddAdditionalData.mockImplementation(
+      (audit: AuditAccumulator, actionType: string, resource: string, extra: AuditAccumulator) => {
+        audit.action_type = actionType
+        audit.resource = resource
+        audit.action = extra.action
+      },
+    )
   })
 
   it('exposes initAudit and logAction functions', () => {
@@ -71,18 +87,27 @@ describe('useWebhookAudit', () => {
     })
 
     expect(mockAddAdditionalData).toHaveBeenCalledTimes(1)
-    expect(mockAddAdditionalData).toHaveBeenCalledWith(
-      expect.any(Object),
-      'CREATE',
-      'webhook',
-      {
+    expect(mockAddAdditionalData).toHaveBeenCalledWith(expect.any(Object), 'CREATE', 'webhook', {
+      action: {
+        action_message: 'created webhook',
+        action_data: { displayName: 'hook', url: 'https://example.com' },
+      },
+    })
+    expect(mockPostUserAction).toHaveBeenCalledTimes(1)
+    // The posted object must be the audit AFTER enrichment, not the bare init.
+    expect(mockPostUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client_id: 'client-1',
+        status: 'success',
+        performedBy: { user_inum: 'inum-1', userId: 'admin' },
+        action_type: 'CREATE',
+        resource: 'webhook',
         action: {
           action_message: 'created webhook',
           action_data: { displayName: 'hook', url: 'https://example.com' },
         },
-      },
+      }),
     )
-    expect(mockPostUserAction).toHaveBeenCalledTimes(1)
   })
 
   it('logs an error and does not throw when postUserAction rejects', async () => {

--- a/admin-ui/plugins/admin/components/Webhook/hooks/__tests__/useWebhookMutations.test.tsx
+++ b/admin-ui/plugins/admin/components/Webhook/hooks/__tests__/useWebhookMutations.test.tsx
@@ -90,6 +90,11 @@ describe('useWebhookMutations', () => {
       const onSuccess = jest.fn()
       const store = buildStore()
       const dispatchSpy = jest.spyOn(store, 'dispatch')
+      // invalidateWebhooksByFeatureQueries calls queryClient.invalidateQueries
+      // with a predicate directly (not via queryUtils), so spy on it here.
+      const predicateInvalidateSpy = jest
+        .spyOn(QueryClient.prototype, 'invalidateQueries')
+        .mockResolvedValue(undefined)
       const { result } = renderHook(() => useCreateWebhookWithAudit({ onSuccess }), {
         wrapper: createWrapper(store),
       })
@@ -105,8 +110,13 @@ describe('useWebhookMutations', () => {
         expect.objectContaining({ action_message: 'created', action_data: webhook }),
       )
       expect(mockInvalidateByKey).toHaveBeenCalled()
+      expect(predicateInvalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ predicate: expect.any(Function) }),
+      )
       expect(dispatchSpy).toHaveBeenCalled()
       expect(onSuccess).toHaveBeenCalledTimes(1)
+
+      predicateInvalidateSpy.mockRestore()
     })
 
     it('dispatches an error toast and calls onError on failure', async () => {
@@ -171,6 +181,9 @@ describe('useWebhookMutations', () => {
       const onSuccess = jest.fn()
       const store = buildStore()
       const dispatchSpy = jest.spyOn(store, 'dispatch')
+      const predicateInvalidateSpy = jest
+        .spyOn(QueryClient.prototype, 'invalidateQueries')
+        .mockResolvedValue(undefined)
       const { result } = renderHook(() => useDeleteWebhookWithAudit({ onSuccess }), {
         wrapper: createWrapper(store),
       })
@@ -185,8 +198,16 @@ describe('useWebhookMutations', () => {
         'webhook',
         expect.objectContaining({ action_data: { inum: 'w-1' } }),
       )
+      expect(mockInvalidateByKey).toHaveBeenCalledWith(expect.any(Object), [
+        '/api/v1/admin-ui/webhook',
+      ])
+      expect(predicateInvalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ predicate: expect.any(Function) }),
+      )
       expect(dispatchSpy).toHaveBeenCalled()
       expect(onSuccess).toHaveBeenCalledTimes(1)
+
+      predicateInvalidateSpy.mockRestore()
     })
 
     it('dispatches an error toast and calls onError on failure', async () => {

--- a/admin-ui/plugins/admin/components/Webhook/hooks/__tests__/useWebhookMutations.test.tsx
+++ b/admin-ui/plugins/admin/components/Webhook/hooks/__tests__/useWebhookMutations.test.tsx
@@ -1,0 +1,209 @@
+import React from 'react'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import {
+  useCreateWebhookWithAudit,
+  useUpdateWebhookWithAudit,
+  useDeleteWebhookWithAudit,
+} from '../useWebhookMutations'
+import type { WebhookEntry } from '../../types'
+
+const mockPostMutateAsync = jest.fn()
+const mockPutMutateAsync = jest.fn()
+const mockDeleteMutateAsync = jest.fn()
+const mockLogAction = jest.fn()
+const mockInvalidateByKey = jest.fn()
+
+jest.mock('JansConfigApi', () => ({
+  usePostWebhook: () => ({
+    mutateAsync: (vars: { data: WebhookEntry }) => mockPostMutateAsync(vars),
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+  usePutWebhook: () => ({
+    mutateAsync: (vars: { data: WebhookEntry }) => mockPutMutateAsync(vars),
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+  useDeleteWebhookByInum: () => ({
+    mutateAsync: (vars: { webhookId: string }) => mockDeleteMutateAsync(vars),
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+  getGetAllWebhooksQueryKey: () => ['/api/v1/admin-ui/webhook'],
+  getGetFeaturesByWebhookIdQueryKey: (id: string) => ['/api/v1/admin-ui/webhook/features', id],
+}))
+
+jest.mock('@/utils/queryUtils', () => {
+  const invalidateQueriesByKey = (queryClient: object, queryKey: readonly string[]) =>
+    mockInvalidateByKey(queryClient, queryKey)
+  return { invalidateQueriesByKey, default: { invalidateQueriesByKey } }
+})
+
+jest.mock('../useWebhookAudit', () => ({
+  useWebhookAudit: () => ({
+    logAction: (actionType: string, resource: string, payload: object) =>
+      mockLogAction(actionType, resource, payload),
+  }),
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const buildStore = () =>
+  configureStore({
+    reducer: combineReducers({
+      authReducer: (state = { hasSession: true }) => state,
+      toastReducer: (state = { showToast: false, message: '', type: 'success' }) => state,
+      noReducer: (state = {}) => state,
+    }),
+  })
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>{children}</Provider>
+    </QueryClientProvider>
+  )
+}
+
+const webhook: WebhookEntry = { inum: 'w-1', displayName: 'hook', url: 'https://example.com' }
+
+describe('useWebhookMutations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPostMutateAsync.mockResolvedValue({ inum: 'w-1' })
+    mockPutMutateAsync.mockResolvedValue({ inum: 'w-1' })
+    mockDeleteMutateAsync.mockResolvedValue({})
+    mockLogAction.mockResolvedValue(undefined)
+  })
+
+  describe('useCreateWebhookWithAudit', () => {
+    it('creates a webhook, logs a CREATE audit and invalidates queries', async () => {
+      const onSuccess = jest.fn()
+      const store = buildStore()
+      const dispatchSpy = jest.spyOn(store, 'dispatch')
+      const { result } = renderHook(() => useCreateWebhookWithAudit({ onSuccess }), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await result.current.createWebhook(webhook, 'created')
+      })
+
+      expect(mockPostMutateAsync).toHaveBeenCalledWith({ data: webhook })
+      expect(mockLogAction).toHaveBeenCalledWith(
+        'CREATE',
+        'webhook',
+        expect.objectContaining({ action_message: 'created', action_data: webhook }),
+      )
+      expect(mockInvalidateByKey).toHaveBeenCalled()
+      expect(dispatchSpy).toHaveBeenCalled()
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
+
+    it('dispatches an error toast and calls onError on failure', async () => {
+      mockPostMutateAsync.mockRejectedValueOnce({
+        response: { data: { responseMessage: 'create boom' } },
+      })
+      const onError = jest.fn()
+      const store = buildStore()
+      const dispatchSpy = jest.spyOn(store, 'dispatch')
+      const { result } = renderHook(() => useCreateWebhookWithAudit({ onError }), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await expect(result.current.createWebhook(webhook)).rejects.toBeDefined()
+      })
+
+      await waitFor(() => {
+        expect(dispatchSpy).toHaveBeenCalled()
+      })
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(mockLogAction).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('useUpdateWebhookWithAudit', () => {
+    it('updates a webhook, logs an UPDATE audit and invalidates feature queries by inum', async () => {
+      const store = buildStore()
+      const { result } = renderHook(() => useUpdateWebhookWithAudit(), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await result.current.updateWebhook(webhook, 'updated')
+      })
+
+      expect(mockPutMutateAsync).toHaveBeenCalledWith({ data: webhook })
+      expect(mockLogAction).toHaveBeenCalledWith('UPDATE', 'webhook', expect.any(Object))
+      // once for all-webhooks key, once for features-by-inum key
+      expect(mockInvalidateByKey).toHaveBeenCalledTimes(2)
+    })
+
+    it('skips the features-by-inum invalidation when inum is absent', async () => {
+      const store = buildStore()
+      const { result } = renderHook(() => useUpdateWebhookWithAudit(), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await result.current.updateWebhook(
+          { displayName: 'no-inum', url: 'https://example.com/no-inum' },
+          'updated',
+        )
+      })
+
+      expect(mockInvalidateByKey).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('useDeleteWebhookWithAudit', () => {
+    it('deletes by inum, logs a DELETION audit and shows a success toast', async () => {
+      const onSuccess = jest.fn()
+      const store = buildStore()
+      const dispatchSpy = jest.spyOn(store, 'dispatch')
+      const { result } = renderHook(() => useDeleteWebhookWithAudit({ onSuccess }), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await result.current.deleteWebhook('w-1', 'removed')
+      })
+
+      expect(mockDeleteMutateAsync).toHaveBeenCalledWith({ webhookId: 'w-1' })
+      expect(mockLogAction).toHaveBeenCalledWith(
+        'DELETION',
+        'webhook',
+        expect.objectContaining({ action_data: { inum: 'w-1' } }),
+      )
+      expect(dispatchSpy).toHaveBeenCalled()
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
+
+    it('dispatches an error toast and calls onError on failure', async () => {
+      mockDeleteMutateAsync.mockRejectedValueOnce(new Error('delete boom'))
+      const onError = jest.fn()
+      const store = buildStore()
+      const dispatchSpy = jest.spyOn(store, 'dispatch')
+      const { result } = renderHook(() => useDeleteWebhookWithAudit({ onError }), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await expect(result.current.deleteWebhook('w-1')).rejects.toBeDefined()
+      })
+
+      expect(dispatchSpy).toHaveBeenCalled()
+      expect(onError).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/admin-ui/plugins/auth-server/components/AuthServerProperties/hooks/__tests__/useAuthServerScripts.test.ts
+++ b/admin-ui/plugins/auth-server/components/AuthServerProperties/hooks/__tests__/useAuthServerScripts.test.ts
@@ -1,0 +1,109 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import type { LogAuditParams } from 'Utils/AuditLogger'
+import { useAuthServerScripts } from 'Plugins/auth-server/components/AuthServerProperties/hooks/useAuthServerScripts'
+
+const mockLogAuditUserAction = jest.fn()
+const mockLoggerError = jest.fn()
+const mockUseGetConfigScripts = jest.fn()
+
+jest.mock('JansConfigApi', () => ({
+  useGetConfigScripts: () => mockUseGetConfigScripts(),
+}))
+
+type AuthState = {
+  authReducer: {
+    config: { clientId: string }
+    userinfo: { inum: string; name: string }
+  }
+}
+
+jest.mock('@/redux/hooks', () => ({
+  useAppSelector: jest.fn(<TSelected>(selector: (s: AuthState) => TSelected) =>
+    selector({
+      authReducer: {
+        config: { clientId: 'test-client-id' },
+        userinfo: { inum: 'inum-123', name: 'admin' },
+      },
+    }),
+  ),
+}))
+
+jest.mock('Utils/AuditLogger', () => ({
+  logAuditUserAction: (params: LogAuditParams) => mockLogAuditUserAction(params),
+}))
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    error: (message: string, detail: Error | string) => mockLoggerError(message, detail),
+  },
+}))
+
+const validScript = { name: 'pwd', scriptType: 'PERSON_AUTHENTICATION', enabled: true }
+const invalidScript = { name: 'broken' }
+
+describe('useAuthServerScripts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLogAuditUserAction.mockResolvedValue(undefined)
+    mockUseGetConfigScripts.mockReturnValue({ data: undefined, isSuccess: false })
+  })
+
+  it('returns an empty array when there is no data', () => {
+    const { result } = renderHook(() => useAuthServerScripts())
+    expect(result.current).toEqual([])
+  })
+
+  it('filters out entries that are not valid script entries', () => {
+    mockUseGetConfigScripts.mockReturnValue({
+      data: { entries: [validScript, invalidScript] },
+      isSuccess: true,
+    })
+    const { result } = renderHook(() => useAuthServerScripts())
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0]).toMatchObject({ name: 'pwd' })
+  })
+
+  it('does not audit while the query has not succeeded', () => {
+    renderHook(() => useAuthServerScripts())
+    expect(mockLogAuditUserAction).not.toHaveBeenCalled()
+  })
+
+  it('logs an audit action once on success', async () => {
+    mockUseGetConfigScripts.mockReturnValue({
+      data: { entries: [validScript] },
+      isSuccess: true,
+    })
+    const { rerender } = renderHook(() => useAuthServerScripts())
+
+    await waitFor(() => {
+      expect(mockLogAuditUserAction).toHaveBeenCalledTimes(1)
+    })
+
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'FETCH SCRIPTS FOR STAT',
+        resource: 'SCRIPT',
+        client_id: 'test-client-id',
+        userinfo: { inum: 'inum-123', name: 'admin' },
+      }),
+    )
+
+    rerender()
+    expect(mockLogAuditUserAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs an error when the audit call rejects', async () => {
+    const failure = new Error('audit failed')
+    mockLogAuditUserAction.mockRejectedValueOnce(failure)
+    mockUseGetConfigScripts.mockReturnValue({
+      data: { entries: [validScript] },
+      isSuccess: true,
+    })
+
+    renderHook(() => useAuthServerScripts())
+
+    await waitFor(() => {
+      expect(mockLoggerError).toHaveBeenCalledWith('[AuthServer scripts audit] failed', failure)
+    })
+  })
+})

--- a/admin-ui/plugins/auth-server/components/Authentication/Acrs/hooks/__tests__/useAcrAudit.test.ts
+++ b/admin-ui/plugins/auth-server/components/Authentication/Acrs/hooks/__tests__/useAcrAudit.test.ts
@@ -1,0 +1,81 @@
+import { renderHook, act } from '@testing-library/react'
+import type { AuthenticationMethod } from 'JansConfigApi'
+import type { LogAuditParams } from 'Utils/AuditLogger'
+import { useAcrAudit } from 'Plugins/auth-server/components/Authentication/Acrs/hooks/useAcrAudit'
+
+const mockLogAuditUserAction = jest.fn()
+
+jest.mock('Utils/AuditLogger', () => ({
+  logAuditUserAction: (params: LogAuditParams) => mockLogAuditUserAction(params),
+}))
+
+type AuthState = {
+  authReducer: {
+    config: { clientId: string }
+    userinfo: { inum: string; name: string }
+  }
+}
+
+jest.mock('@/redux/hooks', () => ({
+  useAppSelector: jest.fn(<TSelected>(selector: (s: AuthState) => TSelected) =>
+    selector({
+      authReducer: {
+        config: { clientId: 'test-client-id' },
+        userinfo: { inum: 'inum-123', name: 'admin' },
+      },
+    }),
+  ),
+}))
+
+const mockAcr: AuthenticationMethod = {
+  defaultAcr: 'simple_password_auth',
+}
+
+describe('useAcrAudit', () => {
+  beforeEach(() => {
+    mockLogAuditUserAction.mockReset()
+    mockLogAuditUserAction.mockResolvedValue(undefined)
+  })
+
+  it('returns a logAcrUpdate function', () => {
+    const { result } = renderHook(() => useAcrAudit())
+    expect(typeof result.current.logAcrUpdate).toBe('function')
+  })
+
+  it('calls logAuditUserAction with the expected audit shape', async () => {
+    const { result } = renderHook(() => useAcrAudit())
+
+    await act(async () => {
+      await result.current.logAcrUpdate(mockAcr, 'Updated default ACR', {
+        defaultAcr: 'simple_password_auth',
+      })
+    })
+
+    expect(mockLogAuditUserAction).toHaveBeenCalledTimes(1)
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'UPDATE',
+        resource: 'api-acrs',
+        message: 'Updated default ACR',
+        modifiedFields: { defaultAcr: 'simple_password_auth' },
+        performedOn: 'simple_password_auth',
+        client_id: 'test-client-id',
+        payload: mockAcr,
+        userinfo: { inum: 'inum-123', name: 'admin' },
+      }),
+    )
+  })
+
+  it('passes performedOn from acr.defaultAcr', async () => {
+    const { result } = renderHook(() => useAcrAudit())
+    const otherAcr: AuthenticationMethod = { defaultAcr: 'otp' }
+
+    await act(async () => {
+      await result.current.logAcrUpdate(otherAcr, 'msg')
+    })
+
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({ performedOn: 'otp', modifiedFields: undefined }),
+    )
+  })
+})

--- a/admin-ui/plugins/auth-server/components/Authentication/AgamaFlows/hooks/__tests__/useAgamaActions.test.ts
+++ b/admin-ui/plugins/auth-server/components/Authentication/AgamaFlows/hooks/__tests__/useAgamaActions.test.ts
@@ -1,0 +1,133 @@
+import { renderHook, act } from '@testing-library/react'
+import type { Deployment } from 'JansConfigApi'
+import type { LogAuditParams } from 'Utils/AuditLogger'
+import { useAgamaActions } from 'Plugins/auth-server/components/Authentication/AgamaFlows/hooks/useAgamaActions'
+
+const mockLogAuditUserAction = jest.fn()
+
+jest.mock('Utils/AuditLogger', () => ({
+  logAuditUserAction: (params: LogAuditParams) => mockLogAuditUserAction(params),
+}))
+
+type AuthState = {
+  authReducer: {
+    config: { clientId: string }
+    userinfo: { inum: string; name: string }
+  }
+}
+
+jest.mock('@/redux/hooks', () => ({
+  useAppSelector: jest.fn(<TSelected>(selector: (s: AuthState) => TSelected) =>
+    selector({
+      authReducer: {
+        config: { clientId: 'test-client-id' },
+        userinfo: { inum: 'inum-123', name: 'admin' },
+      },
+    }),
+  ),
+}))
+
+const mockProject: Deployment = {
+  dn: 'agama-dn-1',
+  id: 'agama-id-1',
+}
+
+describe('useAgamaActions', () => {
+  beforeEach(() => {
+    mockLogAuditUserAction.mockReset()
+    mockLogAuditUserAction.mockResolvedValue(undefined)
+  })
+
+  it('exposes the four audit functions', () => {
+    const { result } = renderHook(() => useAgamaActions())
+    expect(typeof result.current.logAgamaCreation).toBe('function')
+    expect(typeof result.current.logAgamaUpdate).toBe('function')
+    expect(typeof result.current.logAgamaDeletion).toBe('function')
+    expect(typeof result.current.logAcrMappingUpdate).toBe('function')
+  })
+
+  it('logAgamaCreation sends CREATE audit with project identity payload', async () => {
+    const { result } = renderHook(() => useAgamaActions())
+
+    await act(async () => {
+      await result.current.logAgamaCreation(mockProject, 'created project', { name: 'p' })
+    })
+
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'CREATE',
+        resource: 'agama-project',
+        message: 'created project',
+        modifiedFields: { name: 'p' },
+        performedOn: 'agama-dn-1',
+        client_id: 'test-client-id',
+        payload: { dn: 'agama-dn-1', id: 'agama-id-1' },
+        userinfo: { inum: 'inum-123', name: 'admin' },
+      }),
+    )
+  })
+
+  it('logAgamaUpdate sends UPDATE audit', async () => {
+    const { result } = renderHook(() => useAgamaActions())
+
+    await act(async () => {
+      await result.current.logAgamaUpdate(mockProject, 'updated project')
+    })
+
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'UPDATE',
+        resource: 'agama-project',
+        performedOn: 'agama-dn-1',
+      }),
+    )
+  })
+
+  it('logAgamaDeletion sends DELETION audit', async () => {
+    const { result } = renderHook(() => useAgamaActions())
+
+    await act(async () => {
+      await result.current.logAgamaDeletion(mockProject, 'deleted project')
+    })
+
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'DELETION',
+        resource: 'agama-project',
+        performedOn: 'agama-dn-1',
+      }),
+    )
+  })
+
+  it('falls back to project.id for performedOn when dn is missing', async () => {
+    const { result } = renderHook(() => useAgamaActions())
+    const noDn: Deployment = { id: 'only-id' }
+
+    await act(async () => {
+      await result.current.logAgamaCreation(noDn, 'msg')
+    })
+
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({ performedOn: 'only-id' }),
+    )
+  })
+
+  it('logAcrMappingUpdate sends UPDATE audit against json-configuration', async () => {
+    const { result } = renderHook(() => useAgamaActions())
+
+    await act(async () => {
+      await result.current.logAcrMappingUpdate('mapping changed', { acr: 'x' })
+    })
+
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'UPDATE',
+        resource: 'json-configuration',
+        message: 'mapping changed',
+        modifiedFields: { acr: 'x' },
+        performedOn: '/acrMappings',
+        client_id: 'test-client-id',
+      }),
+    )
+  })
+})

--- a/admin-ui/plugins/auth-server/components/Logging/hooks/__tests__/useLoggingApi.test.tsx
+++ b/admin-ui/plugins/auth-server/components/Logging/hooks/__tests__/useLoggingApi.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import type { Logging } from 'JansConfigApi'
+import type { LogAuditParams } from 'Utils/AuditLogger'
+import {
+  useLoggingConfig,
+  useUpdateLoggingConfig,
+} from 'Plugins/auth-server/components/Logging/hooks/useLoggingApi'
+import type { UpdateLoggingParams } from 'Plugins/auth-server/components/Logging/types/UseLoggingApiTypes'
+
+const mockGetQuery = jest.fn()
+const mockPutMutateAsync = jest.fn()
+const mockLogAuditUserAction = jest.fn()
+const mockLoggerError = jest.fn()
+
+jest.mock('JansConfigApi', () => ({
+  useGetConfigLogging: () => mockGetQuery(),
+  usePutConfigLogging: () => ({ mutateAsync: mockPutMutateAsync, isPending: false }),
+  getGetConfigLoggingQueryKey: () => ['config', 'logging'],
+}))
+
+jest.mock('Utils/AuditLogger', () => ({
+  logAuditUserAction: (params: LogAuditParams) => mockLogAuditUserAction(params),
+}))
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    error: (message: string, detail: Error | string) => mockLoggerError(message, detail),
+  },
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const loggingData: Logging = { loggingLevel: 'DEBUG' }
+
+const updateParams: UpdateLoggingParams = {
+  data: loggingData,
+  userMessage: 'updated logging',
+  changedFields: { loggingLevel: { oldValue: 'INFO', newValue: 'DEBUG' } },
+}
+
+const buildStore = (hasSession = true) =>
+  configureStore({
+    reducer: combineReducers({
+      authReducer: (
+        state = {
+          hasSession,
+          userinfo: { inum: 'inum-1', name: 'admin' },
+          config: { clientId: 'client-1' },
+          location: { IPv4: '127.0.0.1' },
+        },
+      ) => state,
+      toastReducer: (state = { showToast: false, message: '', type: 'success' }) => state,
+    }),
+  })
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>{children}</Provider>
+    </QueryClientProvider>
+  )
+  return Wrapper
+}
+
+describe('useLoggingApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLogAuditUserAction.mockResolvedValue(undefined)
+    mockPutMutateAsync.mockResolvedValue(loggingData)
+    mockGetQuery.mockReturnValue({ data: loggingData, isError: false, error: null })
+  })
+
+  describe('useLoggingConfig', () => {
+    it('returns the underlying query object', () => {
+      const store = buildStore(true)
+      const { result } = renderHook(() => useLoggingConfig(), { wrapper: createWrapper(store) })
+      expect(result.current.data).toEqual(loggingData)
+    })
+  })
+
+  describe('useUpdateLoggingConfig', () => {
+    it('exposes a mutateAsync function', () => {
+      const store = buildStore(true)
+      const { result } = renderHook(() => useUpdateLoggingConfig(), {
+        wrapper: createWrapper(store),
+      })
+      expect(typeof result.current.mutateAsync).toBe('function')
+    })
+
+    it('calls the base mutation, dispatches a success toast and audits', async () => {
+      const store = buildStore(true)
+      const dispatchSpy = jest.spyOn(store, 'dispatch')
+      const { result } = renderHook(() => useUpdateLoggingConfig(), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync(updateParams)
+      })
+
+      expect(mockPutMutateAsync).toHaveBeenCalledWith({ data: loggingData })
+      expect(dispatchSpy).toHaveBeenCalled()
+
+      await waitFor(() => {
+        expect(mockLogAuditUserAction).toHaveBeenCalledTimes(1)
+      })
+      expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'UPDATE',
+          resource: 'api-logging',
+          message: 'updated logging',
+          client_id: 'client-1',
+          payload: { modifiedFields: { loggingLevel: { oldValue: 'INFO', newValue: 'DEBUG' } } },
+          extra: { ip_address: '127.0.0.1' },
+        }),
+      )
+    })
+
+    it('logs an error when the audit call rejects but still resolves', async () => {
+      const failure = new Error('audit failed')
+      mockLogAuditUserAction.mockRejectedValueOnce(failure)
+      const store = buildStore(true)
+      const { result } = renderHook(() => useUpdateLoggingConfig(), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await expect(result.current.mutateAsync(updateParams)).resolves.toEqual(loggingData)
+      })
+
+      await waitFor(() => {
+        expect(mockLoggerError).toHaveBeenCalledWith('Failed to log logging audit action:', failure)
+      })
+    })
+  })
+})

--- a/admin-ui/plugins/auth-server/components/OidcClients/__tests__/hooks/useUpdateClient.test.ts
+++ b/admin-ui/plugins/auth-server/components/OidcClients/__tests__/hooks/useUpdateClient.test.ts
@@ -1,0 +1,169 @@
+import { renderHook, act } from '@testing-library/react'
+import type { Client } from 'JansConfigApi'
+import type { LogAuditParams } from 'Utils/AuditLogger'
+import type { JsonValue } from 'Routes/Apps/Gluu/types/common'
+import { useUpdateClient } from 'Plugins/auth-server/components/OidcClients/hooks/useUpdateClient'
+import type {
+  AuditContext,
+  ClientWizardSubmitData,
+} from 'Plugins/auth-server/components/OidcClients/types'
+
+const mockDispatch = jest.fn()
+const mockMutateAsync = jest.fn()
+const mockLogAuditUserAction = jest.fn()
+const mockInvalidateQueriesByKey = jest.fn()
+const mockLoggerError = jest.fn()
+const mockSetQueryData = jest.fn()
+const mockUpdateToast = jest.fn((show: boolean, type: string, msg?: string) => ({
+  type: 'toast',
+  payload: { show, type, msg },
+}))
+type WebhookPayload = {
+  createdFeatureValue: Record<string, JsonValue>
+  feature: string
+}
+const mockTriggerWebhook = jest.fn((payload: WebhookPayload) => ({ type: 'webhook', payload }))
+
+jest.mock('@/redux/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ setQueryData: mockSetQueryData }),
+}))
+
+jest.mock('JansConfigApi', () => ({
+  usePutOauthOpenidClient: () => ({ mutateAsync: mockMutateAsync, isPending: false }),
+  getGetOauthOpenidClientsQueryKey: () => ['oidc', 'clients'],
+  getGetOauthOpenidClientsByInumQueryKey: (inum: string) => ['oidc', 'clients', inum],
+}))
+
+jest.mock('Redux/features/toastSlice', () => ({
+  updateToast: (show: boolean, type: string, msg?: string) => mockUpdateToast(show, type, msg),
+}))
+
+jest.mock('Plugins/admin/redux/features/WebhookSlice', () => ({
+  triggerWebhook: (payload: WebhookPayload) => mockTriggerWebhook(payload),
+}))
+
+jest.mock('Utils/AuditLogger', () => ({
+  logAuditUserAction: (params: LogAuditParams) => mockLogAuditUserAction(params),
+}))
+
+jest.mock('@/utils/queryUtils', () => ({
+  invalidateQueriesByKey: (queryClient: object, key: readonly string[]) =>
+    mockInvalidateQueriesByKey(queryClient, key),
+}))
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    error: (message: string, detail: Error | string) => mockLoggerError(message, detail),
+  },
+}))
+
+const auditContext: AuditContext = {
+  userinfo: { inum: 'inum-123', name: 'admin' },
+  clientId: 'client-1',
+}
+
+const updatedClient: Client = { inum: 'client-inum-1', displayName: 'My Client' }
+
+const buildFormData = (): ClientWizardSubmitData =>
+  ({
+    inum: 'client-inum-1',
+    displayName: 'My Client',
+    action_message: 'updated client',
+    modifiedFields: { displayName: 'My Client' },
+  }) as ClientWizardSubmitData
+
+describe('useUpdateClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockMutateAsync.mockResolvedValue(updatedClient)
+    mockInvalidateQueriesByKey.mockResolvedValue(undefined)
+    mockLogAuditUserAction.mockResolvedValue(undefined)
+  })
+
+  it('exposes updateClient and isUpdating', () => {
+    const { result } = renderHook(() => useUpdateClient(auditContext))
+    expect(typeof result.current.updateClient).toBe('function')
+    expect(result.current.isUpdating).toBe(false)
+  })
+
+  it('mutates with the client payload and returns the updated client', async () => {
+    const { result } = renderHook(() => useUpdateClient(auditContext))
+
+    let returned: Client | undefined
+    await act(async () => {
+      returned = await result.current.updateClient(buildFormData())
+    })
+
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      data: { inum: 'client-inum-1', displayName: 'My Client' },
+    })
+    expect(returned).toEqual(updatedClient)
+  })
+
+  it('dispatches a success toast, invalidates queries and triggers a webhook', async () => {
+    const { result } = renderHook(() => useUpdateClient(auditContext))
+
+    await act(async () => {
+      await result.current.updateClient(buildFormData())
+    })
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'success', undefined)
+    expect(mockInvalidateQueriesByKey).toHaveBeenCalled()
+    expect(mockTriggerWebhook).toHaveBeenCalled()
+    expect(mockDispatch).toHaveBeenCalled()
+  })
+
+  it('logs an audit action with the expected shape', async () => {
+    const { result } = renderHook(() => useUpdateClient(auditContext))
+
+    await act(async () => {
+      await result.current.updateClient(buildFormData())
+    })
+
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'UPDATE',
+        resource: '/openid/clients',
+        message: 'updated client',
+        modifiedFields: { displayName: 'My Client' },
+        performedOn: 'client-inum-1',
+        client_id: 'client-1',
+        userinfo: { inum: 'inum-123', name: 'admin' },
+      }),
+    )
+  })
+
+  it('logs an error but still resolves when audit logging fails', async () => {
+    const failure = new Error('audit boom')
+    mockLogAuditUserAction.mockRejectedValueOnce(failure)
+    const { result } = renderHook(() => useUpdateClient(auditContext))
+
+    let returned: Client | undefined
+    await act(async () => {
+      returned = await result.current.updateClient(buildFormData())
+    })
+
+    expect(mockLoggerError).toHaveBeenCalledWith('Audit logging failed:', failure)
+    expect(returned).toEqual(updatedClient)
+  })
+
+  it('dispatches an error toast and rethrows when the mutation fails', async () => {
+    const failure = new Error('mutation failed')
+    mockMutateAsync.mockRejectedValueOnce(failure)
+    const { result } = renderHook(() => useUpdateClient(auditContext))
+
+    await act(async () => {
+      await expect(result.current.updateClient(buildFormData())).rejects.toThrow('mutation failed')
+    })
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error', 'mutation failed')
+  })
+})

--- a/admin-ui/plugins/auth-server/components/Scopes/hooks/__tests__/useScopeActions.test.ts
+++ b/admin-ui/plugins/auth-server/components/Scopes/hooks/__tests__/useScopeActions.test.ts
@@ -1,0 +1,119 @@
+import { renderHook, act } from '@testing-library/react'
+import type { LogAuditParams } from 'Utils/AuditLogger'
+import { useScopeActions } from '../useScopeActions'
+import type { Scope } from '../../types'
+
+const mockLogAuditUserAction = jest.fn()
+const mockNavigateToRoute = jest.fn()
+
+jest.mock('Utils/AuditLogger', () => ({
+  logAuditUserAction: (params: LogAuditParams) => mockLogAuditUserAction(params),
+}))
+
+jest.mock('@/helpers/navigation', () => ({
+  useAppNavigation: () => ({ navigateToRoute: mockNavigateToRoute }),
+  ROUTES: {
+    AUTH_SERVER_SCOPES_LIST: '/scopes',
+    AUTH_SERVER_SCOPE_ADD: '/scope/new',
+    AUTH_SERVER_SCOPE_EDIT: (inum: string) => `/scope/edit/${inum}`,
+  },
+}))
+
+type MockAuthState = {
+  config: { clientId: string }
+  userinfo: { inum: string; name: string }
+}
+
+type MockRootState = { authReducer: MockAuthState }
+
+const mockAuthState: MockAuthState = {
+  config: { clientId: 'client-123' },
+  userinfo: { inum: 'user-1', name: 'admin' },
+}
+
+jest.mock('@/redux/hooks', () => ({
+  useAppSelector: <T,>(selector: (s: MockRootState) => T): T =>
+    selector({ authReducer: mockAuthState }),
+}))
+
+const scope: Scope = { id: 'scope-id', inum: 'scope-inum', displayName: 'My Scope' } as Scope
+
+describe('useScopeActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLogAuditUserAction.mockResolvedValue(undefined)
+  })
+
+  it('exposes all action functions', () => {
+    const { result } = renderHook(() => useScopeActions())
+    expect(typeof result.current.logScopeCreation).toBe('function')
+    expect(typeof result.current.logScopeUpdate).toBe('function')
+    expect(typeof result.current.logScopeDeletion).toBe('function')
+    expect(typeof result.current.navigateToScopeList).toBe('function')
+    expect(typeof result.current.navigateToScopeAdd).toBe('function')
+    expect(typeof result.current.navigateToScopeEdit).toBe('function')
+  })
+
+  it('logScopeCreation calls audit logger with CREATE action', async () => {
+    const { result } = renderHook(() => useScopeActions())
+    await act(async () => {
+      await result.current.logScopeCreation(scope, 'created')
+    })
+    expect(mockLogAuditUserAction).toHaveBeenCalledTimes(1)
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'CREATE',
+        message: 'created',
+        performedOn: 'scope-id',
+        client_id: 'client-123',
+        userinfo: mockAuthState.userinfo,
+      }),
+    )
+  })
+
+  it('logScopeUpdate calls audit logger with UPDATE action and modifiedFields', async () => {
+    const { result } = renderHook(() => useScopeActions())
+    await act(async () => {
+      await result.current.logScopeUpdate(scope, 'updated', { displayName: 'New' })
+    })
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'UPDATE',
+        message: 'updated',
+        modifiedFields: { displayName: 'New' },
+      }),
+    )
+  })
+
+  it('logScopeDeletion calls audit logger with DELETION action and minimal payload', async () => {
+    const { result } = renderHook(() => useScopeActions())
+    await act(async () => {
+      await result.current.logScopeDeletion(scope, 'deleted')
+    })
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'DELETION',
+        message: 'deleted',
+        payload: { inum: 'scope-inum', id: 'scope-id' },
+      }),
+    )
+  })
+
+  it('navigation helpers call navigateToRoute with the correct routes', () => {
+    const { result } = renderHook(() => useScopeActions())
+    act(() => {
+      result.current.navigateToScopeList()
+    })
+    expect(mockNavigateToRoute).toHaveBeenCalledWith('/scopes')
+
+    act(() => {
+      result.current.navigateToScopeAdd()
+    })
+    expect(mockNavigateToRoute).toHaveBeenCalledWith('/scope/new')
+
+    act(() => {
+      result.current.navigateToScopeEdit('abc')
+    })
+    expect(mockNavigateToRoute).toHaveBeenCalledWith('/scope/edit/abc')
+  })
+})

--- a/admin-ui/plugins/auth-server/components/Scopes/hooks/__tests__/useScopeActions.test.ts
+++ b/admin-ui/plugins/auth-server/components/Scopes/hooks/__tests__/useScopeActions.test.ts
@@ -32,7 +32,7 @@ const mockAuthState: MockAuthState = {
 }
 
 jest.mock('@/redux/hooks', () => ({
-  useAppSelector: <T,>(selector: (s: MockRootState) => T): T =>
+  useAppSelector: <T>(selector: (s: MockRootState) => T): T =>
     selector({ authReducer: mockAuthState }),
 }))
 

--- a/admin-ui/plugins/auth-server/components/Scopes/hooks/__tests__/useScopeMutations.test.tsx
+++ b/admin-ui/plugins/auth-server/components/Scopes/hooks/__tests__/useScopeMutations.test.tsx
@@ -1,0 +1,184 @@
+import React from 'react'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import type { JsonValue } from 'Routes/Apps/Gluu/types/common'
+import { useCreateScope, useUpdateScope } from '../useScopeMutations'
+import type { Scope, ModifiedFields } from '../../types'
+
+const mockCreateMutateAsync = jest.fn()
+const mockUpdateMutateAsync = jest.fn()
+const mockLogScopeCreation = jest.fn()
+const mockLogScopeUpdate = jest.fn()
+const mockNavigateToScopeList = jest.fn()
+const mockUpdateToast = jest.fn()
+const mockTriggerWebhook = jest.fn()
+
+jest.mock('JansConfigApi', () => ({
+  usePostOauthScopes: () => ({
+    mutateAsync: mockCreateMutateAsync,
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+  usePutOauthScopes: () => ({
+    mutateAsync: mockUpdateMutateAsync,
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+  getGetOauthScopesQueryKey: () => ['/scopes'],
+  getGetOauthScopesByInumQueryKey: (inum: string) => [`/scopes/inum/${inum}`],
+}))
+
+jest.mock('Redux/features/toastSlice', () => ({
+  updateToast: (showToast: boolean, type: string, message?: string) => {
+    mockUpdateToast(showToast, type, message)
+    return { type: 'toast/updateToast', payload: { showToast, toastType: type, message } }
+  },
+}))
+
+jest.mock('Plugins/admin/redux/features/WebhookSlice', () => ({
+  triggerWebhook: (payload: { createdFeatureValue: Record<string, JsonValue>; feature: string }) => {
+    mockTriggerWebhook(payload)
+    return { type: 'webhook/triggerWebhook', payload }
+  },
+}))
+
+jest.mock('../useScopeActions', () => ({
+  useScopeActions: () => ({
+    logScopeCreation: (scope: Scope, message: string, modifiedFields?: ModifiedFields) =>
+      mockLogScopeCreation(scope, message, modifiedFields),
+    logScopeUpdate: (scope: Scope, message: string, modifiedFields?: ModifiedFields) =>
+      mockLogScopeUpdate(scope, message, modifiedFields),
+    navigateToScopeList: () => mockNavigateToScopeList(),
+  }),
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const buildStore = () =>
+  configureStore({
+    reducer: combineReducers({
+      authReducer: (state = {}) => state,
+      noReducer: (state = {}) => state,
+    }),
+  })
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>{children}</Provider>
+    </QueryClientProvider>
+  )
+  return Wrapper
+}
+
+describe('useScopeMutations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLogScopeCreation.mockResolvedValue(undefined)
+    mockLogScopeUpdate.mockResolvedValue(undefined)
+  })
+
+  describe('useCreateScope', () => {
+    it('exposes createScope and status fields', () => {
+      const store = buildStore()
+      const { result } = renderHook(() => useCreateScope(), { wrapper: createWrapper(store) })
+      expect(typeof result.current.createScope).toBe('function')
+      expect(result.current.isPending).toBe(false)
+      expect(result.current.isError).toBe(false)
+    })
+
+    it('does nothing when data is empty', async () => {
+      const store = buildStore()
+      const { result } = renderHook(() => useCreateScope(), { wrapper: createWrapper(store) })
+      await act(async () => {
+        await result.current.createScope('', {})
+      })
+      expect(mockCreateMutateAsync).not.toHaveBeenCalled()
+    })
+
+    it('parses data, calls the mutation, dispatches success toast and navigates', async () => {
+      mockCreateMutateAsync.mockResolvedValue({ id: 'new-scope', displayName: 'New Scope' })
+      const store = buildStore()
+      const dispatchSpy = jest.spyOn(store, 'dispatch')
+      const { result } = renderHook(() => useCreateScope(), { wrapper: createWrapper(store) })
+
+      await act(async () => {
+        await result.current.createScope(
+          JSON.stringify({ id: 'new-scope', action_message: 'made it' }),
+          {},
+        )
+      })
+
+      expect(mockCreateMutateAsync).toHaveBeenCalledWith({
+        data: { id: 'new-scope' },
+      })
+      expect(mockUpdateToast).toHaveBeenCalledWith(
+        true,
+        'success',
+        'messages.scope_created_successfully_with_name',
+      )
+      expect(mockTriggerWebhook).toHaveBeenCalledTimes(1)
+      expect(mockLogScopeCreation).toHaveBeenCalledTimes(1)
+      expect(mockNavigateToScopeList).toHaveBeenCalledTimes(1)
+      expect(dispatchSpy).toHaveBeenCalled()
+    })
+
+    it('sets a parse error and rejects on invalid JSON', async () => {
+      const store = buildStore()
+      const { result } = renderHook(() => useCreateScope(), { wrapper: createWrapper(store) })
+
+      await act(async () => {
+        await expect(result.current.createScope('{not json', {})).rejects.toBeInstanceOf(Error)
+      })
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true)
+      })
+      expect(mockCreateMutateAsync).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('useUpdateScope', () => {
+    it('exposes updateScope and status fields', () => {
+      const store = buildStore()
+      const { result } = renderHook(() => useUpdateScope(), { wrapper: createWrapper(store) })
+      expect(typeof result.current.updateScope).toBe('function')
+      expect(result.current.isPending).toBe(false)
+    })
+
+    it('parses data, calls the mutation, dispatches success toast and navigates', async () => {
+      mockUpdateMutateAsync.mockResolvedValue({ id: 'scope-1', displayName: 'Updated' })
+      const store = buildStore()
+      const { result } = renderHook(() => useUpdateScope(), { wrapper: createWrapper(store) })
+
+      await act(async () => {
+        await result.current.updateScope(JSON.stringify({ id: 'scope-1' }), {})
+      })
+
+      expect(mockUpdateMutateAsync).toHaveBeenCalledWith({ data: { id: 'scope-1' } })
+      expect(mockUpdateToast).toHaveBeenCalledWith(
+        true,
+        'success',
+        'messages.scope_updated_successfully_with_name',
+      )
+      expect(mockLogScopeUpdate).toHaveBeenCalledTimes(1)
+      expect(mockNavigateToScopeList).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects on invalid JSON without calling the mutation', async () => {
+      const store = buildStore()
+      const { result } = renderHook(() => useUpdateScope(), { wrapper: createWrapper(store) })
+      await act(async () => {
+        await expect(result.current.updateScope('}}invalid', {})).rejects.toBeInstanceOf(Error)
+      })
+      expect(mockUpdateMutateAsync).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/admin-ui/plugins/auth-server/components/Scopes/hooks/__tests__/useScopeMutations.test.tsx
+++ b/admin-ui/plugins/auth-server/components/Scopes/hooks/__tests__/useScopeMutations.test.tsx
@@ -40,7 +40,10 @@ jest.mock('Redux/features/toastSlice', () => ({
 }))
 
 jest.mock('Plugins/admin/redux/features/WebhookSlice', () => ({
-  triggerWebhook: (payload: { createdFeatureValue: Record<string, JsonValue>; feature: string }) => {
+  triggerWebhook: (payload: {
+    createdFeatureValue: Record<string, JsonValue>
+    feature: string
+  }) => {
     mockTriggerWebhook(payload)
     return { type: 'webhook/triggerWebhook', payload }
   },

--- a/admin-ui/plugins/auth-server/components/Scopes/hooks/__tests__/useScopeQueries.test.ts
+++ b/admin-ui/plugins/auth-server/components/Scopes/hooks/__tests__/useScopeQueries.test.ts
@@ -118,6 +118,20 @@ describe('useScopeQueries', () => {
         expect(result.current.attributes).toHaveLength(3)
       })
       expect(mockGetAttributes).toHaveBeenCalledTimes(2)
+
+      // The loop must advance startIndex by the page size between calls,
+      // otherwise it would re-fetch the same cursor.
+      expect(mockGetAttributes.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ limit: 2, startIndex: 0 }),
+      )
+      expect(mockGetAttributes.mock.calls[1][0]).toEqual(
+        expect.objectContaining({ limit: 2, startIndex: 2 }),
+      )
+      expect(result.current.attributes).toEqual([
+        { dn: 'd1', name: 'n1', key: 'k1' },
+        { dn: 'd2', name: 'n2', key: 'k2' },
+        { dn: 'd3', name: 'n3', key: 'k3' },
+      ])
     })
   })
 })

--- a/admin-ui/plugins/auth-server/components/Scopes/hooks/__tests__/useScopeQueries.test.ts
+++ b/admin-ui/plugins/auth-server/components/Scopes/hooks/__tests__/useScopeQueries.test.ts
@@ -1,0 +1,123 @@
+import React from 'react'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { GetOauthScopesParams, GetAttributesParams } from 'JansConfigApi'
+import { useScopes, useScopeAttributes, useScopeScripts } from '../useScopeQueries'
+
+type QueryOptions = { query?: Record<string, boolean | number> }
+
+const mockUseGetOauthScopes = jest.fn()
+const mockUseGetConfigScripts = jest.fn()
+const mockGetAttributes = jest.fn()
+
+jest.mock('JansConfigApi', () => ({
+  useGetOauthScopes: (params: GetOauthScopesParams, options: QueryOptions) =>
+    mockUseGetOauthScopes(params, options),
+  useGetConfigScripts: (params: undefined, options: QueryOptions) =>
+    mockUseGetConfigScripts(params, options),
+  getAttributes: (params: GetAttributesParams, _options: undefined, signal?: AbortSignal) =>
+    mockGetAttributes(params, _options, signal),
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+  return Wrapper
+}
+
+describe('useScopeQueries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('useScopes', () => {
+    it('passes params and query options to useGetOauthScopes and returns its result', () => {
+      const queryResult = { data: { entries: [] }, isLoading: false }
+      mockUseGetOauthScopes.mockReturnValue(queryResult)
+      const params = { limit: 10, startIndex: 0 }
+      const { result } = renderHook(() => useScopes(params))
+
+      expect(result.current).toBe(queryResult)
+      expect(mockUseGetOauthScopes).toHaveBeenCalledWith(
+        params,
+        expect.objectContaining({
+          query: expect.objectContaining({ retry: false, refetchOnWindowFocus: false }),
+        }),
+      )
+    })
+  })
+
+  describe('useScopeScripts', () => {
+    it('returns empty scripts when there is no data', () => {
+      mockUseGetConfigScripts.mockReturnValue({ data: undefined, isLoading: false, error: null })
+      const { result } = renderHook(() => useScopeScripts())
+      expect(result.current.scripts).toEqual([])
+    })
+
+    it('maps config script entries to the script shape', () => {
+      mockUseGetConfigScripts.mockReturnValue({
+        data: {
+          entries: [
+            { dn: 'dn1', name: 'script1', inum: 'i1', scriptType: 'person', enabled: true },
+          ],
+        },
+        isLoading: false,
+        error: null,
+      })
+      const { result } = renderHook(() => useScopeScripts())
+      expect(result.current.scripts).toHaveLength(1)
+      expect(result.current.scripts[0]).toEqual({
+        dn: 'dn1',
+        name: 'script1',
+        inum: 'i1',
+        scriptType: 'person',
+        enabled: true,
+      })
+    })
+  })
+
+  describe('useScopeAttributes', () => {
+    it('aggregates a single page of attributes and maps them to claims', async () => {
+      mockGetAttributes.mockResolvedValueOnce({
+        entries: [{ dn: 'dn-a', name: 'attr-a', key: 'k-a' }],
+        totalEntriesCount: 1,
+      })
+
+      const { result } = renderHook(() => useScopeAttributes({ limit: 100 }), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.attributes).toEqual([{ dn: 'dn-a', name: 'attr-a', key: 'k-a' }])
+      expect(mockGetAttributes).toHaveBeenCalledTimes(1)
+    })
+
+    it('paginates until a short page is returned', async () => {
+      mockGetAttributes
+        .mockResolvedValueOnce({
+          entries: [
+            { dn: 'd1', name: 'n1', key: 'k1' },
+            { dn: 'd2', name: 'n2', key: 'k2' },
+          ],
+          totalEntriesCount: 3,
+        })
+        .mockResolvedValueOnce({
+          entries: [{ dn: 'd3', name: 'n3', key: 'k3' }],
+          totalEntriesCount: 3,
+        })
+
+      const { result } = renderHook(() => useScopeAttributes({ limit: 2 }), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.attributes).toHaveLength(3)
+      })
+      expect(mockGetAttributes).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/admin-ui/plugins/auth-server/components/Sessions/hooks/__tests__/useSessionMutations.test.tsx
+++ b/admin-ui/plugins/auth-server/components/Sessions/hooks/__tests__/useSessionMutations.test.tsx
@@ -1,0 +1,201 @@
+import React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import type { LogAuditParams } from 'Utils/AuditLogger'
+import { useDeleteSessionWithAudit, useRevokeSessionWithAudit } from '../useSessionMutations'
+import type { AuditContext } from '../../types'
+
+const mockDeleteMutateAsync = jest.fn()
+const mockRevokeMutateAsync = jest.fn()
+const mockUpdateToast = jest.fn()
+const mockLogAuditUserAction = jest.fn()
+const mockLoggerError = jest.fn()
+
+jest.mock('JansConfigApi', () => ({
+  useDeleteSession: () => ({ mutateAsync: mockDeleteMutateAsync, isPending: false, isError: false, error: null }),
+  useRevokeUserSession: () => ({ mutateAsync: mockRevokeMutateAsync, isPending: false, isError: false, error: null }),
+  getGetSessionsQueryKey: () => ['/sessions'],
+}))
+
+jest.mock('Redux/features/toastSlice', () => ({
+  updateToast: (showToast: boolean, type: string, message?: string) => {
+    mockUpdateToast(showToast, type, message)
+    return { type: 'toast/updateToast', payload: { showToast, toastType: type, message } }
+  },
+}))
+
+jest.mock('Utils/AuditLogger', () => ({
+  logAuditUserAction: (params: LogAuditParams) => mockLogAuditUserAction(params),
+}))
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    error: (message: string, detail?: Error | string, meta?: Record<string, string>) =>
+      mockLoggerError(message, detail, meta),
+  },
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const auditContext: AuditContext = {
+  userinfo: { inum: 'user-1', name: 'admin' },
+  client_id: 'client-1',
+}
+
+const buildStore = () =>
+  configureStore({
+    reducer: combineReducers({
+      authReducer: (state = {}) => state,
+      noReducer: (state = {}) => state,
+    }),
+  })
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>{children}</Provider>
+    </QueryClientProvider>
+  )
+  return Wrapper
+}
+
+describe('useDeleteSessionWithAudit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLogAuditUserAction.mockResolvedValue(undefined)
+  })
+
+  it('exposes deleteSession and status fields', () => {
+    const store = buildStore()
+    const { result } = renderHook(() => useDeleteSessionWithAudit(auditContext), {
+      wrapper: createWrapper(store),
+    })
+    expect(typeof result.current.deleteSession).toBe('function')
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('deletes, logs the audit action, dispatches success and calls onSuccess', async () => {
+    mockDeleteMutateAsync.mockResolvedValue(undefined)
+    const onSuccess = jest.fn()
+    const store = buildStore()
+    const { result } = renderHook(() => useDeleteSessionWithAudit(auditContext, { onSuccess }), {
+      wrapper: createWrapper(store),
+    })
+
+    await act(async () => {
+      await result.current.deleteSession('sid-1', 'reason', 'bob')
+    })
+
+    expect(mockDeleteMutateAsync).toHaveBeenCalledWith({ sid: 'sid-1' })
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'DELETION',
+        resource: 'session',
+        message: 'reason',
+        client_id: 'client-1',
+        payload: { sessionId: 'sid-1', username: 'bob' },
+      }),
+    )
+    expect(mockUpdateToast).toHaveBeenCalledWith(
+      true,
+      'success',
+      'messages.session_deleted_successfully',
+    )
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+  })
+
+  it('dispatches an error toast, calls onError and rethrows on delete failure', async () => {
+    const failure = new Error('delete failed')
+    mockDeleteMutateAsync.mockRejectedValue(failure)
+    const onError = jest.fn()
+    const store = buildStore()
+    const { result } = renderHook(() => useDeleteSessionWithAudit(auditContext, { onError }), {
+      wrapper: createWrapper(store),
+    })
+
+    await act(async () => {
+      await expect(result.current.deleteSession('sid-2')).rejects.toBe(failure)
+    })
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error', 'delete failed')
+    expect(onError).toHaveBeenCalledWith(failure)
+    expect(mockLogAuditUserAction).not.toHaveBeenCalled()
+  })
+
+  it('dispatches a warning toast when audit logging fails', async () => {
+    mockDeleteMutateAsync.mockResolvedValue(undefined)
+    mockLogAuditUserAction.mockRejectedValue(new Error('audit boom'))
+    const store = buildStore()
+    const { result } = renderHook(() => useDeleteSessionWithAudit(auditContext), {
+      wrapper: createWrapper(store),
+    })
+
+    await act(async () => {
+      await result.current.deleteSession('sid-3')
+    })
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'warning', 'messages.audit_logging_failed')
+    expect(mockUpdateToast).toHaveBeenCalledWith(
+      true,
+      'success',
+      'messages.session_deleted_successfully',
+    )
+  })
+})
+
+describe('useRevokeSessionWithAudit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLogAuditUserAction.mockResolvedValue(undefined)
+  })
+
+  it('revokes, logs the audit action and dispatches success', async () => {
+    mockRevokeMutateAsync.mockResolvedValue(undefined)
+    const onSuccess = jest.fn()
+    const store = buildStore()
+    const { result } = renderHook(() => useRevokeSessionWithAudit(auditContext, { onSuccess }), {
+      wrapper: createWrapper(store),
+    })
+
+    await act(async () => {
+      await result.current.revokeSession('user-dn', 'reason', 'bob')
+    })
+
+    expect(mockRevokeMutateAsync).toHaveBeenCalledWith({ userDn: 'user-dn' })
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'DELETION',
+        resource: 'session',
+        payload: { userDn: 'user-dn', username: 'bob' },
+      }),
+    )
+    expect(mockUpdateToast).toHaveBeenCalledWith(
+      true,
+      'success',
+      'messages.session_revoked_successfully',
+    )
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+  })
+
+  it('dispatches an error toast and rethrows on revoke failure', async () => {
+    const failure = new Error('revoke failed')
+    mockRevokeMutateAsync.mockRejectedValue(failure)
+    const onError = jest.fn()
+    const store = buildStore()
+    const { result } = renderHook(() => useRevokeSessionWithAudit(auditContext, { onError }), {
+      wrapper: createWrapper(store),
+    })
+
+    await act(async () => {
+      await expect(result.current.revokeSession('user-dn')).rejects.toBe(failure)
+    })
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error', 'revoke failed')
+    expect(onError).toHaveBeenCalledWith(failure)
+  })
+})

--- a/admin-ui/plugins/auth-server/components/Sessions/hooks/__tests__/useSessionMutations.test.tsx
+++ b/admin-ui/plugins/auth-server/components/Sessions/hooks/__tests__/useSessionMutations.test.tsx
@@ -14,8 +14,18 @@ const mockLogAuditUserAction = jest.fn()
 const mockLoggerError = jest.fn()
 
 jest.mock('JansConfigApi', () => ({
-  useDeleteSession: () => ({ mutateAsync: mockDeleteMutateAsync, isPending: false, isError: false, error: null }),
-  useRevokeUserSession: () => ({ mutateAsync: mockRevokeMutateAsync, isPending: false, isError: false, error: null }),
+  useDeleteSession: () => ({
+    mutateAsync: mockDeleteMutateAsync,
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+  useRevokeUserSession: () => ({
+    mutateAsync: mockRevokeMutateAsync,
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
   getGetSessionsQueryKey: () => ['/sessions'],
 }))
 
@@ -197,5 +207,34 @@ describe('useRevokeSessionWithAudit', () => {
 
     expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error', 'revoke failed')
     expect(onError).toHaveBeenCalledWith(failure)
+  })
+
+  it('still succeeds with a warning toast when audit logging fails after a revoke', async () => {
+    mockRevokeMutateAsync.mockResolvedValue(undefined)
+    const auditFailure = new Error('audit boom')
+    mockLogAuditUserAction.mockRejectedValue(auditFailure)
+    const onSuccess = jest.fn()
+    const onError = jest.fn()
+    const store = buildStore()
+    const { result } = renderHook(
+      () => useRevokeSessionWithAudit(auditContext, { onSuccess, onError }),
+      { wrapper: createWrapper(store) },
+    )
+
+    await act(async () => {
+      await result.current.revokeSession('user-dn', 'reason', 'bob')
+    })
+
+    // The revoke itself still runs and the audit failure is non-fatal.
+    expect(mockRevokeMutateAsync).toHaveBeenCalledWith({ userDn: 'user-dn' })
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'warning', 'messages.audit_logging_failed')
+    expect(mockUpdateToast).toHaveBeenCalledWith(
+      true,
+      'success',
+      'messages.session_revoked_successfully',
+    )
+    // Audit failure is not a revoke failure: onSuccess fires, onError does not.
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    expect(onError).not.toHaveBeenCalled()
   })
 })

--- a/admin-ui/plugins/auth-server/components/Ssa/hooks/__tests__/useSsaApi.test.tsx
+++ b/admin-ui/plugins/auth-server/components/Ssa/hooks/__tests__/useSsaApi.test.tsx
@@ -1,0 +1,199 @@
+import React from 'react'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import {
+  SSA_QUERY_KEYS,
+  useGetAllSsas,
+  useSsaJwtQuery,
+  useCreateSsa,
+  useGetSsaJwt,
+} from '../useSsaApi'
+import type { SsaCreatePayload } from '../../types'
+
+const ssaPayload: SsaCreatePayload = {
+  software_id: 's1',
+  one_time_use: false,
+  org_id: 'org-1',
+  description: 'desc',
+  software_roles: ['password'],
+  rotate_ssa: false,
+  grant_types: ['client_credentials'],
+  is_expirable: false,
+  expirationDate: null,
+}
+
+type AuthState = { jwtToken: string | null; config: { authServerHost: string } }
+
+const buildStore = (overrides: Partial<AuthState> = {}) => {
+  const authState: AuthState = {
+    jwtToken: 'token-123',
+    config: { authServerHost: 'https://auth.example' },
+    ...overrides,
+  }
+  return configureStore({
+    reducer: combineReducers({
+      authReducer: (state = authState) => state,
+      noReducer: (state = {}) => state,
+    }),
+  })
+}
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>{children}</Provider>
+    </QueryClientProvider>
+  )
+  return Wrapper
+}
+
+const mockFetch = jest.fn()
+
+type JsonLike =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonLike[]
+  | { [key: string]: JsonLike }
+
+const jsonResponse = (body: JsonLike, ok = true, status = 200): Response => {
+  const partial: Pick<Response, 'ok' | 'status' | 'statusText' | 'json'> = {
+    ok,
+    status,
+    statusText: 'OK',
+    json: () => Promise.resolve(body),
+  }
+  return partial as Response
+}
+
+beforeAll(() => {
+  global.fetch = mockFetch as typeof fetch
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('SSA_QUERY_KEYS', () => {
+  it('builds list and detail keys', () => {
+    expect(SSA_QUERY_KEYS.all).toEqual(['ssas'])
+    expect(SSA_QUERY_KEYS.detail('abc')).toEqual(['ssas', 'abc'])
+  })
+})
+
+describe('useGetAllSsas', () => {
+  it('fetches all SSAs with an authorization header', async () => {
+    mockFetch.mockResolvedValue(jsonResponse([{ status: 'active' }]))
+    const store = buildStore()
+    const { result } = renderHook(() => useGetAllSsas(), { wrapper: createWrapper(store) })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    expect(result.current.data).toEqual([{ status: 'active' }])
+    const [url, options] = mockFetch.mock.calls[0]
+    expect(url).toBe('https://auth.example/jans-auth/restv1/ssa')
+    expect(options.headers.Authorization).toBe('Bearer token-123')
+  })
+
+  it('is disabled when there is no token', () => {
+    const store = buildStore({ jwtToken: null })
+    const { result } = renderHook(() => useGetAllSsas(), { wrapper: createWrapper(store) })
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('surfaces an error when the response is not ok', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'forbidden' }, false, 403))
+    const store = buildStore()
+    const { result } = renderHook(() => useGetAllSsas(), { wrapper: createWrapper(store) })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+    expect(result.current.error?.message).toBe('forbidden')
+  })
+})
+
+describe('useSsaJwtQuery', () => {
+  it('is disabled when enabled is false', () => {
+    const store = buildStore()
+    const { result } = renderHook(() => useSsaJwtQuery('jti-1', false), {
+      wrapper: createWrapper(store),
+    })
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('fetches the JWT for the given jti when enabled', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ ssa: 'jwt-value' }))
+    const store = buildStore()
+    const { result } = renderHook(() => useSsaJwtQuery('jti-1', true), {
+      wrapper: createWrapper(store),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    expect(result.current.data).toEqual({ ssa: 'jwt-value' })
+    expect(mockFetch.mock.calls[0][0]).toContain('/jans-auth/restv1/ssa/jwt?jti=jti-1')
+  })
+})
+
+describe('useCreateSsa', () => {
+  it('posts the payload and resolves with created SSA', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ status: 'created' }))
+    const store = buildStore()
+    const { result } = renderHook(() => useCreateSsa(), { wrapper: createWrapper(store) })
+
+    await act(async () => {
+      const created = await result.current.mutateAsync(ssaPayload)
+      expect(created).toEqual({ status: 'created' })
+    })
+
+    const [url, options] = mockFetch.mock.calls[0]
+    expect(url).toBe('https://auth.example/jans-auth/restv1/ssa')
+    expect(options.method).toBe('POST')
+  })
+
+  it('rejects when no token is available', async () => {
+    const store = buildStore({ jwtToken: null })
+    const { result } = renderHook(() => useCreateSsa(), { wrapper: createWrapper(store) })
+
+    await act(async () => {
+      await expect(result.current.mutateAsync(ssaPayload)).rejects.toThrow(
+        'No authentication token available',
+      )
+    })
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('useGetSsaJwt', () => {
+  it('fetches the JWT for the supplied jti', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ ssa: 'jwt-x' }))
+    const store = buildStore()
+    const { result } = renderHook(() => useGetSsaJwt(), { wrapper: createWrapper(store) })
+
+    await act(async () => {
+      const value = await result.current.mutateAsync('jti-9')
+      expect(value).toEqual({ ssa: 'jwt-x' })
+    })
+    expect(mockFetch.mock.calls[0][0]).toContain('jti=jti-9')
+  })
+
+  it('rejects when the auth server host is not configured', async () => {
+    const store = buildStore({ config: { authServerHost: '' } })
+    const { result } = renderHook(() => useGetSsaJwt(), { wrapper: createWrapper(store) })
+
+    await act(async () => {
+      await expect(result.current.mutateAsync('jti-9')).rejects.toThrow(
+        'Auth server host not configured',
+      )
+    })
+  })
+})

--- a/admin-ui/plugins/auth-server/components/Ssa/hooks/__tests__/useSsaApi.test.tsx
+++ b/admin-ui/plugins/auth-server/components/Ssa/hooks/__tests__/useSsaApi.test.tsx
@@ -52,13 +52,7 @@ const createWrapper = (store: ReturnType<typeof buildStore>) => {
 
 const mockFetch = jest.fn()
 
-type JsonLike =
-  | string
-  | number
-  | boolean
-  | null
-  | JsonLike[]
-  | { [key: string]: JsonLike }
+type JsonLike = string | number | boolean | null | JsonLike[] | { [key: string]: JsonLike }
 
 const jsonResponse = (body: JsonLike, ok = true, status = 200): Response => {
   const partial: Pick<Response, 'ok' | 'status' | 'statusText' | 'json'> = {
@@ -70,8 +64,14 @@ const jsonResponse = (body: JsonLike, ok = true, status = 200): Response => {
   return partial as Response
 }
 
+const originalFetch = global.fetch
+
 beforeAll(() => {
   global.fetch = mockFetch as typeof fetch
+})
+
+afterAll(() => {
+  global.fetch = originalFetch
 })
 
 beforeEach(() => {

--- a/admin-ui/plugins/auth-server/components/Ssa/hooks/__tests__/useSsaMutations.test.tsx
+++ b/admin-ui/plugins/auth-server/components/Ssa/hooks/__tests__/useSsaMutations.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import { useRevokeSsaWithAudit } from '../useSsaMutations'
+import type { SsaAuditLogPayload } from '../../types/SsaFormTypes'
+import type { CaughtError } from '../../types/ErrorTypes'
+
+const mockRevokeMutateAsync = jest.fn()
+const mockUpdateToast = jest.fn()
+const mockLogSsaDeletion = jest.fn()
+const mockGetErrorMessage = jest.fn()
+const mockLoggerError = jest.fn()
+
+let mockIsPending = false
+let mockIsError = false
+let mockError: Error | null = null
+
+jest.mock('JansConfigApi', () => ({
+  useRevokeSsa: () => ({
+    mutateAsync: mockRevokeMutateAsync,
+    get isPending() {
+      return mockIsPending
+    },
+    get isError() {
+      return mockIsError
+    },
+    get error() {
+      return mockError
+    },
+  }),
+}))
+
+jest.mock('Redux/features/toastSlice', () => ({
+  updateToast: (showToast: boolean, type: string, message?: string) => {
+    mockUpdateToast(showToast, type, message)
+    return { type: 'toast/updateToast', payload: { showToast, toastType: type, message } }
+  },
+}))
+
+jest.mock('../../helper', () => ({
+  logSsaDeletion: (jti: string, payload?: SsaAuditLogPayload, message?: string) =>
+    mockLogSsaDeletion(jti, payload, message),
+  getErrorMessage: (error: CaughtError) => mockGetErrorMessage(error),
+}))
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    error: (message: string, detail?: Error | string, meta?: Record<string, string>) =>
+      mockLoggerError(message, detail, meta),
+  },
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const buildStore = () =>
+  configureStore({
+    reducer: combineReducers({
+      authReducer: (state = {}) => state,
+      noReducer: (state = {}) => state,
+    }),
+  })
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>{children}</Provider>
+    </QueryClientProvider>
+  )
+  return Wrapper
+}
+
+describe('useRevokeSsaWithAudit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsPending = false
+    mockIsError = false
+    mockError = null
+    mockLogSsaDeletion.mockResolvedValue(undefined)
+  })
+
+  it('exposes revokeSsa and status fields', () => {
+    const store = buildStore()
+    const { result } = renderHook(() => useRevokeSsaWithAudit(), { wrapper: createWrapper(store) })
+    expect(typeof result.current.revokeSsa).toBe('function')
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isError).toBe(false)
+  })
+
+  it('revokes, logs deletion, dispatches success toast and calls onSuccess', async () => {
+    mockRevokeMutateAsync.mockResolvedValue(undefined)
+    const onSuccess = jest.fn()
+    const store = buildStore()
+    const { result } = renderHook(() => useRevokeSsaWithAudit({ onSuccess }), {
+      wrapper: createWrapper(store),
+    })
+
+    await act(async () => {
+      await result.current.revokeSsa('jti-1', 'because', { jti: 'jti-1' })
+    })
+
+    expect(mockRevokeMutateAsync).toHaveBeenCalledWith({ params: { jti: 'jti-1' } })
+    expect(mockLogSsaDeletion).toHaveBeenCalledWith('jti-1', { jti: 'jti-1' }, 'because')
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'success', undefined)
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+  })
+
+  it('dispatches an error toast, calls onError and rethrows when the mutation fails', async () => {
+    const failure = new Error('revoke failed')
+    mockRevokeMutateAsync.mockRejectedValue(failure)
+    mockGetErrorMessage.mockReturnValue('friendly error')
+    const onError = jest.fn()
+    const store = buildStore()
+    const { result } = renderHook(() => useRevokeSsaWithAudit({ onError }), {
+      wrapper: createWrapper(store),
+    })
+
+    await act(async () => {
+      await expect(result.current.revokeSsa('jti-2')).rejects.toBe(failure)
+    })
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error', 'friendly error')
+    expect(onError).toHaveBeenCalledWith(failure)
+    expect(mockLogSsaDeletion).not.toHaveBeenCalled()
+  })
+
+  it('dispatches a warning toast when audit logging fails but still succeeds', async () => {
+    mockRevokeMutateAsync.mockResolvedValue(undefined)
+    mockLogSsaDeletion.mockRejectedValue(new Error('audit boom'))
+    const store = buildStore()
+    const { result } = renderHook(() => useRevokeSsaWithAudit(), { wrapper: createWrapper(store) })
+
+    await act(async () => {
+      await result.current.revokeSsa('jti-3')
+    })
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'warning', 'messages.audit_logging_failed')
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'success', undefined)
+    expect(mockLoggerError).toHaveBeenCalled()
+  })
+})

--- a/admin-ui/plugins/auth-server/components/Ssa/hooks/__tests__/useSsaValidationState.test.ts
+++ b/admin-ui/plugins/auth-server/components/Ssa/hooks/__tests__/useSsaValidationState.test.ts
@@ -6,11 +6,30 @@ import type { SsaFormValues } from '../../types'
 type TouchedInput = FormikTouched<SsaFormValues>
 type ErrorsInput = Partial<Record<keyof SsaFormValues, string | string[]>>
 
-const makeFormik = (touched: TouchedInput, errors: ErrorsInput): FormikProps<SsaFormValues> => {
-  const partial: Pick<FormikProps<SsaFormValues>, 'touched'> & {
+const defaultValues: SsaFormValues = {
+  software_id: '',
+  one_time_use: false,
+  org_id: '',
+  description: '',
+  software_roles: [],
+  rotate_ssa: false,
+  grant_types: [],
+  is_expirable: false,
+  expirationDate: null,
+}
+
+const makeFormik = (
+  touched: TouchedInput,
+  errors: ErrorsInput,
+  values: Partial<SsaFormValues> = {},
+): FormikProps<SsaFormValues> => {
+  const partial: Pick<FormikProps<SsaFormValues>, 'touched' | 'values'> & {
     errors: ErrorsInput
-  } = { touched, errors }
-  return partial as Pick<FormikProps<SsaFormValues>, 'touched' | 'errors'> as FormikProps<SsaFormValues>
+  } = { touched, errors, values: { ...defaultValues, ...values } }
+  return partial as Pick<
+    FormikProps<SsaFormValues>,
+    'touched' | 'errors' | 'values'
+  > as FormikProps<SsaFormValues>
 }
 
 describe('useSsaValidationState', () => {
@@ -26,9 +45,7 @@ describe('useSsaValidationState', () => {
 
   it('flags an error only when a field is both touched and has an error', () => {
     const { result } = renderHook(() =>
-      useSsaValidationState(
-        makeFormik({ software_id: true }, { software_id: 'required' }),
-      ),
+      useSsaValidationState(makeFormik({ software_id: true }, { software_id: 'required' })),
     )
     expect(result.current.softwareIdError).toBe(true)
     expect(result.current.softwareIdErrorMessage).toBe('required')
@@ -68,6 +85,23 @@ describe('useSsaValidationState', () => {
     expect(result.current.grantTypesErrorMessage).toBe('grants required')
     expect(result.current.descriptionError).toBe(true)
     expect(result.current.descriptionErrorMessage).toBe('desc required')
+  })
+
+  it('flags the expiration error only when is_expirable is set and an error exists', () => {
+    const enabled = renderHook(() =>
+      useSsaValidationState(
+        makeFormik({}, { expirationDate: 'date required' }, { is_expirable: true }),
+      ),
+    )
+    expect(enabled.result.current.expirationDateError).toBe(true)
+    expect(enabled.result.current.expirationDateErrorMessage).toBe('date required')
+
+    const disabled = renderHook(() =>
+      useSsaValidationState(
+        makeFormik({}, { expirationDate: 'date required' }, { is_expirable: false }),
+      ),
+    )
+    expect(disabled.result.current.expirationDateError).toBe(false)
   })
 
   it('returns an empty message when the error is not a string', () => {

--- a/admin-ui/plugins/auth-server/components/Ssa/hooks/__tests__/useSsaValidationState.test.ts
+++ b/admin-ui/plugins/auth-server/components/Ssa/hooks/__tests__/useSsaValidationState.test.ts
@@ -1,0 +1,82 @@
+import { renderHook } from '@testing-library/react'
+import type { FormikProps, FormikTouched } from 'formik'
+import { useSsaValidationState } from '../useSsaValidationState'
+import type { SsaFormValues } from '../../types'
+
+type TouchedInput = FormikTouched<SsaFormValues>
+type ErrorsInput = Partial<Record<keyof SsaFormValues, string | string[]>>
+
+const makeFormik = (touched: TouchedInput, errors: ErrorsInput): FormikProps<SsaFormValues> => {
+  const partial: Pick<FormikProps<SsaFormValues>, 'touched'> & {
+    errors: ErrorsInput
+  } = { touched, errors }
+  return partial as Pick<FormikProps<SsaFormValues>, 'touched' | 'errors'> as FormikProps<SsaFormValues>
+}
+
+describe('useSsaValidationState', () => {
+  it('returns no errors when nothing is touched', () => {
+    const { result } = renderHook(() => useSsaValidationState(makeFormik({}, {})))
+    expect(result.current.softwareIdError).toBe(false)
+    expect(result.current.softwareIdErrorMessage).toBe('')
+    expect(result.current.organizationError).toBe(false)
+    expect(result.current.softwareRolesError).toBe(false)
+    expect(result.current.grantTypesError).toBe(false)
+    expect(result.current.descriptionError).toBe(false)
+  })
+
+  it('flags an error only when a field is both touched and has an error', () => {
+    const { result } = renderHook(() =>
+      useSsaValidationState(
+        makeFormik({ software_id: true }, { software_id: 'required' }),
+      ),
+    )
+    expect(result.current.softwareIdError).toBe(true)
+    expect(result.current.softwareIdErrorMessage).toBe('required')
+  })
+
+  it('does not flag an error when there is an error but the field is untouched', () => {
+    const { result } = renderHook(() =>
+      useSsaValidationState(makeFormik({}, { software_id: 'required' })),
+    )
+    expect(result.current.softwareIdError).toBe(false)
+  })
+
+  it('maps each form field to its corresponding error state', () => {
+    const { result } = renderHook(() =>
+      useSsaValidationState(
+        makeFormik(
+          {
+            org_id: true,
+            software_roles: true,
+            grant_types: true,
+            description: true,
+          },
+          {
+            org_id: 'org required',
+            software_roles: 'roles required',
+            grant_types: 'grants required',
+            description: 'desc required',
+          },
+        ),
+      ),
+    )
+    expect(result.current.organizationError).toBe(true)
+    expect(result.current.organizationErrorMessage).toBe('org required')
+    expect(result.current.softwareRolesError).toBe(true)
+    expect(result.current.softwareRolesErrorMessage).toBe('roles required')
+    expect(result.current.grantTypesError).toBe(true)
+    expect(result.current.grantTypesErrorMessage).toBe('grants required')
+    expect(result.current.descriptionError).toBe(true)
+    expect(result.current.descriptionErrorMessage).toBe('desc required')
+  })
+
+  it('returns an empty message when the error is not a string', () => {
+    const { result } = renderHook(() =>
+      useSsaValidationState(
+        makeFormik({ software_roles: true }, { software_roles: ['array error'] }),
+      ),
+    )
+    expect(result.current.softwareRolesError).toBe(true)
+    expect(result.current.softwareRolesErrorMessage).toBe('')
+  })
+})

--- a/admin-ui/plugins/auth-server/hooks/__tests__/useAuthServerJsonProperties.test.tsx
+++ b/admin-ui/plugins/auth-server/hooks/__tests__/useAuthServerJsonProperties.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { UserAction } from 'Utils/types'
+import type { AppConfiguration } from 'Plugins/auth-server/components/AuthServerProperties/types'
+import {
+  useAuthServerJsonPropertiesQuery,
+  usePatchAuthServerJsonPropertiesMutation,
+  authServerJsonPropertiesQueryKey,
+} from 'Plugins/auth-server/hooks/useAuthServerJsonProperties'
+
+const mockDispatch = jest.fn()
+const mockFetch = jest.fn()
+const mockPatch = jest.fn()
+const mockUpdateToast = jest.fn((show: boolean, type: string) => ({
+  type: 'toast',
+  payload: { show, type },
+}))
+
+jest.mock('@/redux/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+}))
+
+jest.mock('Redux/features/toastSlice', () => ({
+  updateToast: (show: boolean, type: string) => mockUpdateToast(show, type),
+}))
+
+jest.mock('Plugins/auth-server/services/jsonPropertiesService', () => ({
+  fetchAuthServerJsonProperties: () => mockFetch(),
+  patchAuthServerJsonProperties: (action: UserAction) => mockPatch(action),
+}))
+
+const config: AppConfiguration = { issuer: 'https://issuer' } as AppConfiguration
+
+const userAction: UserAction = {
+  action_message: 'patched',
+  action_data: null,
+}
+
+const createWrapper = (queryClient: QueryClient) => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  return Wrapper
+}
+
+const newClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+describe('useAuthServerJsonProperties', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFetch.mockResolvedValue(config)
+    mockPatch.mockResolvedValue(config)
+  })
+
+  describe('useAuthServerJsonPropertiesQuery', () => {
+    it('fetches and returns json properties', async () => {
+      const queryClient = newClient()
+      const { result } = renderHook(() => useAuthServerJsonPropertiesQuery(), {
+        wrapper: createWrapper(queryClient),
+      })
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(result.current.data).toEqual(config)
+    })
+  })
+
+  describe('usePatchAuthServerJsonPropertiesMutation', () => {
+    it('patches, dispatches a success toast and caches the result on success', async () => {
+      const queryClient = newClient()
+      const setQueryDataSpy = jest.spyOn(queryClient, 'setQueryData')
+      const userOnSuccess = jest.fn()
+      const { result } = renderHook(
+        () => usePatchAuthServerJsonPropertiesMutation({ onSuccess: userOnSuccess }),
+        { wrapper: createWrapper(queryClient) },
+      )
+
+      await act(async () => {
+        await result.current.mutateAsync(userAction)
+      })
+
+      expect(mockPatch).toHaveBeenCalledWith(userAction)
+      expect(mockUpdateToast).toHaveBeenCalledWith(true, 'success')
+      expect(mockDispatch).toHaveBeenCalled()
+      expect(setQueryDataSpy).toHaveBeenCalledWith(authServerJsonPropertiesQueryKey, config)
+      expect(userOnSuccess).toHaveBeenCalledTimes(1)
+    })
+
+    it('invalidates queries when the patch result is not a plain object', async () => {
+      mockPatch.mockResolvedValueOnce(null)
+      const queryClient = newClient()
+      const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries')
+      const { result } = renderHook(() => usePatchAuthServerJsonPropertiesMutation(), {
+        wrapper: createWrapper(queryClient),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync(userAction)
+      })
+
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: authServerJsonPropertiesQueryKey })
+    })
+
+    it('dispatches an error toast and calls the user onError when the patch fails', async () => {
+      const failure = new Error('patch failed')
+      mockPatch.mockRejectedValueOnce(failure)
+      const queryClient = newClient()
+      const userOnError = jest.fn()
+      const { result } = renderHook(
+        () => usePatchAuthServerJsonPropertiesMutation({ onError: userOnError }),
+        { wrapper: createWrapper(queryClient) },
+      )
+
+      await act(async () => {
+        await expect(result.current.mutateAsync(userAction)).rejects.toThrow('patch failed')
+      })
+
+      expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error')
+      await waitFor(() => {
+        expect(userOnError).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+})

--- a/admin-ui/plugins/auth-server/hooks/__tests__/useAuthServerJsonProperties.test.tsx
+++ b/admin-ui/plugins/auth-server/hooks/__tests__/useAuthServerJsonProperties.test.tsx
@@ -119,6 +119,12 @@ describe('useAuthServerJsonProperties', () => {
       })
 
       expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error')
+      // Guard against a regression where the hook builds the toast but stops
+      // dispatching the error action.
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'toast',
+        payload: { show: true, type: 'error' },
+      })
       await waitFor(() => {
         expect(userOnError).toHaveBeenCalledTimes(1)
       })

--- a/admin-ui/plugins/saml/components/hooks/__tests__/useSamlApi.test.tsx
+++ b/admin-ui/plugins/saml/components/hooks/__tests__/useSamlApi.test.tsx
@@ -137,6 +137,15 @@ describe('useSamlApi', () => {
       expect(mockGet).toHaveBeenCalledWith('/kc/saml/idp', { params: { limit: 5 } })
     })
 
+    it('does not run the identity providers query without a session', () => {
+      const store = buildStore(false)
+      const { result } = renderHook(() => useIdentityProviders({ limit: 5 }), {
+        wrapper: createWrapper(store),
+      })
+      expect(result.current.fetchStatus).toBe('idle')
+      expect(mockGet).not.toHaveBeenCalled()
+    })
+
     it('fetches trust relationships', async () => {
       mockGet.mockResolvedValueOnce({ data: [] })
       const store = buildStore(true)
@@ -146,6 +155,15 @@ describe('useSamlApi', () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
       expect(mockGet).toHaveBeenCalledWith('/kc/saml/trust-relationships')
     })
+
+    it('does not run the trust relationships query without a session', () => {
+      const store = buildStore(false)
+      const { result } = renderHook(() => useTrustRelationships(), {
+        wrapper: createWrapper(store),
+      })
+      expect(result.current.fetchStatus).toBe('idle')
+      expect(mockGet).not.toHaveBeenCalled()
+    })
   })
 
   describe('useUpdateSamlConfiguration', () => {
@@ -153,6 +171,9 @@ describe('useSamlApi', () => {
       mockPut.mockResolvedValueOnce({ data: { enabled: false } })
       const store = buildStore(true)
       const dispatchSpy = jest.spyOn(store, 'dispatch')
+      const invalidateSpy = jest
+        .spyOn(QueryClient.prototype, 'invalidateQueries')
+        .mockResolvedValue(undefined)
       const { result } = renderHook(() => useUpdateSamlConfiguration(), {
         wrapper: createWrapper(store),
       })
@@ -162,7 +183,15 @@ describe('useSamlApi', () => {
       })
 
       expect(mockPut).toHaveBeenCalledWith('/kc/saml/properties', { enabled: false })
-      expect(dispatchSpy).toHaveBeenCalled()
+      // Assert the exact success-toast action, not merely that something was dispatched.
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'toast/updateToast',
+          payload: expect.objectContaining({ showToast: true, type: 'success' }),
+        }),
+      )
+      // The saml-properties cache must be refreshed after a successful update.
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['kc', 'saml', 'properties'] })
       expect(mockTriggerWebhook).toHaveBeenCalledWith(
         { enabled: false },
         'saml_configuration_write',
@@ -170,6 +199,8 @@ describe('useSamlApi', () => {
       expect(mockLogAuditUserAction).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'UPDATE' }),
       )
+
+      invalidateSpy.mockRestore()
     })
   })
 
@@ -264,7 +295,17 @@ describe('useSamlApi', () => {
           result.current.mutateAsync({ inum: 'idp-1', userMessage: 'x' }),
         ).rejects.toThrow('delete boom')
       })
-      expect(dispatchSpy).toHaveBeenCalled()
+      // Assert the exact error-toast action, including the propagated message.
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'toast/updateToast',
+          payload: expect.objectContaining({
+            showToast: true,
+            type: 'error',
+            message: 'delete boom',
+          }),
+        }),
+      )
     })
   })
 

--- a/admin-ui/plugins/saml/components/hooks/__tests__/useSamlApi.test.tsx
+++ b/admin-ui/plugins/saml/components/hooks/__tests__/useSamlApi.test.tsx
@@ -1,0 +1,310 @@
+import React from 'react'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import {
+  useSamlConfiguration,
+  useIdentityProviders,
+  useTrustRelationships,
+  useUpdateSamlConfiguration,
+  useCreateIdentityProvider,
+  useUpdateIdentityProvider,
+  useDeleteIdentityProvider,
+  useCreateTrustRelationship,
+  useDeleteTrustRelationshipMutation,
+} from 'Plugins/saml/components/hooks/useSamlApi'
+import type {
+  BrokerIdentityProviderForm,
+  TrustRelationshipForm,
+} from 'Plugins/saml/components/hooks/useSamlApi'
+import type { LogAuditParams } from 'Utils/AuditLogger'
+import type { JsonValue } from 'Routes/Apps/Gluu/types/common'
+
+const mockGet = jest.fn()
+const mockPost = jest.fn()
+const mockPut = jest.fn()
+const mockDelete = jest.fn()
+const mockLogAuditUserAction = jest.fn()
+const mockTriggerWebhook = jest.fn()
+
+jest.mock('Orval', () => ({
+  ...jest.requireActual('Orval'),
+  AXIOS_INSTANCE: {
+    get: (...args: Parameters<typeof mockGet>) => mockGet(...args),
+    post: (...args: Parameters<typeof mockPost>) => mockPost(...args),
+    put: (...args: Parameters<typeof mockPut>) => mockPut(...args),
+    delete: (...args: Parameters<typeof mockDelete>) => mockDelete(...args),
+  },
+}))
+
+jest.mock('@/audit', () => ({
+  useAuditContext: () => ({
+    userinfo: { inum: 'inum-1', name: 'admin' },
+    client_id: 'client-1',
+    ip_address: '127.0.0.1',
+  }),
+  CREATE: 'CREATE',
+  UPDATE: 'UPDATE',
+  DELETION: 'DELETION',
+}))
+
+jest.mock('Utils/AuditLogger', () => ({
+  logAuditUserAction: (params: LogAuditParams) => mockLogAuditUserAction(params),
+}))
+
+jest.mock('@/utils/triggerWebhookForFeature', () => ({
+  triggerWebhookForFeature: (data: Record<string, JsonValue>, feature: string) =>
+    mockTriggerWebhook(data, feature),
+}))
+
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn() },
+}))
+
+jest.mock('@/constants', () => ({
+  adminUiFeatures: {
+    saml_configuration_write: 'saml_configuration_write',
+    saml_idp_write: 'saml_idp_write',
+    saml_delete: 'saml_delete',
+  },
+}))
+
+const buildStore = (hasSession = true) =>
+  configureStore({
+    reducer: combineReducers({
+      authReducer: (state = { hasSession }) => state,
+      noReducer: (state = {}) => state,
+    }),
+  })
+
+const createWrapper = (store: ReturnType<typeof buildStore>) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>{children}</Provider>
+    </QueryClientProvider>
+  )
+}
+
+const idpForm: BrokerIdentityProviderForm = {
+  identityProvider: { displayName: 'IdP One' },
+}
+
+const trustForm: TrustRelationshipForm = {
+  trustRelationship: { displayName: 'TR One' },
+}
+
+describe('useSamlApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLogAuditUserAction.mockResolvedValue(undefined)
+    mockGet.mockResolvedValue({ data: {} })
+    mockPost.mockResolvedValue({ data: { inum: 'created' } })
+    mockPut.mockResolvedValue({ data: { inum: 'updated' } })
+    mockDelete.mockResolvedValue({ data: undefined })
+  })
+
+  describe('queries', () => {
+    it('fetches the saml properties when a session exists', async () => {
+      mockGet.mockResolvedValueOnce({ data: { enabled: true } })
+      const store = buildStore(true)
+      const { result } = renderHook(() => useSamlConfiguration(), {
+        wrapper: createWrapper(store),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockGet).toHaveBeenCalledWith('/kc/saml/properties')
+      expect(result.current.data).toEqual({ enabled: true })
+    })
+
+    it('does not run the properties query without a session', () => {
+      const store = buildStore(false)
+      const { result } = renderHook(() => useSamlConfiguration(), {
+        wrapper: createWrapper(store),
+      })
+      expect(result.current.fetchStatus).toBe('idle')
+      expect(mockGet).not.toHaveBeenCalled()
+    })
+
+    it('fetches identity providers with the supplied params', async () => {
+      mockGet.mockResolvedValueOnce({ data: { entries: [], totalEntriesCount: 0 } })
+      const store = buildStore(true)
+      const { result } = renderHook(() => useIdentityProviders({ limit: 5 }), {
+        wrapper: createWrapper(store),
+      })
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockGet).toHaveBeenCalledWith('/kc/saml/idp', { params: { limit: 5 } })
+    })
+
+    it('fetches trust relationships', async () => {
+      mockGet.mockResolvedValueOnce({ data: [] })
+      const store = buildStore(true)
+      const { result } = renderHook(() => useTrustRelationships(), {
+        wrapper: createWrapper(store),
+      })
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(mockGet).toHaveBeenCalledWith('/kc/saml/trust-relationships')
+    })
+  })
+
+  describe('useUpdateSamlConfiguration', () => {
+    it('updates, dispatches a success toast, triggers webhook and audits', async () => {
+      mockPut.mockResolvedValueOnce({ data: { enabled: false } })
+      const store = buildStore(true)
+      const dispatchSpy = jest.spyOn(store, 'dispatch')
+      const { result } = renderHook(() => useUpdateSamlConfiguration(), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({ data: { enabled: false }, userMessage: 'updated' })
+      })
+
+      expect(mockPut).toHaveBeenCalledWith('/kc/saml/properties', { enabled: false })
+      expect(dispatchSpy).toHaveBeenCalled()
+      expect(mockTriggerWebhook).toHaveBeenCalledWith(
+        { enabled: false },
+        'saml_configuration_write',
+      )
+      expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'UPDATE' }),
+      )
+    })
+  })
+
+  describe('useCreateIdentityProvider', () => {
+    it('uploads, sets savedForm, triggers webhook and audits with CREATE', async () => {
+      mockPost.mockResolvedValueOnce({ data: { inum: 'idp-1' } })
+      const store = buildStore(true)
+      const { result } = renderHook(() => useCreateIdentityProvider(), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({ data: idpForm, userMessage: 'created idp' })
+      })
+
+      expect(mockPost).toHaveBeenCalledWith('/kc/saml/idp/upload', expect.any(FormData))
+      expect(result.current.savedForm).toBe(true)
+      expect(mockTriggerWebhook).toHaveBeenCalledWith({ inum: 'idp-1' }, 'saml_idp_write')
+      expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'CREATE' }),
+      )
+
+      act(() => {
+        result.current.resetSavedForm()
+      })
+      expect(result.current.savedForm).toBe(false)
+    })
+
+    it('keeps savedForm false and rethrows when the upload fails', async () => {
+      mockPost.mockRejectedValueOnce(new Error('upload boom'))
+      const store = buildStore(true)
+      const { result } = renderHook(() => useCreateIdentityProvider(), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await expect(
+          result.current.mutateAsync({ data: idpForm, userMessage: 'x' }),
+        ).rejects.toThrow('upload boom')
+      })
+      expect(result.current.savedForm).toBe(false)
+    })
+  })
+
+  describe('useUpdateIdentityProvider', () => {
+    it('puts the identity provider and audits with UPDATE', async () => {
+      mockPut.mockResolvedValueOnce({ data: { inum: 'idp-1' } })
+      const store = buildStore(true)
+      const { result } = renderHook(() => useUpdateIdentityProvider(), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({ data: idpForm, userMessage: 'updated idp' })
+      })
+
+      expect(mockPut).toHaveBeenCalledWith('/kc/saml/idp/upload', expect.any(FormData))
+      expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'UPDATE' }),
+      )
+    })
+  })
+
+  describe('useDeleteIdentityProvider', () => {
+    it('deletes by inum, triggers webhook and audits with DELETION', async () => {
+      const store = buildStore(true)
+      const { result } = renderHook(() => useDeleteIdentityProvider(), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({ inum: 'idp-1', userMessage: 'removed' })
+      })
+
+      expect(mockDelete).toHaveBeenCalledWith('/kc/saml/idp/idp-1')
+      expect(mockTriggerWebhook).toHaveBeenCalledWith({ inum: 'idp-1' }, 'saml_delete')
+      expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'DELETION' }),
+      )
+    })
+
+    it('dispatches an error toast and rethrows when the delete fails', async () => {
+      mockDelete.mockRejectedValueOnce(new Error('delete boom'))
+      const store = buildStore(true)
+      const dispatchSpy = jest.spyOn(store, 'dispatch')
+      const { result } = renderHook(() => useDeleteIdentityProvider(), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await expect(
+          result.current.mutateAsync({ inum: 'idp-1', userMessage: 'x' }),
+        ).rejects.toThrow('delete boom')
+      })
+      expect(dispatchSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('trust relationship mutations', () => {
+    it('creates a trust relationship and audits with CREATE', async () => {
+      mockPost.mockResolvedValueOnce({ data: { inum: 'tr-1' } })
+      const store = buildStore(true)
+      const { result } = renderHook(() => useCreateTrustRelationship(), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({ data: trustForm, userMessage: 'created tr' })
+      })
+
+      expect(mockPost).toHaveBeenCalledWith(
+        '/kc/saml/trust-relationship/upload',
+        expect.any(FormData),
+      )
+      expect(result.current.savedForm).toBe(true)
+      expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'CREATE' }),
+      )
+    })
+
+    it('deletes a trust relationship by id and audits with DELETION', async () => {
+      const store = buildStore(true)
+      const { result } = renderHook(() => useDeleteTrustRelationshipMutation(), {
+        wrapper: createWrapper(store),
+      })
+
+      await act(async () => {
+        await result.current.mutateAsync({ id: 'tr-1', userMessage: 'removed' })
+      })
+
+      expect(mockDelete).toHaveBeenCalledWith('/kc/saml/trust-relationship/tr-1')
+      expect(mockTriggerWebhook).toHaveBeenCalledWith({ inum: 'tr-1' }, 'saml_delete')
+      expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'DELETION' }),
+      )
+    })
+  })
+})

--- a/admin-ui/plugins/scripts/components/hooks/__tests__/useCustomScriptApi.test.tsx
+++ b/admin-ui/plugins/scripts/components/hooks/__tests__/useCustomScriptApi.test.tsx
@@ -121,9 +121,12 @@ describe('useCustomScriptApi', () => {
     })
 
     it('disables the query when external enabled is false', () => {
-      renderHook(() => useCustomScriptsByType('person_authentication', undefined, { enabled: false }), {
-        wrapper: createWrapper(),
-      })
+      renderHook(
+        () => useCustomScriptsByType('person_authentication', undefined, { enabled: false }),
+        {
+          wrapper: createWrapper(),
+        },
+      )
       expect(mockUseGetConfigScriptsByType).toHaveBeenCalledWith(
         'person_authentication',
         undefined,

--- a/admin-ui/plugins/scripts/components/hooks/__tests__/useCustomScriptApi.test.tsx
+++ b/admin-ui/plugins/scripts/components/hooks/__tests__/useCustomScriptApi.test.tsx
@@ -1,0 +1,230 @@
+import React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { JsonValue } from 'Routes/Apps/Gluu/types/common'
+import type { CustomScript } from 'JansConfigApi'
+import {
+  useCustomScriptsByType,
+  useCustomScript,
+  useCustomScriptTypes,
+  useCreateCustomScript,
+  useUpdateCustomScript,
+  useDeleteCustomScript,
+} from 'Plugins/scripts/components/hooks/useCustomScriptApi'
+
+if (typeof globalThis.structuredClone !== 'function') {
+  globalThis.structuredClone = function structuredClonePolyfill<T>(value: T): T {
+    return JSON.parse(JSON.stringify(value)) as T
+  }
+}
+
+type WebhookArg = { createdFeatureValue: Record<string, JsonValue>; feature?: string }
+type AuditArgs = [string, string, Record<string, JsonValue>]
+
+const mockPostMutateAsync = jest.fn()
+const mockPutMutateAsync = jest.fn()
+const mockDeleteMutateAsync = jest.fn()
+const mockUseGetConfigScriptsByType = jest.fn()
+const mockUseGetConfigScriptsByInum = jest.fn()
+const mockUseGetCustomScriptType = jest.fn()
+const mockLogAuditAction = jest.fn((...args: AuditArgs) => args)
+const mockTriggerWebhook = jest.fn((payload: WebhookArg) => ({ type: 'webhook', payload }))
+const mockDispatch = jest.fn()
+const mockUpdateToast = jest.fn((show: boolean, type: string, message?: string) => ({
+  type: 'toast/update',
+  payload: { show, type, message },
+}))
+
+let mockHasSession = true
+
+jest.mock('JansConfigApi', () => ({
+  useGetConfigScriptsByType: (...args: Parameters<typeof mockUseGetConfigScriptsByType>) =>
+    mockUseGetConfigScriptsByType(...args),
+  useGetConfigScriptsByInum: (...args: Parameters<typeof mockUseGetConfigScriptsByInum>) =>
+    mockUseGetConfigScriptsByInum(...args),
+  useGetCustomScriptType: (...args: Parameters<typeof mockUseGetCustomScriptType>) =>
+    mockUseGetCustomScriptType(...args),
+  usePostConfigScripts: () => ({ mutateAsync: mockPostMutateAsync, isPending: false }),
+  usePutConfigScripts: () => ({ mutateAsync: mockPutMutateAsync, isPending: false }),
+  useDeleteConfigScriptsByInum: () => ({ mutateAsync: mockDeleteMutateAsync, isPending: false }),
+  getGetConfigScriptsQueryKey: () => ['/api/v1/config/scripts/'],
+  getGetConfigScriptsByTypeQueryKey: (type: string) => [`/api/v1/config/scripts/type/${type}`],
+  getGetConfigScriptsByInumQueryKey: (inum: string) => [`/api/v1/config/scripts/${inum}`],
+}))
+
+jest.mock('@/redux/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+  useAppSelector: (selector: (s: { authReducer: { hasSession: boolean } }) => boolean) =>
+    selector({ authReducer: { hasSession: mockHasSession } }),
+}))
+
+jest.mock('Redux/features/toastSlice', () => ({
+  updateToast: (show: boolean, type: string, message?: string) =>
+    mockUpdateToast(show, type, message),
+}))
+
+jest.mock('@/redux/features/toastSlice', () => ({
+  updateToast: (show: boolean, type: string, message?: string) =>
+    mockUpdateToast(show, type, message),
+}))
+
+jest.mock('Plugins/scripts/components/helper', () => ({
+  logAuditAction: (...args: AuditArgs) => mockLogAuditAction(...args),
+}))
+
+jest.mock('Plugins/admin/redux/features/WebhookSlice', () => ({
+  triggerWebhook: (payload: WebhookArg) => mockTriggerWebhook(payload),
+}))
+
+jest.mock('@/constants', () => ({
+  adminUiFeatures: {
+    custom_script_write: 'custom_script_write',
+    custom_script_delete: 'custom_script_delete',
+  },
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useCustomScriptApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockHasSession = true
+    mockUseGetConfigScriptsByType.mockReturnValue({ data: undefined, error: null })
+    mockUseGetConfigScriptsByInum.mockReturnValue({ data: undefined, error: null })
+    mockUseGetCustomScriptType.mockReturnValue({ data: [] })
+  })
+
+  describe('useCustomScriptsByType', () => {
+    it('passes type, params and enabled flag to the underlying query', () => {
+      renderHook(() => useCustomScriptsByType('person_authentication', { limit: 5 }), {
+        wrapper: createWrapper(),
+      })
+
+      expect(mockUseGetConfigScriptsByType).toHaveBeenCalledWith(
+        'person_authentication',
+        { limit: 5 },
+        expect.objectContaining({ query: expect.objectContaining({ enabled: true }) }),
+      )
+    })
+
+    it('dispatches an error toast when the query errors', () => {
+      mockUseGetConfigScriptsByType.mockReturnValue({ data: undefined, error: new Error('boom') })
+      renderHook(() => useCustomScriptsByType('person_authentication'), {
+        wrapper: createWrapper(),
+      })
+      expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error', expect.anything())
+    })
+
+    it('disables the query when external enabled is false', () => {
+      renderHook(() => useCustomScriptsByType('person_authentication', undefined, { enabled: false }), {
+        wrapper: createWrapper(),
+      })
+      expect(mockUseGetConfigScriptsByType).toHaveBeenCalledWith(
+        'person_authentication',
+        undefined,
+        expect.objectContaining({ query: expect.objectContaining({ enabled: false }) }),
+      )
+    })
+  })
+
+  describe('useCustomScript', () => {
+    it('enables the query only when inum and session are present', () => {
+      renderHook(() => useCustomScript('script-1'), { wrapper: createWrapper() })
+      expect(mockUseGetConfigScriptsByInum).toHaveBeenCalledWith(
+        'script-1',
+        expect.objectContaining({ query: expect.objectContaining({ enabled: true }) }),
+      )
+    })
+  })
+
+  describe('useCustomScriptTypes', () => {
+    it('formats script type strings via the select transform', () => {
+      renderHook(() => useCustomScriptTypes(), { wrapper: createWrapper() })
+      const options = mockUseGetCustomScriptType.mock.calls[0][0] as {
+        query: { select: (data: string[]) => Array<{ value: string; name: string }> }
+      }
+      const selected = options.query.select(['person_authentication', 'cache'])
+      expect(selected).toEqual([
+        { value: 'person_authentication', name: 'Person Authentication' },
+        { value: 'cache', name: 'Cache' },
+      ])
+    })
+
+    it('returns an empty list from select when data is not an array', () => {
+      renderHook(() => useCustomScriptTypes(), { wrapper: createWrapper() })
+      const options = mockUseGetCustomScriptType.mock.calls[0][0] as {
+        query: { select: (data: string[] | undefined) => Array<{ value: string; name: string }> }
+      }
+      expect(options.query.select(undefined)).toEqual([])
+    })
+  })
+
+  describe('useCreateCustomScript', () => {
+    it('creates, invalidates, triggers webhook and audits', async () => {
+      const created: CustomScript = { inum: 'new-1', scriptType: 'person_authentication' }
+      mockPostMutateAsync.mockResolvedValue(created)
+      const { result } = renderHook(() => useCreateCustomScript(), { wrapper: createWrapper() })
+
+      await act(async () => {
+        await result.current.mutateAsync({ data: created, actionMessage: 'created' })
+      })
+
+      expect(mockPostMutateAsync).toHaveBeenCalledWith({ data: created })
+      expect(mockTriggerWebhook).toHaveBeenCalledWith(
+        expect.objectContaining({ feature: 'custom_script_write' }),
+      )
+      expect(mockLogAuditAction).toHaveBeenCalledWith(
+        'CREATE',
+        'custom-script',
+        expect.objectContaining({
+          action: expect.objectContaining({ action_message: 'created' }),
+        }),
+      )
+    })
+  })
+
+  describe('useUpdateCustomScript', () => {
+    it('updates, triggers webhook and audits with UPDATE action', async () => {
+      const updated: CustomScript = { inum: 'upd-1', scriptType: 'person_authentication' }
+      mockPutMutateAsync.mockResolvedValue(updated)
+      const { result } = renderHook(() => useUpdateCustomScript(), { wrapper: createWrapper() })
+
+      await act(async () => {
+        await result.current.mutateAsync({ data: updated, actionMessage: 'updated' })
+      })
+
+      expect(mockPutMutateAsync).toHaveBeenCalledWith({ data: updated })
+      expect(mockTriggerWebhook).toHaveBeenCalled()
+      expect(mockLogAuditAction).toHaveBeenCalledWith('UPDATE', 'custom-script', expect.anything())
+    })
+  })
+
+  describe('useDeleteCustomScript', () => {
+    it('deletes, triggers a delete webhook and audits with DELETION action', async () => {
+      mockDeleteMutateAsync.mockResolvedValue(undefined)
+      const { result } = renderHook(() => useDeleteCustomScript(), { wrapper: createWrapper() })
+
+      await act(async () => {
+        await result.current.mutateAsync({ inum: 'del-1', actionMessage: 'removed' })
+      })
+
+      expect(mockDeleteMutateAsync).toHaveBeenCalledWith({ inum: 'del-1' })
+      expect(mockTriggerWebhook).toHaveBeenCalledWith(
+        expect.objectContaining({
+          createdFeatureValue: { inum: 'del-1' },
+          feature: 'custom_script_delete',
+        }),
+      )
+      expect(mockLogAuditAction).toHaveBeenCalledWith(
+        'DELETION',
+        'custom-script',
+        expect.objectContaining({ action: { action_data: { inum: 'del-1' } } }),
+      )
+    })
+  })
+})

--- a/admin-ui/plugins/scripts/components/hooks/__tests__/useMutationEffects.test.ts
+++ b/admin-ui/plugins/scripts/components/hooks/__tests__/useMutationEffects.test.ts
@@ -1,0 +1,123 @@
+import { renderHook } from '@testing-library/react'
+import type { UseMutationResult } from '@tanstack/react-query'
+import { useMutationEffects } from 'Plugins/scripts/components/hooks/useMutationEffects'
+
+const mockDispatch = jest.fn()
+const mockUpdateToast = jest.fn((show: boolean, type: string, message?: string) => ({
+  type: 'toast/update',
+  payload: { show, type, message },
+}))
+const mockNavigateBack = jest.fn()
+
+jest.mock('@/redux/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+}))
+
+jest.mock('Redux/features/toastSlice', () => ({
+  updateToast: (show: boolean, type: string, message?: string) =>
+    mockUpdateToast(show, type, message),
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+jest.mock('@/helpers/navigation', () => ({
+  useAppNavigation: () => ({ navigateBack: mockNavigateBack }),
+  ROUTES: { CUSTOM_SCRIPT_LIST: '/custom-script-list' },
+}))
+
+type ErrorLike = Error | { response?: { data?: string | { message?: string } } } | null
+
+type MutationState = {
+  isSuccess?: boolean
+  isError?: boolean
+  isIdle?: boolean
+  error?: ErrorLike
+}
+
+const buildMutation = (state: MutationState): UseMutationResult<object, Error, void, void> => {
+  const mutationLike = {
+    isSuccess: false,
+    isError: false,
+    isIdle: false,
+    error: null,
+    ...state,
+  }
+  return mutationLike as UseMutationResult<object, Error, void, void>
+}
+
+const renderEffects = (
+  mutation: UseMutationResult<object, Error, void, void>,
+  navigateOnSuccess = true,
+) =>
+  renderHook(() =>
+    useMutationEffects({
+      mutation,
+      successMessage: 'success.key',
+      errorMessage: 'error.key',
+      navigateOnSuccess,
+    }),
+  )
+
+describe('scripts useMutationEffects', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('dispatches a success toast and navigates back on success', () => {
+    renderEffects(buildMutation({ isSuccess: true }))
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'success', 'success.key')
+    expect(mockDispatch).toHaveBeenCalledTimes(1)
+    expect(mockNavigateBack).toHaveBeenCalledWith('/custom-script-list')
+  })
+
+  it('does not navigate when navigateOnSuccess is false', () => {
+    renderEffects(buildMutation({ isSuccess: true }), false)
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'success', 'success.key')
+    expect(mockNavigateBack).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the mutation is idle', () => {
+    renderEffects(buildMutation({ isIdle: true }))
+
+    expect(mockDispatch).not.toHaveBeenCalled()
+    expect(mockNavigateBack).not.toHaveBeenCalled()
+  })
+
+  it('dispatches an error toast using the axios response string', () => {
+    renderEffects(
+      buildMutation({
+        isError: true,
+        error: { response: { data: 'server says no' } },
+      }),
+    )
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error', 'server says no')
+  })
+
+  it('dispatches an error toast using the axios response message field', () => {
+    renderEffects(
+      buildMutation({
+        isError: true,
+        error: { response: { data: { message: 'detailed message' } } },
+      }),
+    )
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error', 'detailed message')
+  })
+
+  it('falls back to the Error message when no response data exists', () => {
+    renderEffects(buildMutation({ isError: true, error: new Error('boom') }))
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error', 'boom')
+  })
+
+  it('falls back to the translated error key when there is no usable message', () => {
+    renderEffects(buildMutation({ isError: true, error: {} }))
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error', 'error.key')
+  })
+})

--- a/admin-ui/plugins/user-claims/hooks/__tests__/useAttributeApi.test.tsx
+++ b/admin-ui/plugins/user-claims/hooks/__tests__/useAttributeApi.test.tsx
@@ -1,0 +1,231 @@
+import React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { JansAttribute } from 'JansConfigApi'
+import {
+  useAttributes,
+  useAttribute,
+  toAttributeList,
+  useCreateAttribute,
+  useUpdateAttribute,
+  useDeleteAttribute,
+} from 'Plugins/user-claims/hooks/useAttributeApi'
+
+const buildAttribute = (overrides: Partial<JansAttribute>): JansAttribute => ({
+  inum: 'attr-1',
+  name: 'email',
+  displayName: 'Email',
+  description: 'Email attribute',
+  dataType: 'string',
+  editType: ['admin'],
+  viewType: ['admin'],
+  ...overrides,
+})
+
+const mockPostMutateAsync = jest.fn()
+const mockPutMutateAsync = jest.fn()
+const mockDeleteMutateAsync = jest.fn()
+const mockUseGetAttributes = jest.fn()
+const mockUseGetAttributesByInum = jest.fn()
+const mockLogAudit = jest.fn()
+const mockTriggerAttributeWebhook = jest.fn()
+const mockDispatch = jest.fn()
+const mockLoggerError = jest.fn()
+
+type MutationOptions = { mutation?: { onError?: (e: Error) => void } }
+
+let mockHasSession = true
+let postOptions: MutationOptions | undefined
+
+jest.mock('JansConfigApi', () => ({
+  useGetAttributes: (...args: Parameters<typeof mockUseGetAttributes>) =>
+    mockUseGetAttributes(...args),
+  useGetAttributesByInum: (...args: Parameters<typeof mockUseGetAttributesByInum>) =>
+    mockUseGetAttributesByInum(...args),
+  usePostAttributes: (options: MutationOptions) => {
+    postOptions = options
+    return { mutateAsync: mockPostMutateAsync, isPending: false }
+  },
+  usePutAttributes: () => ({ mutateAsync: mockPutMutateAsync, isPending: false }),
+  useDeleteAttributesByInum: () => ({ mutateAsync: mockDeleteMutateAsync, isPending: false }),
+  getGetAttributesQueryKey: () => ['/api/v1/attributes'],
+  getGetAttributesByInumQueryKey: (inum: string) => [`/api/v1/attributes/${inum}`],
+}))
+
+jest.mock('@/redux/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+  useAppSelector: (selector: (s: { authReducer: { hasSession: boolean } }) => boolean) =>
+    selector({ authReducer: { hasSession: mockHasSession } }),
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+jest.mock('Redux/features/toastSlice', () => ({
+  updateToast: (show: boolean, type: string, message?: string) => ({
+    type: 'toast/update',
+    payload: { show, type, message },
+  }),
+}))
+
+jest.mock('Plugins/user-claims/hooks/useSchemaAuditLogger', () => ({
+  useSchemaAuditLogger: () => ({ logAudit: mockLogAudit }),
+}))
+
+jest.mock('Plugins/user-claims/hooks/useSchemaWebhook', () => ({
+  useSchemaWebhook: () => ({ triggerAttributeWebhook: mockTriggerAttributeWebhook }),
+}))
+
+jest.mock('@/utils/logger', () => ({
+  logger: { error: (...args: Parameters<typeof mockLoggerError>) => mockLoggerError(...args) },
+}))
+
+jest.mock('@/constants', () => ({
+  adminUiFeatures: { attributes_write: 'attributes_write', attributes_delete: 'attributes_delete' },
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useAttributeApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockHasSession = true
+    mockLogAudit.mockResolvedValue(undefined)
+    mockUseGetAttributes.mockReturnValue({ data: undefined, error: null })
+    mockUseGetAttributesByInum.mockReturnValue({ data: undefined, error: null })
+  })
+
+  describe('useAttributes', () => {
+    it('enables the query when a session exists', () => {
+      renderHook(() => useAttributes({ limit: 10 }), { wrapper: createWrapper() })
+      expect(mockUseGetAttributes).toHaveBeenCalledWith(
+        { limit: 10 },
+        expect.objectContaining({ query: expect.objectContaining({ enabled: true }) }),
+      )
+    })
+
+    it('disables the query when there is no session', () => {
+      mockHasSession = false
+      renderHook(() => useAttributes(), { wrapper: createWrapper() })
+      expect(mockUseGetAttributes).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({ query: expect.objectContaining({ enabled: false }) }),
+      )
+    })
+  })
+
+  describe('toAttributeList', () => {
+    it('returns an empty array when no entries are provided', () => {
+      expect(toAttributeList()).toEqual([])
+    })
+
+    it('maps entries into attribute objects', () => {
+      const list = toAttributeList([{ inum: 'a' }, { inum: 'b' }])
+      expect(list).toHaveLength(2)
+      expect(list[0]).toEqual({ inum: 'a' })
+    })
+  })
+
+  describe('useAttribute', () => {
+    it('enables the query only when inum and session exist', () => {
+      renderHook(() => useAttribute('attr-1'), { wrapper: createWrapper() })
+      expect(mockUseGetAttributesByInum).toHaveBeenCalledWith(
+        'attr-1',
+        expect.objectContaining({ query: expect.objectContaining({ enabled: true }) }),
+      )
+    })
+  })
+
+  describe('useCreateAttribute', () => {
+    it('creates, invalidates, triggers webhook and audits with CREATE', async () => {
+      const created = buildAttribute({ inum: 'attr-1', name: 'email' })
+      mockPostMutateAsync.mockResolvedValue(created)
+      const { result } = renderHook(() => useCreateAttribute(), { wrapper: createWrapper() })
+
+      await act(async () => {
+        await result.current.mutateAsync({ data: created, userMessage: 'created' })
+      })
+
+      expect(mockPostMutateAsync).toHaveBeenCalledWith({ data: created })
+      expect(mockTriggerAttributeWebhook).toHaveBeenCalledWith(created)
+      expect(mockLogAudit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'CREATE',
+          resource: 'api-attribute',
+          message: 'created',
+          payload: created,
+        }),
+      )
+    })
+
+    it('exposes a mutate wrapper that logs failures without throwing', async () => {
+      mockPostMutateAsync.mockRejectedValue(new Error('create boom'))
+      const { result } = renderHook(() => useCreateAttribute(), { wrapper: createWrapper() })
+
+      await act(async () => {
+        result.current.mutate({ data: buildAttribute({ inum: 'x' }) })
+        await Promise.resolve()
+      })
+
+      expect(typeof result.current.mutate).toBe('function')
+    })
+
+    it('dispatches an error toast through the onError handler', () => {
+      renderHook(() => useCreateAttribute(), { wrapper: createWrapper() })
+      const dispatchCallsBefore = mockDispatch.mock.calls.length
+      postOptions?.mutation?.onError?.(new Error('server boom'))
+      expect(mockDispatch.mock.calls.length).toBeGreaterThan(dispatchCallsBefore)
+    })
+  })
+
+  describe('useUpdateAttribute', () => {
+    it('updates, invalidates and audits with UPDATE and modifiedFields', async () => {
+      const updated = buildAttribute({ inum: 'attr-1', name: 'email' })
+      mockPutMutateAsync.mockResolvedValue(updated)
+      const { result } = renderHook(() => useUpdateAttribute(), { wrapper: createWrapper() })
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          data: updated,
+          userMessage: 'updated',
+          modifiedFields: { name: 'email' },
+        })
+      })
+
+      expect(mockPutMutateAsync).toHaveBeenCalledWith({ data: updated })
+      expect(mockTriggerAttributeWebhook).toHaveBeenCalledWith(updated)
+      expect(mockLogAudit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'UPDATE',
+          modifiedFields: { name: 'email' },
+        }),
+      )
+    })
+  })
+
+  describe('useDeleteAttribute', () => {
+    it('deletes, triggers a delete webhook and audits with DELETION', async () => {
+      mockDeleteMutateAsync.mockResolvedValue(undefined)
+      const { result } = renderHook(() => useDeleteAttribute(), { wrapper: createWrapper() })
+
+      await act(async () => {
+        await result.current.mutateAsync({ inum: 'attr-1', name: 'email', userMessage: 'removed' })
+      })
+
+      expect(mockDeleteMutateAsync).toHaveBeenCalledWith({ inum: 'attr-1' })
+      expect(mockTriggerAttributeWebhook).toHaveBeenCalledWith(
+        { inum: 'attr-1', name: 'email' },
+        'attributes_delete',
+      )
+      expect(mockLogAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'DELETION', payload: { inum: 'attr-1', name: 'email' } }),
+      )
+    })
+  })
+})

--- a/admin-ui/plugins/user-claims/hooks/__tests__/useAttributeApi.test.tsx
+++ b/admin-ui/plugins/user-claims/hooks/__tests__/useAttributeApi.test.tsx
@@ -165,22 +165,40 @@ describe('useAttributeApi', () => {
     })
 
     it('exposes a mutate wrapper that logs failures without throwing', async () => {
-      mockPostMutateAsync.mockRejectedValue(new Error('create boom'))
+      const failure = new Error('create boom')
+      mockPostMutateAsync.mockRejectedValue(failure)
       const { result } = renderHook(() => useCreateAttribute(), { wrapper: createWrapper() })
 
       await act(async () => {
-        result.current.mutate({ data: buildAttribute({ inum: 'x' }) })
+        // The wrapper swallows the rejection; calling it must not throw.
+        expect(() => result.current.mutate({ data: buildAttribute({ inum: 'x' }) })).not.toThrow()
+        await Promise.resolve()
         await Promise.resolve()
       })
 
-      expect(typeof result.current.mutate).toBe('function')
+      expect(mockLoggerError).toHaveBeenCalledWith('Create attribute failed:', failure)
     })
 
-    it('dispatches an error toast through the onError handler', () => {
+    it('dispatches the exact error toast through the onError handler', () => {
       renderHook(() => useCreateAttribute(), { wrapper: createWrapper() })
-      const dispatchCallsBefore = mockDispatch.mock.calls.length
       postOptions?.mutation?.onError?.(new Error('server boom'))
-      expect(mockDispatch.mock.calls.length).toBeGreaterThan(dispatchCallsBefore)
+      // Plain error has no response.data.message, so it falls back to the i18n key.
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'toast/update',
+        payload: { show: true, type: 'error', message: 'messages.error_in_saving' },
+      })
+    })
+
+    it('uses the server-provided message in the error toast when present', () => {
+      renderHook(() => useCreateAttribute(), { wrapper: createWrapper() })
+      const apiError = Object.assign(new Error('server boom'), {
+        response: { data: { message: 'Name already exists' } },
+      })
+      postOptions?.mutation?.onError?.(apiError)
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'toast/update',
+        payload: { show: true, type: 'error', message: 'Name already exists' },
+      })
     })
   })
 

--- a/admin-ui/plugins/user-claims/hooks/__tests__/useMutationEffects.test.ts
+++ b/admin-ui/plugins/user-claims/hooks/__tests__/useMutationEffects.test.ts
@@ -1,0 +1,112 @@
+import { renderHook } from '@testing-library/react'
+import type { UseMutationResult } from '@tanstack/react-query'
+import { useMutationEffects } from 'Plugins/user-claims/hooks/useMutationEffects'
+
+const mockDispatch = jest.fn()
+const mockUpdateToast = jest.fn((show: boolean, type: string, message?: string) => ({
+  type: 'toast/update',
+  payload: { show, type, message },
+}))
+const mockNavigateBack = jest.fn()
+
+jest.mock('@/redux/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+}))
+
+jest.mock('Redux/features/toastSlice', () => ({
+  updateToast: (show: boolean, type: string, message?: string) =>
+    mockUpdateToast(show, type, message),
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+jest.mock('@/helpers/navigation', () => ({
+  useAppNavigation: () => ({ navigateBack: mockNavigateBack }),
+  ROUTES: { ATTRIBUTES_LIST: '/attributes-list' },
+}))
+
+type ErrorLike = Error | { response?: { data?: string | { message?: string } } } | null
+
+type MutationState = {
+  isSuccess?: boolean
+  isError?: boolean
+  error?: ErrorLike
+}
+
+const buildMutation = (state: MutationState): UseMutationResult<object, Error, void, void> => {
+  const mutationLike = {
+    isSuccess: false,
+    isError: false,
+    error: null,
+    ...state,
+  }
+  return mutationLike as UseMutationResult<object, Error, void, void>
+}
+
+const renderEffects = (
+  mutation: UseMutationResult<object, Error, void, void>,
+  navigateOnSuccess = true,
+) =>
+  renderHook(() =>
+    useMutationEffects({
+      mutation,
+      successMessage: 'success.key',
+      errorMessage: 'error.key',
+      navigateOnSuccess,
+    }),
+  )
+
+describe('user-claims useMutationEffects', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('dispatches a success toast and navigates to the attributes list on success', () => {
+    renderEffects(buildMutation({ isSuccess: true }))
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'success', 'success.key')
+    expect(mockNavigateBack).toHaveBeenCalledWith('/attributes-list')
+  })
+
+  it('does not navigate when navigateOnSuccess is false', () => {
+    renderEffects(buildMutation({ isSuccess: true }), false)
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'success', 'success.key')
+    expect(mockNavigateBack).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the mutation is neither successful nor errored', () => {
+    renderEffects(buildMutation({}))
+
+    expect(mockDispatch).not.toHaveBeenCalled()
+    expect(mockNavigateBack).not.toHaveBeenCalled()
+  })
+
+  it('dispatches an error toast using the axios response string', () => {
+    renderEffects(buildMutation({ isError: true, error: { response: { data: 'server says no' } } }))
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error', 'server says no')
+  })
+
+  it('dispatches an error toast using the axios response message field', () => {
+    renderEffects(
+      buildMutation({ isError: true, error: { response: { data: { message: 'detailed' } } } }),
+    )
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error', 'detailed')
+  })
+
+  it('falls back to the Error message when no response data exists', () => {
+    renderEffects(buildMutation({ isError: true, error: new Error('boom') }))
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error', 'boom')
+  })
+
+  it('falls back to the translated error key when there is no usable message', () => {
+    renderEffects(buildMutation({ isError: true, error: {} }))
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error', 'error.key')
+  })
+})

--- a/admin-ui/plugins/user-claims/hooks/__tests__/useSchemaAuditLogger.test.ts
+++ b/admin-ui/plugins/user-claims/hooks/__tests__/useSchemaAuditLogger.test.ts
@@ -1,0 +1,134 @@
+import { renderHook, act } from '@testing-library/react'
+import type { LogAuditParams } from 'Utils/AuditLogger'
+import { useSchemaAuditLogger } from 'Plugins/user-claims/hooks/useSchemaAuditLogger'
+
+const mockLogAuditUserAction = jest.fn()
+const mockLoggerError = jest.fn()
+
+type AuthState = {
+  userinfo?: { inum: string; name: string }
+  config?: { clientId?: string }
+  location?: { IPv4?: string }
+}
+
+let mockAuthState: AuthState = {
+  userinfo: { inum: 'inum-123', name: 'admin' },
+  config: { clientId: 'client-1' },
+  location: { IPv4: '127.0.0.1' },
+}
+
+jest.mock('@/redux/hooks', () => ({
+  useAppSelector: jest.fn((selector: (s: { authReducer: AuthState }) => AuthState) =>
+    selector({ authReducer: mockAuthState }),
+  ),
+}))
+
+jest.mock('@/utils/AuditLogger', () => ({
+  logAuditUserAction: (params: LogAuditParams) => mockLogAuditUserAction(params),
+}))
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    error: (message: string, detail: Error | string) => mockLoggerError(message, detail),
+  },
+}))
+
+describe('useSchemaAuditLogger', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLogAuditUserAction.mockResolvedValue(undefined)
+    mockAuthState = {
+      userinfo: { inum: 'inum-123', name: 'admin' },
+      config: { clientId: 'client-1' },
+      location: { IPv4: '127.0.0.1' },
+    }
+  })
+
+  it('returns a logAudit function', () => {
+    const { result } = renderHook(() => useSchemaAuditLogger())
+    expect(typeof result.current.logAudit).toBe('function')
+  })
+
+  it('forwards a non-update action with its payload and audit context', async () => {
+    const { result } = renderHook(() => useSchemaAuditLogger())
+    const payload = { inum: 'attr-1' }
+
+    await act(async () => {
+      await result.current.logAudit({
+        action: 'CREATE',
+        resource: 'api-attribute',
+        message: 'created',
+        payload,
+      })
+    })
+
+    expect(mockLogAuditUserAction).toHaveBeenCalledTimes(1)
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'CREATE',
+        resource: 'api-attribute',
+        message: 'created',
+        client_id: 'client-1',
+        userinfo: { inum: 'inum-123', name: 'admin' },
+        extra: { ip_address: '127.0.0.1' },
+        payload,
+      }),
+    )
+  })
+
+  it('omits the payload for UPDATE actions and forwards modifiedFields', async () => {
+    const { result } = renderHook(() => useSchemaAuditLogger())
+
+    await act(async () => {
+      await result.current.logAudit({
+        action: 'UPDATE',
+        resource: 'api-attribute',
+        message: 'updated',
+        payload: { inum: 'attr-1' },
+        modifiedFields: { displayName: 'new' },
+      })
+    })
+
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'UPDATE',
+        payload: undefined,
+        modifiedFields: { displayName: 'new' },
+      }),
+    )
+  })
+
+  it('passes an empty extra object when no IP address is available', async () => {
+    mockAuthState = { userinfo: { inum: 'inum-123', name: 'admin' } }
+    const { result } = renderHook(() => useSchemaAuditLogger())
+
+    await act(async () => {
+      await result.current.logAudit({
+        action: 'CREATE',
+        resource: 'api-attribute',
+        message: 'created',
+        payload: {},
+      })
+    })
+
+    expect(mockLogAuditUserAction).toHaveBeenCalledWith(expect.objectContaining({ extra: {} }))
+  })
+
+  it('logs an error and does not throw when logAuditUserAction rejects', async () => {
+    const failure = new Error('audit failed')
+    mockLogAuditUserAction.mockRejectedValueOnce(failure)
+    const { result } = renderHook(() => useSchemaAuditLogger())
+
+    await act(async () => {
+      await expect(
+        result.current.logAudit({ action: 'CREATE', resource: 'r', message: 'm', payload: {} }),
+      ).resolves.toBeUndefined()
+    })
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1)
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      '[useSchemaAuditLogger] Failed to log audit action:',
+      failure,
+    )
+  })
+})

--- a/admin-ui/plugins/user-claims/hooks/__tests__/useSchemaWebhook.test.ts
+++ b/admin-ui/plugins/user-claims/hooks/__tests__/useSchemaWebhook.test.ts
@@ -1,0 +1,84 @@
+import { renderHook, act } from '@testing-library/react'
+import type { JsonValue } from 'Routes/Apps/Gluu/types/common'
+import { useSchemaWebhook } from 'Plugins/user-claims/hooks/useSchemaWebhook'
+
+type WebhookArg = { createdFeatureValue: Record<string, JsonValue>; feature: string }
+
+const mockDispatch = jest.fn()
+const mockTriggerWebhook = jest.fn((payload: WebhookArg) => ({ type: 'webhook/trigger', payload }))
+const mockLoggerError = jest.fn()
+
+jest.mock('@/redux/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+}))
+
+jest.mock('Plugins/admin/redux/features/WebhookSlice', () => ({
+  triggerWebhook: (payload: WebhookArg) => mockTriggerWebhook(payload),
+}))
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    error: (message: string, detail: Error | string) => mockLoggerError(message, detail),
+  },
+}))
+
+jest.mock('@/constants', () => ({
+  adminUiFeatures: {
+    attributes_write: 'attributes_write',
+    attributes_delete: 'attributes_delete',
+  },
+}))
+
+describe('useSchemaWebhook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns a triggerAttributeWebhook function', () => {
+    const { result } = renderHook(() => useSchemaWebhook())
+    expect(typeof result.current.triggerAttributeWebhook).toBe('function')
+  })
+
+  it('dispatches the webhook with the default attributes_write feature', () => {
+    const { result } = renderHook(() => useSchemaWebhook())
+    const attribute = { inum: 'attr-1', name: 'email' }
+
+    act(() => {
+      result.current.triggerAttributeWebhook(attribute)
+    })
+
+    expect(mockTriggerWebhook).toHaveBeenCalledWith({
+      createdFeatureValue: attribute,
+      feature: 'attributes_write',
+    })
+    expect(mockDispatch).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the provided feature when one is passed', () => {
+    const { result } = renderHook(() => useSchemaWebhook())
+
+    act(() => {
+      result.current.triggerAttributeWebhook({ inum: 'attr-1' }, 'attributes_delete')
+    })
+
+    expect(mockTriggerWebhook).toHaveBeenCalledWith(
+      expect.objectContaining({ feature: 'attributes_delete' }),
+    )
+  })
+
+  it('logs an error and does not throw when dispatch fails', () => {
+    const failure = new Error('dispatch failed')
+    mockDispatch.mockImplementationOnce(() => {
+      throw failure
+    })
+    const { result } = renderHook(() => useSchemaWebhook())
+
+    expect(() => {
+      act(() => {
+        result.current.triggerAttributeWebhook({ inum: 'attr-1' })
+      })
+    }).not.toThrow()
+
+    expect(mockLoggerError).toHaveBeenCalledWith('Failed to trigger attribute webhook:', failure)
+  })
+})

--- a/admin-ui/plugins/user-management/hooks/__tests__/useUserMutations.test.tsx
+++ b/admin-ui/plugins/user-management/hooks/__tests__/useUserMutations.test.tsx
@@ -1,0 +1,178 @@
+import React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useDeleteUserWithAudit } from 'Plugins/user-management/hooks/useUserMutations'
+import type { CustomUser } from 'Plugins/user-management/types'
+
+const mockDeleteMutateAsync = jest.fn()
+const mockUseDeleteUser = jest.fn()
+const mockInvalidateQueriesByKey = jest.fn()
+const mockLogUserDeletion = jest.fn()
+const mockTriggerUserWebhook = jest.fn()
+const mockGetErrorMessage = jest.fn((_error: Error) => 'mapped error')
+const mockUpdateToast = jest.fn((show: boolean, type: string, message?: string) => ({
+  type: 'toast/update',
+  payload: { show, type, message },
+}))
+const mockDispatch = jest.fn()
+const mockLoggerError = jest.fn()
+
+jest.mock('JansConfigApi', () => ({
+  useDeleteUser: () => mockUseDeleteUser(),
+  getGetUserQueryKey: () => ['users'],
+}))
+
+jest.mock('@/utils/queryUtils', () => ({
+  __esModule: true,
+  default: {
+    invalidateQueriesByKey: (...args: Parameters<typeof mockInvalidateQueriesByKey>) =>
+      mockInvalidateQueriesByKey(...args),
+  },
+}))
+
+jest.mock('@/redux/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+}))
+
+jest.mock('Redux/features/toastSlice', () => ({
+  updateToast: (show: boolean, type: string, message?: string) =>
+    mockUpdateToast(show, type, message),
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+jest.mock('Plugins/user-management/helper', () => ({
+  logUserDeletion: (...args: Parameters<typeof mockLogUserDeletion>) =>
+    mockLogUserDeletion(...args),
+  getErrorMessage: (...args: Parameters<typeof mockGetErrorMessage>) =>
+    mockGetErrorMessage(...args),
+  triggerUserWebhook: (...args: Parameters<typeof mockTriggerUserWebhook>) =>
+    mockTriggerUserWebhook(...args),
+}))
+
+jest.mock('@/constants', () => ({
+  adminUiFeatures: { users_delete: 'users_delete' },
+}))
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    error: (...args: Parameters<typeof mockLoggerError>) => mockLoggerError(...args),
+  },
+}))
+
+const userData: CustomUser = { inum: 'user-1', userId: 'jdoe' } as CustomUser
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useDeleteUserWithAudit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDeleteMutateAsync.mockResolvedValue(undefined)
+    mockLogUserDeletion.mockResolvedValue(undefined)
+    mockInvalidateQueriesByKey.mockResolvedValue(undefined)
+    mockUseDeleteUser.mockReturnValue({
+      mutateAsync: mockDeleteMutateAsync,
+      isPending: false,
+      isError: false,
+      error: null,
+    })
+  })
+
+  it('exposes deleteUser and pass-through mutation state', () => {
+    const { result } = renderHook(() => useDeleteUserWithAudit(), { wrapper: createWrapper() })
+    expect(typeof result.current.deleteUser).toBe('function')
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isError).toBe(false)
+  })
+
+  it('runs the full delete flow: delete, audit, webhook, invalidate, success toast', async () => {
+    const onSuccess = jest.fn()
+    const { result } = renderHook(() => useDeleteUserWithAudit({ onSuccess }), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.deleteUser('user-1', 'msg', userData)
+    })
+
+    expect(mockDeleteMutateAsync).toHaveBeenCalledWith({ inum: 'user-1' })
+    expect(mockLogUserDeletion).toHaveBeenCalledWith('user-1', userData)
+    expect(mockTriggerUserWebhook).toHaveBeenCalledWith(userData, 'users_delete')
+    expect(mockInvalidateQueriesByKey).toHaveBeenCalledWith(expect.anything(), ['users'])
+    expect(mockUpdateToast).toHaveBeenLastCalledWith(
+      true,
+      'success',
+      'messages.user_deleted_successfully',
+    )
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not trigger the webhook when no userData is provided', async () => {
+    const { result } = renderHook(() => useDeleteUserWithAudit(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      await result.current.deleteUser('user-1')
+    })
+
+    expect(mockTriggerUserWebhook).not.toHaveBeenCalled()
+    expect(mockLogUserDeletion).toHaveBeenCalledWith('user-1', undefined)
+  })
+
+  it('dispatches an error toast and rethrows when the delete fails', async () => {
+    const failure = new Error('delete boom')
+    mockDeleteMutateAsync.mockRejectedValueOnce(failure)
+    const onError = jest.fn()
+    const { result } = renderHook(() => useDeleteUserWithAudit({ onError }), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await expect(result.current.deleteUser('user-1', 'msg', userData)).rejects.toThrow(
+        'delete boom',
+      )
+    })
+
+    expect(mockGetErrorMessage).toHaveBeenCalledWith(failure)
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'error', 'mapped error')
+    expect(onError).toHaveBeenCalledWith(failure)
+    expect(mockLogUserDeletion).not.toHaveBeenCalled()
+  })
+
+  it('dispatches a warning toast and continues when audit logging fails', async () => {
+    mockLogUserDeletion.mockRejectedValueOnce(new Error('audit boom'))
+    const { result } = renderHook(() => useDeleteUserWithAudit(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      await result.current.deleteUser('user-1', 'msg', userData)
+    })
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(true, 'warning', 'messages.audit_logging_failed')
+    expect(mockUpdateToast).toHaveBeenLastCalledWith(
+      true,
+      'success',
+      'messages.user_deleted_successfully',
+    )
+  })
+
+  it('dispatches a warning toast and continues when query invalidation fails', async () => {
+    mockInvalidateQueriesByKey.mockRejectedValueOnce(new Error('invalidate boom'))
+    const { result } = renderHook(() => useDeleteUserWithAudit(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      await result.current.deleteUser('user-1', 'msg', userData)
+    })
+
+    expect(mockUpdateToast).toHaveBeenCalledWith(
+      true,
+      'warning',
+      'messages.query_invalidation_failed',
+    )
+  })
+})


### PR DESCRIPTION
### feat(admin-ui): add test files for all hooks across the system (#2895)

#### Summary
This PR expands the Admin UI test suite by adding test files for hooks across the application that previously had no dedicated test coverage.

The goal is to improve confidence in shared business logic, reduce regression risk, and strengthen the overall Jest test suite by ensuring reusable hooks are independently validated.

---

#### Fix Summary
- Added test files for hooks that previously had no test coverage
- Increased unit test coverage across shared and feature-specific hooks
- Added validation for hook initialization and default behavior
- Added tests for success and error scenarios where applicable
- Improved consistency of hook testing across Admin UI modules and plugins
- Established a foundation for future hook enhancements and regression testing
- Aligned hook tests with existing Jest testing patterns

---

#### Verification

```bash
npm run test:all
npm run check:all
```

passes successfully.

- Verified all newly added hook test files execute successfully
- Verified existing test suites remain unaffected
- Verified hook behavior is validated across supported scenarios
- Verified lint and type-check pass successfully
- Verified no regressions introduced by the additional test coverage

---

#### 🔗 Ticket

Closes: #2895

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added and expanded Jest + React Testing Library coverage for many admin UI hooks (profiles, dashboards, licenses, assets, health, mapping, webhooks, SAML, scripts, user claims, user management, and more).
  * Validated session/permission-aware query enabling, data shaping and formatting, aggregated/normalized outputs, mutation success/error flows, toast and navigation side effects, and audit/webhook logging behavior.
  * Added coverage for debouncing and first-authorized-path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->