### PR TITLE
fix(admin-ui): data not preloading on the Asset edit page (#2913)

### DIFF
--- a/admin-ui/app/routes/Apps/Gluu/GluuSelectRow.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/GluuSelectRow.tsx
@@ -72,12 +72,20 @@ const GluuSelectRow: React.FC<GluuSelectRowProps> = ({
   )
 
   const displayValue = value != null ? String(value) : ''
+  const resolvedValues = useMemo(() => {
+    if (!displayValue) return values
+    const hasValue = values.some(
+      (item) => (typeof item === 'string' ? item : item.value) === displayValue,
+    )
+    return hasValue ? values : [displayValue, ...values]
+  }, [values, displayValue])
+
   const options = useMemo(
     () =>
-      deduplicateSelectValues(values).map((item) =>
+      deduplicateSelectValues(resolvedValues).map((item) =>
         typeof item === 'string' ? item : (item.label ?? item.value),
       ),
-    [values],
+    [resolvedValues],
   )
 
   const content = freeSolo ? (
@@ -147,7 +155,7 @@ const GluuSelectRow: React.FC<GluuSelectRowProps> = ({
             className={classes.select}
           >
             {!hideChooseOption && <option value="">{t('actions.choose')}...</option>}
-            {deduplicateSelectValues(values).map((item) => {
+            {deduplicateSelectValues(resolvedValues).map((item) => {
               const optionValue = typeof item === 'string' ? item : item.value
               const optionLabel = typeof item === 'string' ? item : (item.label ?? item.value)
               return (

--- a/admin-ui/plugins/admin/components/Assets/AssetForm.tsx
+++ b/admin-ui/plugins/admin/components/Assets/AssetForm.tsx
@@ -36,10 +36,13 @@ import { T_KEYS } from './constants'
 
 const AssetForm: React.FC = () => {
   const { id } = useParams<RouteParams>()
-  const { data: assetPage, isLoading: isLoadingAsset } = useGetAssetByInum(id ?? '', {
+  const { data: assetResponse, isLoading: isLoadingAsset } = useGetAssetByInum(id ?? '', {
     query: { enabled: !!id },
   })
-  const asset = assetPage?.entries?.[0] as Document | undefined
+  const asset = useMemo(() => {
+    const entry = assetResponse?.entries?.[0]
+    return (entry ?? assetResponse) as Document | undefined
+  }, [assetResponse])
   const { data: servicesData } = useAssetServices()
   const services = servicesData ?? []
   const { t, i18n } = useTranslation()


### PR DESCRIPTION
### fix(admin-ui): data not preloading on the Asset edit page (#2913)

#### Summary
This PR fixes an issue where asset data was not being loaded when opening the Asset page in edit mode.

The update ensures the existing asset details are fetched correctly before rendering the edit form, allowing users to view and modify the current asset configuration without manually reloading the page.

---

#### Fix Summary
- Fixed asset data fetching in edit mode
- Ensured existing asset details are loaded before rendering the edit form
- Restored pre-population of asset fields during editing
- Corrected edit page initialization flow
- Preserved existing asset creation behavior
- Improved reliability of the Asset management workflow

---

#### Verification

```bash
npm run check:all
```

passes successfully.

- Verified asset data is preloaded when opening an existing asset for editing
- Verified all asset fields are populated with the existing values
- Verified asset updates can be saved successfully
- Verified asset creation flow remains unaffected
- Verified no regressions in the Asset management workflow

---

#### 🔗 Ticket

Closes: #2913

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection fields so the currently chosen value remains visible even if it is not included in the latest list of options.
  * Made asset details load more reliably when data is returned in different response shapes, helping prevent missing or inconsistent asset information in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->