### PR TITLE
feat(admin-ui): implement responsive mobile layout for Scopes, Auth Server Properties, and Config API Configuration pages

### DIFF
--- a/admin-ui/app/components/GluuDetailGrid/GluuDetailGrid.style.ts
+++ b/admin-ui/app/components/GluuDetailGrid/GluuDetailGrid.style.ts
@@ -1,5 +1,7 @@
 import { makeStyles } from 'tss-react/mui'
-import { SPACING } from '@/constants'
+import { MOBILE_MEDIA_QUERY, SPACING } from '@/constants'
+
+const MOBILE_DETAIL_COL_MIN = 160
 
 export const useStyles = makeStyles()((theme) => ({
   detailGrid: {
@@ -11,8 +13,8 @@ export const useStyles = makeStyles()((theme) => ({
     [theme.breakpoints.down('lg')]: {
       gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
     },
-    [theme.breakpoints.down('sm')]: {
-      gridTemplateColumns: '1fr',
+    [`@media ${MOBILE_MEDIA_QUERY}`]: {
+      gridTemplateColumns: `repeat(auto-fit, minmax(${MOBILE_DETAIL_COL_MIN}px, 1fr))`,
     },
   },
   detailItem: {

--- a/admin-ui/app/components/GluuTable/GluuTable.style.ts
+++ b/admin-ui/app/components/GluuTable/GluuTable.style.ts
@@ -17,6 +17,16 @@ import { fontFamily, fontSizes, fontWeights } from '@/styles/fonts'
 const EXPAND_BUTTON_SIZE = 32
 export const TABLE_MIN_WIDTH = 1024
 export const TABLE_RESPONSIVE_BREAKPOINT = 1200
+export const MOBILE_TABLE_MIN_WIDTH = 560
+export const MIN_COL_WIDTH = 60
+export const EMPTY_TABLE_ESTIMATE = 15
+export const COLUMN_MIN_PCT = 10
+export const COLUMN_MAX_PCT = 30
+export const AUTO_COL_MIN_PX = 100
+export const AUTO_COL_MAX_PX = 520
+export const MOBILE_AUTO_COL_MAX_PX = 200
+export const AUTO_COL_CHAR_PX = 8
+export const AUTO_COL_PADDING_PX = 32
 
 export const DEFAULT_COLUMN_ALIGN = 'center' as const
 

--- a/admin-ui/app/components/GluuTable/GluuTable.tsx
+++ b/admin-ui/app/components/GluuTable/GluuTable.tsx
@@ -11,44 +11,48 @@ import {
   useStyles,
   TABLE_MIN_WIDTH,
   TABLE_RESPONSIVE_BREAKPOINT,
+  MOBILE_TABLE_MIN_WIDTH,
+  MIN_COL_WIDTH,
+  EMPTY_TABLE_ESTIMATE,
+  COLUMN_MIN_PCT,
+  COLUMN_MAX_PCT,
+  AUTO_COL_MIN_PX,
+  AUTO_COL_MAX_PX,
+  MOBILE_AUTO_COL_MAX_PX,
+  AUTO_COL_CHAR_PX,
+  AUTO_COL_PADDING_PX,
   DEFAULT_COLUMN_ALIGN,
   ALIGN_TO_JUSTIFY,
 } from './GluuTable.style'
 import { T_KEYS, EMPTY_CELL_PLACEHOLDER } from './constants'
 import type { CellValue, ColumnKey, GluuTableProps, SortDirection } from './types'
 import { ChevronIcon } from '@/components/SVG'
-import { ICON_SIZE } from '@/constants'
+import { ICON_SIZE, MOBILE_MEDIA_QUERY } from '@/constants'
 import {
   getDefaultPagingSize,
   getRowsPerPageOptions,
   PAGING_SIZE_CHANGED_EVENT,
 } from '@/utils/pagingUtils'
 
-const MIN_COL_WIDTH = 60
-const EMPTY_TABLE_ESTIMATE = 15
-const COLUMN_MIN_PCT = 10
-const COLUMN_MAX_PCT = 30
-const AUTO_COL_MIN_PX = 100
-const AUTO_COL_MAX_PX = 520
-const AUTO_COL_CHAR_PX = 8
-const AUTO_COL_PADDING_PX = 32
 const TABLE_RESPONSIVE_QUERY = `(max-width: ${TABLE_RESPONSIVE_BREAKPOINT - 1}px)`
 
-const useIsBelowResponsiveBreakpoint = (): boolean => {
-  const [isBelow, setIsBelow] = useState<boolean>(() => {
+const useMediaMatch = (query: string): boolean => {
+  const [matches, setMatches] = useState<boolean>(() => {
     if (typeof window === 'undefined') return false
-    return window.matchMedia(TABLE_RESPONSIVE_QUERY).matches
+    return window.matchMedia(query).matches
   })
   useEffect(() => {
     if (typeof window === 'undefined') return
-    const mql = window.matchMedia(TABLE_RESPONSIVE_QUERY)
-    const onChange = (e: MediaQueryListEvent) => setIsBelow(e.matches)
-    setIsBelow(mql.matches)
+    const mql = window.matchMedia(query)
+    const onChange = (e: MediaQueryListEvent) => setMatches(e.matches)
+    setMatches(mql.matches)
     mql.addEventListener('change', onChange)
     return () => mql.removeEventListener('change', onChange)
-  }, [])
-  return isBelow
+  }, [query])
+  return matches
 }
+
+const useIsBelowResponsiveBreakpoint = (): boolean => useMediaMatch(TABLE_RESPONSIVE_QUERY)
 
 const parseMinWidth = (col: { minWidth?: string | number }): string | number | undefined => {
   const mw = col.minWidth
@@ -122,6 +126,7 @@ const computeContentBasedWidths = <T,>(
 const computeContentBasedPixelWidths = <T,>(
   columns: { key: ColumnKey<T>; id?: string; label: string }[],
   data: T[],
+  maxPx: number,
 ): Record<string, number> => {
   if (columns.length === 0) return {}
   return Object.fromEntries(
@@ -138,7 +143,7 @@ const computeContentBasedPixelWidths = <T,>(
         maxLen = Math.max(maxLen, EMPTY_TABLE_ESTIMATE)
       }
       const px = Math.round(maxLen * AUTO_COL_CHAR_PX + AUTO_COL_PADDING_PX)
-      const clamped = Math.max(AUTO_COL_MIN_PX, Math.min(AUTO_COL_MAX_PX, px))
+      const clamped = Math.max(AUTO_COL_MIN_PX, Math.min(maxPx, px))
       return [colId(col), clamped]
     }),
   )
@@ -204,10 +209,16 @@ const GluuTable = <T,>(props: Readonly<GluuTableProps<T>>) => {
   }, [data, sortState, columns])
 
   const isBelowResponsiveBreakpoint = useIsBelowResponsiveBreakpoint()
+  const isMobileViewport = useMediaMatch(MOBILE_MEDIA_QUERY)
   const computedWidths = useMemo(() => computeContentBasedWidths(columns, data), [columns, data])
   const computedPixelWidths = useMemo(
-    () => computeContentBasedPixelWidths(columns, data),
-    [columns, data],
+    () =>
+      computeContentBasedPixelWidths(
+        columns,
+        data,
+        isMobileViewport ? MOBILE_AUTO_COL_MAX_PX : AUTO_COL_MAX_PX,
+      ),
+    [columns, data, isMobileViewport],
   )
   const effectiveWidths = useMemo(() => {
     const out: Record<string, string> = {}
@@ -223,7 +234,7 @@ const GluuTable = <T,>(props: Readonly<GluuTableProps<T>>) => {
         out[id] = `${resized}%`
         continue
       }
-      if (isBelowResponsiveBreakpoint) {
+      if (isMobileViewport) {
         const autoPx = computedPixelWidths[id]
         out[id] =
           autoPx != null ? `${autoPx}px` : (computedWidths[id] ?? `${100 / columns.length}%`)
@@ -232,13 +243,7 @@ const GluuTable = <T,>(props: Readonly<GluuTableProps<T>>) => {
       }
     }
     return out
-  }, [
-    columns,
-    resizedColumnWidths,
-    computedWidths,
-    computedPixelWidths,
-    isBelowResponsiveBreakpoint,
-  ])
+  }, [columns, resizedColumnWidths, computedWidths, computedPixelWidths, isMobileViewport])
 
   const { classes } = useStyles({ isDark, themeColors, stickyHeader })
 
@@ -361,7 +366,7 @@ const GluuTable = <T,>(props: Readonly<GluuTableProps<T>>) => {
     for (const col of columns) {
       if (typeof col.width === 'number') {
         sum += col.width
-      } else if (isBelowResponsiveBreakpoint) {
+      } else if (isMobileViewport) {
         sum += computedPixelWidths[colId(col)] ?? AUTO_COL_MIN_PX
       } else {
         sum += AUTO_COL_MIN_PX
@@ -373,7 +378,8 @@ const GluuTable = <T,>(props: Readonly<GluuTableProps<T>>) => {
     if (actions?.length) {
       sum += Math.max(100, actions.length * 40 + 16)
     }
-    return isBelowResponsiveBreakpoint ? Math.max(sum, TABLE_MIN_WIDTH) : sum
+    if (!isBelowResponsiveBreakpoint) return sum
+    return Math.max(sum, isMobileViewport ? MOBILE_TABLE_MIN_WIDTH : TABLE_MIN_WIDTH)
   }, [
     columns,
     expandable,
@@ -381,6 +387,7 @@ const GluuTable = <T,>(props: Readonly<GluuTableProps<T>>) => {
     actions,
     computedPixelWidths,
     isBelowResponsiveBreakpoint,
+    isMobileViewport,
   ])
 
   const toggleRow = useCallback((key: string | number) => {

--- a/admin-ui/app/components/MobileBottomNav/MobileNavSheet.tsx
+++ b/admin-ui/app/components/MobileBottomNav/MobileNavSheet.tsx
@@ -338,7 +338,7 @@ const MobileNavSheet = ({
                       </button>
                       <div
                         className={cx(classes.subListWrap, expanded && classes.subListWrapOpen)}
-                        aria-hidden={!expanded}
+                        inert={!expanded}
                       >
                         <div className={classes.subListInner}>
                           <div className={classes.subList}>

--- a/admin-ui/app/components/MobileBottomNav/__tests__/MobileNavSheet.test.tsx
+++ b/admin-ui/app/components/MobileBottomNav/__tests__/MobileNavSheet.test.tsx
@@ -119,14 +119,13 @@ describe('MobileNavSheet', () => {
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ path: '/home/health' }))
   })
 
-  it('renders Security as a collapsed expandable row (children hidden, does not navigate)', () => {
+  it('renders Security as a collapsed expandable row (children inert, does not navigate)', () => {
     const onSelect = jest.fn()
     render(<MobileNavSheet openKey="home" onClose={noop} onSelect={onSelect} />)
-    const security = screen.getByRole('button', { name: /menus.security/ })
+    const security = screen.getByRole('button', { name: 'menus.security' })
     expect(security).toHaveAttribute('aria-expanded', 'false')
-    expect(
-      screen.queryByRole('button', { name: 'menus.securityDropdown.mapping' }),
-    ).not.toBeInTheDocument()
+    const child = screen.getByRole('button', { name: 'menus.securityDropdown.mapping' })
+    expect(child.closest('[inert]')).not.toBeNull()
     fireEvent.click(security)
     expect(security).toHaveAttribute('aria-expanded', 'true')
     expect(onSelect).not.toHaveBeenCalled()
@@ -135,9 +134,9 @@ describe('MobileNavSheet', () => {
   it('reveals Security children on expand and selects a child on tap', () => {
     const onSelect = jest.fn()
     render(<MobileNavSheet openKey="home" onClose={noop} onSelect={onSelect} />)
-    fireEvent.click(screen.getByRole('button', { name: /menus.security/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'menus.security' }))
     const child = screen.getByRole('button', { name: 'menus.securityDropdown.mapping' })
-    expect(child).toBeInTheDocument()
+    expect(child.closest('[inert]')).toBeNull()
     fireEvent.click(child)
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ path: '/home/mapping' }))
   })

--- a/admin-ui/app/constants/ui.ts
+++ b/admin-ui/app/constants/ui.ts
@@ -1,3 +1,4 @@
+import { fontFamily, fontSizes, fontWeights } from '@/styles/fonts'
 import type { ThemeConfig } from '@/context/theme/config'
 
 export const OPACITY = {
@@ -270,3 +271,18 @@ export const MAPPING_SPACING = {
   INFO_ICON_SIZE: 24,
   CONTENT_PADDING_TOP: 27,
 } as const
+
+export const createMobilePageTitleStyle = (fontColor: string) => ({
+  display: 'none' as const,
+  [`@media ${MOBILE_MEDIA_QUERY}`]: {
+    display: 'block' as const,
+    fontFamily,
+    fontSize: fontSizes.pageTitle,
+    fontStyle: 'normal' as const,
+    fontWeight: fontWeights.bold,
+    lineHeight: 'normal' as const,
+    color: fontColor,
+    margin: 0,
+    marginBottom: SPACING.PAGE,
+  },
+})

--- a/admin-ui/app/helpers/navigation.ts
+++ b/admin-ui/app/helpers/navigation.ts
@@ -91,6 +91,9 @@ const ROUTES = {
   AUTH_SERVER_SCOPE_EDIT: (inum: string) =>
     `${PLUGIN_BASE_PATHS.AUTH_SERVER}/scope/edit/${encodeURIComponent(inum)}`,
   AUTH_SERVER_SCOPE_EDIT_TEMPLATE: `${PLUGIN_BASE_PATHS.AUTH_SERVER}/scope/edit/:id`,
+  AUTH_SERVER_SCOPE_VIEW: (inum: string) =>
+    `${PLUGIN_BASE_PATHS.AUTH_SERVER}/scope/view/${encodeURIComponent(inum)}`,
+  AUTH_SERVER_SCOPE_VIEW_TEMPLATE: `${PLUGIN_BASE_PATHS.AUTH_SERVER}/scope/view/:id`,
 
   // Configuration
   AUTH_SERVER_CONFIG_PROPERTIES: `${PLUGIN_BASE_PATHS.AUTH_SERVER}/config/properties`,

--- a/admin-ui/app/locales/en/translation.json
+++ b/admin-ui/app/locales/en/translation.json
@@ -1475,6 +1475,7 @@
     "audit_logs": "Admin UI Audit Log",
     "webhooks": "Webhooks",
     "edit_webhook": "Edit Webhook",
+    "view_scope": "View Scope",
     "view_webhook": "View Webhook",
     "edit_script": "Edit Custom Script",
     "authentication": "Authentication",

--- a/admin-ui/app/locales/es/translation.json
+++ b/admin-ui/app/locales/es/translation.json
@@ -1478,6 +1478,7 @@
     "audit_logs": "Admin UI Registros de Auditoría",
     "webhooks": "Webhooks",
     "edit_webhook": "Editar Webhook",
+    "view_scope": "Ver Ámbito",
     "view_webhook": "Ver Webhook",
     "edit_script": "Editar Script Personalizado",
     "authentication": "Autenticación",

--- a/admin-ui/app/locales/fr/translation.json
+++ b/admin-ui/app/locales/fr/translation.json
@@ -1558,6 +1558,7 @@
     "delete_identity_provider": "Supprimer le Fournisseur d'Identité",
     "webhooks": "Webhooks",
     "edit_webhook": "Modifier le Webhook",
+    "view_scope": "Voir la Portée",
     "view_webhook": "Voir le Webhook",
     "edit_script": "Modifier le script personnalisé",
     "authentication": "Authentification",

--- a/admin-ui/app/locales/pt/translation.json
+++ b/admin-ui/app/locales/pt/translation.json
@@ -1449,6 +1449,7 @@
     "audit_logs": "Admin UI Logs de Auditoria",
     "webhooks": "Webhooks",
     "edit_webhook": "Editar Webhook",
+    "view_scope": "Ver Escopo",
     "view_webhook": "Ver Webhook",
     "edit_script": "Editar Script Personalizado",
     "assets": "Recursos Jans",

--- a/admin-ui/app/routes/Apps/Gluu/GluuAutocomplete.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/GluuAutocomplete.tsx
@@ -2,6 +2,8 @@ import React, { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import Autocomplete from '@mui/material/Autocomplete'
 import TextField from '@mui/material/TextField'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { MOBILE_MEDIA_QUERY } from '@/constants'
 import { Check as CheckIcon, Close as CloseIcon, HelpOutline } from '@/components/icons'
 import { ChevronIcon } from '@/components/SVG'
 import GluuTooltip from './GluuTooltip'
@@ -29,6 +31,7 @@ const GluuAutocomplete = ({
   onChange,
   onBlur,
   disabled = false,
+  viewOnly = false,
   placeholder,
   allowCustom = false,
   onSearch,
@@ -51,6 +54,8 @@ const GluuAutocomplete = ({
   const { state: themeState } = useTheme()
   const selectedTheme = themeState?.theme ?? DEFAULT_THEME
   const themeColors = React.useMemo(() => getThemeColor(selectedTheme), [selectedTheme])
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
+  const hideControls = viewOnly || isMobile
   const { classes } = useStyles({
     themeColors,
     allowCustom,
@@ -58,6 +63,7 @@ const GluuAutocomplete = ({
     contrastOptionHover,
     withWrapper,
     compactSelectionSpacing,
+    hideControls,
   })
 
   const resolvedHelperText = helperText ?? t('messages.multi_select_hint')
@@ -183,7 +189,6 @@ const GluuAutocomplete = ({
                 place="right"
               />
               <HelpOutline
-                tabIndex={-1}
                 className={classes.helpIcon}
                 data-tooltip-id={doc_entry}
                 data-for={doc_entry}
@@ -192,137 +197,140 @@ const GluuAutocomplete = ({
           )}
         </div>
       )}
-      <div className={classes.controls}>
-        <div className={classes.autocompleteWrapper}>
-          <Autocomplete
-            multiple
-            loading={isLoading}
-            loadingText={`${t('messages.loading')}...`}
-            noOptionsText={t('messages.no_data_available')}
-            clearText={t('actions.clear')}
-            closeText={t('actions.close')}
-            openText={t('actions.choose')}
-            openOnFocus
-            inputValue={inputValue}
-            onInputChange={(_e, val, reason) => {
-              if (reason !== 'reset') {
-                setInputValue(val)
-                onSearch?.(val)
-              }
-            }}
-            options={autocompleteOptions}
-            value={selectedItems}
-            isOptionEqualToValue={(option, val) => option === val}
-            onChange={handleChange}
-            onBlur={onBlur}
-            onClose={() => {
-              lockedPlacementRef.current = null
-            }}
-            disabled={disabled}
-            disableClearable
-            disableCloseOnSelect
-            disablePortal
-            className={classes.autocompleteRoot}
-            slotProps={popperSlotProps}
-            forcePopupIcon
-            popupIcon={<ChevronIcon width={20} height={20} direction="down" />}
-            filterOptions={filterOptions}
-            getOptionLabel={(option) => getDisplayLabel(option)}
-            renderOption={(props, option) => {
-              const isNewSelection =
-                typeof option === 'string' && option.startsWith(NEW_SELECTION_PREFIX)
-              const selected = selectedItems.includes(option)
-              return (
-                <li {...props} key={option}>
-                  {!isNewSelection && (
-                    <span
-                      aria-hidden
-                      className={
-                        selected
-                          ? `${classes.optionCheckbox} ${classes.optionCheckboxChecked}`
-                          : classes.optionCheckbox
-                      }
-                    >
-                      {selected && <CheckIcon />}
-                    </span>
-                  )}
-                  {isNewSelection ? (
-                    <>
-                      <GluuText disableThemeColor className={classes.newSelectionPrefix}>
-                        {t('placeholders.new_selection')}:&nbsp;
-                      </GluuText>
-                      <GluuText disableThemeColor className={classes.newSelectionValue}>
-                        {option.slice(NEW_SELECTION_PREFIX.length)}
-                      </GluuText>
-                    </>
-                  ) : (
-                    <span className={classes.optionLabel}>{getDisplayLabel(option)}</span>
-                  )}
-                </li>
-              )
-            }}
-            renderInput={(params) => {
-              const { slotProps: paramsSlotProps, ...restParams } = params
-              const paramsInputProps = paramsSlotProps.htmlInput
-              const paramsInputComponentProps = paramsSlotProps.input
-              return (
-                <TextField
-                  {...restParams}
-                  placeholder={placeholder ?? t('placeholders.search_here')}
-                  size="small"
-                  fullWidth
-                  slotProps={{
-                    htmlInput: {
-                      ...paramsInputProps,
-                      onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
-                        if (allowCustom && e.key === 'Enter') {
-                          const trimmed = inputValue.trim()
-                          if (
-                            trimmed &&
-                            !optionValues.some(
-                              (o) => getDisplayLabel(o).toLowerCase() === trimmed.toLowerCase(),
-                            ) &&
-                            !selectedItems.some(
-                              (s) => getDisplayLabel(s).toLowerCase() === trimmed.toLowerCase(),
-                            )
-                          ) {
-                            e.preventDefault()
-                            onChange([...selectedItems, trimmed])
-                            setInputValue('')
-                            e.currentTarget.blur()
-                            return
-                          }
+      {!viewOnly && (
+        <div className={classes.controls}>
+          <div className={classes.autocompleteWrapper}>
+            <Autocomplete
+              multiple
+              loading={isLoading}
+              loadingText={`${t('messages.loading')}...`}
+              noOptionsText={t('messages.no_data_available')}
+              clearText={t('actions.clear')}
+              closeText={t('actions.close')}
+              openText={t('actions.choose')}
+              openOnFocus
+              inputValue={inputValue}
+              onInputChange={(_e, val, reason) => {
+                if (reason !== 'reset') {
+                  setInputValue(val)
+                  onSearch?.(val)
+                }
+              }}
+              options={autocompleteOptions}
+              value={selectedItems}
+              isOptionEqualToValue={(option, val) => option === val}
+              onChange={handleChange}
+              onBlur={onBlur}
+              onClose={() => {
+                lockedPlacementRef.current = null
+              }}
+              disabled={disabled}
+              disableClearable
+              disableCloseOnSelect
+              disablePortal
+              className={classes.autocompleteRoot}
+              slotProps={popperSlotProps}
+              forcePopupIcon
+              popupIcon={<ChevronIcon width={20} height={20} direction="down" />}
+              filterOptions={filterOptions}
+              getOptionLabel={(option) => getDisplayLabel(option)}
+              renderOption={(props, option) => {
+                const isNewSelection =
+                  typeof option === 'string' && option.startsWith(NEW_SELECTION_PREFIX)
+                const selected = selectedItems.includes(option)
+                return (
+                  <li {...props} key={option}>
+                    {!isNewSelection && (
+                      <span
+                        aria-hidden
+                        className={
+                          selected
+                            ? `${classes.optionCheckbox} ${classes.optionCheckboxChecked}`
+                            : classes.optionCheckbox
                         }
-                        paramsInputProps?.onKeyDown?.(e)
+                      >
+                        {selected && <CheckIcon />}
+                      </span>
+                    )}
+                    {isNewSelection ? (
+                      <>
+                        <GluuText disableThemeColor className={classes.newSelectionPrefix}>
+                          {t('placeholders.new_selection')}:&nbsp;
+                        </GluuText>
+                        <GluuText disableThemeColor className={classes.newSelectionValue}>
+                          {option.slice(NEW_SELECTION_PREFIX.length)}
+                        </GluuText>
+                      </>
+                    ) : (
+                      <span className={classes.optionLabel}>{getDisplayLabel(option)}</span>
+                    )}
+                  </li>
+                )
+              }}
+              renderInput={(params) => {
+                const { slotProps: paramsSlotProps, ...restParams } = params
+                const paramsInputProps = paramsSlotProps.htmlInput
+                const paramsInputComponentProps = paramsSlotProps.input
+                return (
+                  <TextField
+                    {...restParams}
+                    placeholder={placeholder ?? t('placeholders.search_here')}
+                    size="small"
+                    fullWidth
+                    slotProps={{
+                      htmlInput: {
+                        ...paramsInputProps,
+                        onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+                          if (allowCustom && e.key === 'Enter') {
+                            const trimmed = inputValue.trim()
+                            if (
+                              trimmed &&
+                              !optionValues.some(
+                                (o) => getDisplayLabel(o).toLowerCase() === trimmed.toLowerCase(),
+                              ) &&
+                              !selectedItems.some(
+                                (s) => getDisplayLabel(s).toLowerCase() === trimmed.toLowerCase(),
+                              )
+                            ) {
+                              e.preventDefault()
+                              onChange([...selectedItems, trimmed])
+                              setInputValue('')
+                              e.currentTarget.blur()
+                              return
+                            }
+                          }
+                          paramsInputProps?.onKeyDown?.(e)
+                        },
                       },
-                    },
-                    input: {
-                      ...paramsInputComponentProps,
-                      endAdornment: (
-                        <>
-                          {inputValue && (
-                            <button
-                              type="button"
-                              onClick={() => setInputValue('')}
-                              className={classes.endIconButton}
-                              aria-label={t('actions.clear')}
-                            >
-                              <CloseIcon />
-                            </button>
-                          )}
-                          {paramsInputComponentProps?.endAdornment}
-                        </>
-                      ),
-                    },
-                  }}
-                />
-              )
-            }}
-            renderValue={() => null}
-          />
+                      input: {
+                        ...paramsInputComponentProps,
+                        endAdornment: (
+                          <>
+                            {inputValue && (
+                              <button
+                                type="button"
+                                onClick={() => setInputValue('')}
+                                className={classes.endIconButton}
+                                aria-label={t('actions.clear')}
+                              >
+                                <CloseIcon />
+                              </button>
+                            )}
+                            {paramsInputComponentProps?.endAdornment}
+                          </>
+                        ),
+                      },
+                    }}
+                  />
+                )
+              }}
+              renderValue={() => null}
+            />
+          </div>
         </div>
-      </div>
+      )}
       {resolvedHelperText &&
+        !viewOnly &&
         !showError &&
         !(hideHelperWhenSelected && selectedItems.length > 0) && (
           <GluuText disableThemeColor className={classes.helperText}>
@@ -336,18 +344,20 @@ const GluuAutocomplete = ({
               <GluuText disableThemeColor className={classes.tagLabel}>
                 {getDisplayLabel(item)}
               </GluuText>
-              <button
-                type="button"
-                className={classes.tagRemove}
-                onClick={() => {
-                  const next = selectedItems.filter((x) => x !== item)
-                  onChange(next)
-                  onBlur?.()
-                }}
-                aria-label={t('actions.remove')}
-              >
-                <CloseIcon />
-              </button>
+              {!hideControls && (
+                <button
+                  type="button"
+                  className={classes.tagRemove}
+                  onClick={() => {
+                    const next = selectedItems.filter((x) => x !== item)
+                    onChange(next)
+                    onBlur?.()
+                  }}
+                  aria-label={t('actions.remove')}
+                >
+                  <CloseIcon />
+                </button>
+              )}
             </span>
           ))}
         </div>

--- a/admin-ui/app/routes/Apps/Gluu/GluuAutocomplete.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/GluuAutocomplete.tsx
@@ -370,7 +370,7 @@ const GluuAutocomplete = ({
     </div>
   )
 
-  if (onRemoveField) {
+  if (onRemoveField && !hideControls) {
     return (
       <div className={classes.wrapper}>
         <div className={classes.cardWrapper}>{content}</div>

--- a/admin-ui/app/routes/Apps/Gluu/GluuLabel.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/GluuLabel.tsx
@@ -62,7 +62,6 @@ const GluuLabel: React.FC<GluuLabelProps> = ({
                   place="right"
                 />
                 <HelpOutline
-                  tabIndex={-1}
                   style={{
                     width: 18,
                     height: 18,

--- a/admin-ui/app/routes/Apps/Gluu/__tests__/GluuAutocomplete.test.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/__tests__/GluuAutocomplete.test.tsx
@@ -3,6 +3,16 @@ import GluuAutocomplete from '../GluuAutocomplete'
 import AppTestWrapper from 'Routes/Apps/Gluu/Tests/Components/AppTestWrapper'
 import type { AutocompleteOption } from '../types/GluuAutocomplete.types'
 
+let mockIsMobile = false
+jest.mock('@mui/material/useMediaQuery', () => ({
+  __esModule: true,
+  default: () => mockIsMobile,
+}))
+
+afterEach(() => {
+  mockIsMobile = false
+})
+
 const NAME = 'servers'
 const LABEL = 'Servers'
 
@@ -88,4 +98,30 @@ it('renders the error message when showError is set', () => {
 it('disables the input when disabled is set', () => {
   renderComponent({ disabled: true })
   expect(screen.getByRole('combobox')).toBeDisabled()
+})
+
+it('in viewOnly hides the input, helper text, and every remove control but keeps selected values', () => {
+  const options: AutocompleteOption[] = [{ value: 'dn-1', label: 'First Server' }]
+  renderComponent({
+    viewOnly: true,
+    value: ['dn-1'],
+    options,
+    onRemoveField: jest.fn(),
+    helperText: 'Pick some items',
+  })
+  expect(screen.getByText('First Server')).toBeInTheDocument()
+  expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  expect(screen.queryByText('Pick some items')).not.toBeInTheDocument()
+  expect(screen.queryAllByRole('button')).toHaveLength(0)
+})
+
+it('on mobile hides the tag-remove and field-remove buttons while keeping the value and input', () => {
+  mockIsMobile = true
+  const options: AutocompleteOption[] = [{ value: 'dn-1', label: 'First Server' }]
+  renderComponent({ value: ['dn-1'], options, onRemoveField: jest.fn() })
+  expect(screen.getByText('First Server')).toBeInTheDocument()
+  expect(screen.getByRole('combobox')).toBeInTheDocument()
+  const tag = screen.getByTitle('First Server')
+  expect(within(tag).queryByRole('button')).not.toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument()
 })

--- a/admin-ui/app/routes/Apps/Gluu/styles/GluuAutocomplete.style.ts
+++ b/admin-ui/app/routes/Apps/Gluu/styles/GluuAutocomplete.style.ts
@@ -1,6 +1,12 @@
 import { makeStyles } from 'tss-react/mui'
 import type { ThemeConfig } from '@/context/theme/config'
-import { CEDARLING_CONFIG_SPACING, ICON_BUTTON_SIZE, MAPPING_SPACING, OPACITY } from '@/constants'
+import {
+  CEDARLING_CONFIG_SPACING,
+  ICON_BUTTON_SIZE,
+  MAPPING_SPACING,
+  MOBILE_MEDIA_QUERY,
+  OPACITY,
+} from '@/constants'
 import { fontFamily, fontSizes, fontWeights, letterSpacing, lineHeights } from '@/styles/fonts'
 import applicationStyle from './applicationStyle'
 
@@ -11,6 +17,7 @@ interface GluuAutocompleteStyleParams {
   contrastOptionHover?: boolean
   withWrapper?: boolean
   compactSelectionSpacing?: boolean
+  hideControls?: boolean
 }
 
 export const useStyles = makeStyles<GluuAutocompleteStyleParams>()((
@@ -22,6 +29,7 @@ export const useStyles = makeStyles<GluuAutocompleteStyleParams>()((
     contrastOptionHover,
     withWrapper = true,
     compactSelectionSpacing = false,
+    hideControls = false,
   },
 ) => {
   const settings = themeColors.settings
@@ -76,6 +84,9 @@ export const useStyles = makeStyles<GluuAutocompleteStyleParams>()((
       'alignItems': 'center',
       '@media (max-width: 900px)': {
         gridTemplateColumns: '1fr',
+      },
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        display: 'none',
       },
     },
     autocompleteWrapper: {
@@ -435,7 +446,7 @@ export const useStyles = makeStyles<GluuAutocompleteStyleParams>()((
       },
     },
     tags: {
-      marginTop: compactSelectionSpacing ? 6 : 12,
+      marginTop: hideControls ? 8 : compactSelectionSpacing ? 6 : 12,
       display: 'flex',
       gap: compactSelectionSpacing ? 8 : 10,
       flexWrap: 'wrap',
@@ -444,7 +455,7 @@ export const useStyles = makeStyles<GluuAutocompleteStyleParams>()((
       display: 'inline-flex',
       alignItems: 'center',
       gap: 6,
-      padding: '4px 4px 4px 10px',
+      padding: hideControls ? '4px 10px' : '4px 4px 4px 10px',
       borderRadius: 999,
       backgroundColor: themeColors.badges.statusActiveBg,
       color: themeColors.badges.statusActive,
@@ -502,6 +513,9 @@ export const useStyles = makeStyles<GluuAutocompleteStyleParams>()((
       color: fontColor,
       margin: `4px 2px`,
       fontSize: fontSizes.sm,
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        display: 'none',
+      },
     },
     removeFieldButton: {
       ...(applicationStyle.removableInputRow as object),

--- a/admin-ui/app/routes/Apps/Gluu/styles/GluuLabel.style.ts
+++ b/admin-ui/app/routes/Apps/Gluu/styles/GluuLabel.style.ts
@@ -1,4 +1,5 @@
 import { makeStyles } from 'tss-react/mui'
+import { MOBILE_MEDIA_QUERY } from '@/constants'
 
 export const useStyles = makeStyles<{ labelColor: string }>()((_, { labelColor }) => ({
   titleRow: {
@@ -10,5 +11,11 @@ export const useStyles = makeStyles<{ labelColor: string }>()((_, { labelColor }
   titleContent: {
     display: 'flex',
     alignItems: 'center',
+    [`@media ${MOBILE_MEDIA_QUERY}`]: {
+      'display': 'inline',
+      '& svg': {
+        verticalAlign: 'text-bottom',
+      },
+    },
   },
 }))

--- a/admin-ui/app/routes/Apps/Gluu/types/GluuAutocomplete.types.ts
+++ b/admin-ui/app/routes/Apps/Gluu/types/GluuAutocomplete.types.ts
@@ -11,6 +11,7 @@ export type GluuAutocompleteProps = {
   onChange: (value: string[]) => void
   onBlur?: () => void
   disabled?: boolean
+  viewOnly?: boolean
   placeholder?: string
   /** When true, allow typing a value not in options and adding it */
   allowCustom?: boolean

--- a/admin-ui/app/routes/Dashboards/DashboardPage.style.ts
+++ b/admin-ui/app/routes/Dashboards/DashboardPage.style.ts
@@ -419,7 +419,7 @@ const useStyles = makeStyles<{ themeColors: DashboardThemeColors; isDark: boolea
         rowGap: '4px',
       },
       [`@media ${MOBILE_MEDIA_QUERY}`]: {
-        '& > :first-child': {
+        '& > span:first-of-type': {
           flexBasis: '100%',
           marginBottom: `${SPACING.CARD_CONTENT_GAP}px`,
         },

--- a/admin-ui/app/routes/License/LicenseDetailsPage.style.ts
+++ b/admin-ui/app/routes/License/LicenseDetailsPage.style.ts
@@ -1,4 +1,5 @@
 import { makeStyles } from 'tss-react/mui'
+import { createMobilePageTitleStyle } from '@/constants'
 import type { ThemeConfig } from '@/context/theme/config'
 import customColors from '@/customColors'
 import { SPACING, MOBILE_MEDIA_QUERY } from '@/constants'
@@ -23,19 +24,7 @@ export const useStyles = makeStyles<StylesParams>()((theme, { themeColors, isDar
         boxSizing: 'border-box',
       },
     },
-    mobilePageTitle: {
-      display: 'none',
-      [`@media ${MOBILE_MEDIA_QUERY}`]: {
-        display: 'block',
-        fontFamily,
-        fontSize: fontSizes.pageTitle,
-        fontWeight: fontWeights.bold,
-        lineHeight: 'normal',
-        color: themeColors.fontColor,
-        margin: 0,
-        marginBottom: SPACING.PAGE,
-      },
-    },
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     licenseCard: {
       backgroundColor: cardBg,
       borderRadius: '16px',

--- a/admin-ui/app/styles/index.css
+++ b/admin-ui/app/styles/index.css
@@ -9,7 +9,7 @@
 }
 
 .material-icons {
-    font-family: "Material Icons";
+    font-family: "Material Icons", sans-serif;
     font-weight: normal;
     font-style: normal;
     font-size: 24px;

--- a/admin-ui/app/styles/main.scss
+++ b/admin-ui/app/styles/main.scss
@@ -457,7 +457,7 @@ html {
 .month-picker .tab.btn:before {
     font-style: normal;
     font-weight: normal;
-    font-family: "icomoon", sans-serif;
+    font-family: icomoon, sans-serif;
     -webkit-font-smoothing: antialiased;
     -webkit-text-stroke-width: 0.2px;
     font-size: 1.8rem;

--- a/admin-ui/app/styles/main.scss
+++ b/admin-ui/app/styles/main.scss
@@ -457,7 +457,7 @@ html {
 .month-picker .tab.btn:before {
     font-style: normal;
     font-weight: normal;
-    font-family: "icomoon";
+    font-family: "icomoon", sans-serif;
     -webkit-font-smoothing: antialiased;
     -webkit-text-stroke-width: 0.2px;
     font-size: 1.8rem;

--- a/admin-ui/plugins/admin/components/Assets/JansAssetFormPage.style.ts
+++ b/admin-ui/plugins/admin/components/Assets/JansAssetFormPage.style.ts
@@ -1,11 +1,11 @@
 import { makeStyles } from 'tss-react/mui'
+import { createMobilePageTitleStyle } from '@/constants'
 import type { Theme } from '@mui/material/styles'
 import {
   SPACING,
   BORDER_RADIUS,
   CEDARLING_CONFIG_SPACING,
   MAPPING_SPACING,
-  MOBILE_MEDIA_QUERY,
   ICON_SIZE,
   OPACITY,
 } from '@/constants'
@@ -44,20 +44,7 @@ export const useStyles = makeStyles<AssetFormPageStylesParams>()((
     CEDARLING_CONFIG_SPACING.INPUT_HEIGHT - 2 * CEDARLING_CONFIG_SPACING.INPUT_PADDING_VERTICAL - 2
 
   return {
-    mobilePageTitle: {
-      display: 'none',
-      [`@media ${MOBILE_MEDIA_QUERY}`]: {
-        display: 'block',
-        fontFamily,
-        fontSize: '28px',
-        fontStyle: 'normal',
-        fontWeight: fontWeights.bold,
-        lineHeight: 'normal',
-        color: themeColors.fontColor,
-        margin: 0,
-        marginBottom: SPACING.PAGE,
-      },
-    },
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     formCard: {
       backgroundColor: cardBg,
       ...cardBorderStyle,

--- a/admin-ui/plugins/admin/components/Assets/JansAssetListPage.style.ts
+++ b/admin-ui/plugins/admin/components/Assets/JansAssetListPage.style.ts
@@ -1,9 +1,10 @@
 import { makeStyles } from 'tss-react/mui'
+import { createMobilePageTitleStyle } from '@/constants'
 import type { ThemeConfig } from '@/context/theme/config'
 import { BORDER_RADIUS, ICON_SIZE, MOBILE_MEDIA_QUERY, SPACING } from '@/constants'
 import { getCardBorderStyle } from '@/styles/cardBorderStyles'
 import { createSearchCardStyle } from '@/styles/searchCardStyle'
-import { fontFamily, fontWeights } from '@/styles/fonts'
+import { fontFamily } from '@/styles/fonts'
 
 interface AssetListPageStylesParams {
   isDark: boolean
@@ -26,20 +27,7 @@ export const useStyles = makeStyles<AssetListPageStylesParams>()((_, { isDark, t
         boxSizing: 'border-box',
       },
     },
-    mobilePageTitle: {
-      display: 'none',
-      [`@media ${MOBILE_MEDIA_QUERY}`]: {
-        display: 'block',
-        fontFamily,
-        fontSize: '28px',
-        fontStyle: 'normal',
-        fontWeight: fontWeights.bold,
-        lineHeight: 'normal',
-        color: themeColors.fontColor,
-        margin: 0,
-        marginBottom: SPACING.PAGE,
-      },
-    },
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     cellFileName: {
       color: themeColors.fontColor,
       fontWeight: 500,

--- a/admin-ui/plugins/admin/components/Audit/AuditListPage.style.ts
+++ b/admin-ui/plugins/admin/components/Audit/AuditListPage.style.ts
@@ -1,4 +1,5 @@
 import { makeStyles } from 'tss-react/mui'
+import { createMobilePageTitleStyle } from '@/constants'
 import type { ThemeConfig } from '@/context/theme/config'
 import {
   BORDER_RADIUS,
@@ -25,6 +26,7 @@ const useStyles = makeStyles<{ isDark: boolean; themeColors: ThemeConfig }>()((
     page: {
       fontFamily,
     },
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     searchCard: createSearchCardStyle({ cardBg, isDark }),
     searchCardContent: {
       position: 'relative',

--- a/admin-ui/plugins/admin/components/Audit/AuditListPage.tsx
+++ b/admin-ui/plugins/admin/components/Audit/AuditListPage.tsx
@@ -336,6 +336,9 @@ const AuditListPage: React.FC = () => {
     <GluuLoader blocking={isLoading}>
       <div className={classes.page}>
         <GluuViewWrapper canShow={canReadAuditLogs}>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {t(T_KEYS.TITLE_AUDIT_LOGS)}
+          </GluuText>
           <div className={classes.searchCard}>
             <div className={classes.searchCardContent}>
               <GluuSearchToolbar

--- a/admin-ui/plugins/admin/components/Cedarling/CedarlingConfigPage.style.ts
+++ b/admin-ui/plugins/admin/components/Cedarling/CedarlingConfigPage.style.ts
@@ -1,4 +1,5 @@
 import { makeStyles } from 'tss-react/mui'
+import { createMobilePageTitleStyle } from '@/constants'
 import type { Theme } from '@mui/material/styles'
 import { alpha } from '@mui/material/styles'
 import {
@@ -37,20 +38,7 @@ const useStyles = makeStyles<CedarlingConfigPageStyleParams>()((theme: Theme, pa
         paddingRight: `${MOBILE_PAGE_PADDING_X.SM}px`,
       },
     },
-    mobilePageTitle: {
-      display: 'none',
-      [`@media ${MOBILE_MEDIA_QUERY}`]: {
-        display: 'block',
-        fontFamily,
-        fontSize: fontSizes.pageTitle,
-        fontStyle: 'normal',
-        fontWeight: fontWeights.bold,
-        lineHeight: 'normal',
-        color: themeColors.fontColor,
-        margin: 0,
-        marginBottom: SPACING.PAGE,
-      },
-    },
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     configCard: {
       backgroundColor: 'transparent',
       padding: 0,

--- a/admin-ui/plugins/admin/components/Health/HealthPage.style.ts
+++ b/admin-ui/plugins/admin/components/Health/HealthPage.style.ts
@@ -1,4 +1,5 @@
 import { makeStyles } from 'tss-react/mui'
+import { createMobilePageTitleStyle } from '@/constants'
 import type { Theme } from '@mui/material/styles'
 import { SPACING, BORDER_RADIUS } from '@/constants'
 import { fontFamily, fontWeights, fontSizes, lineHeights } from '@/styles/fonts'
@@ -32,20 +33,7 @@ const useStyles = makeStyles<{ themeColors: HealthPageThemeColors; isDark: boole
         boxSizing: 'border-box',
       },
     },
-    mobilePageTitle: {
-      display: 'none',
-      [`@media ${MOBILE_MEDIA_QUERY}`]: {
-        display: 'block',
-        fontFamily,
-        fontSize: fontSizes.pageTitle,
-        fontStyle: 'normal',
-        fontWeight: fontWeights.bold,
-        lineHeight: 'normal',
-        color: themeColors.text,
-        margin: 0,
-        marginBottom: SPACING.PAGE,
-      },
-    },
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.text),
     healthCard: {
       backgroundColor: themeColors.cardBg,
       ...cardBorderStyle,

--- a/admin-ui/plugins/admin/components/MAU/MauPage.style.ts
+++ b/admin-ui/plugins/admin/components/MAU/MauPage.style.ts
@@ -1,4 +1,5 @@
 import { makeStyles } from 'tss-react/mui'
+import { createMobilePageTitleStyle } from '@/constants'
 import type { Theme } from '@mui/material/styles'
 import { BORDER_RADIUS, SPACING, MOBILE_MEDIA_QUERY, TABLET_BAND_MEDIA_QUERY } from '@/constants'
 import { fontFamily, fontWeights, fontSizes, lineHeights } from '@/styles/fonts'
@@ -29,20 +30,7 @@ export const useMauStyles = makeStyles<MauStylesParams>()((
         boxSizing: 'border-box',
       },
     },
-    mobilePageTitle: {
-      display: 'none',
-      [`@media ${MOBILE_MEDIA_QUERY}`]: {
-        display: 'block',
-        fontFamily,
-        fontSize: fontSizes.pageTitle,
-        fontStyle: 'normal',
-        fontWeight: fontWeights.bold,
-        lineHeight: 'normal',
-        color: themeColors.text,
-        margin: 0,
-        marginBottom: SPACING.PAGE,
-      },
-    },
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.text),
     sectionSpacing: {
       marginBottom: 24,
     },

--- a/admin-ui/plugins/admin/components/Settings/SettingsPage.style.ts
+++ b/admin-ui/plugins/admin/components/Settings/SettingsPage.style.ts
@@ -1,4 +1,5 @@
 import { makeStyles } from 'tss-react/mui'
+import { createMobilePageTitleStyle } from '@/constants'
 import type { Theme } from '@mui/material/styles'
 import { SPACING, BORDER_RADIUS, OPACITY, MOBILE_MEDIA_QUERY } from '@/constants'
 import { fontFamily, fontWeights, fontSizes, lineHeights, letterSpacing } from '@/styles/fonts'
@@ -37,20 +38,7 @@ export const useStyles = makeStyles<SettingsStylesParams>()((
         boxSizing: 'border-box',
       },
     },
-    mobilePageTitle: {
-      display: 'none',
-      [`@media ${MOBILE_MEDIA_QUERY}`]: {
-        display: 'block',
-        fontFamily,
-        fontSize: fontSizes.pageTitle,
-        fontStyle: 'normal',
-        fontWeight: fontWeights.bold,
-        lineHeight: 'normal',
-        color: themeColors.fontColor,
-        margin: 0,
-        marginBottom: SPACING.PAGE,
-      },
-    },
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     settingsCard: {
       backgroundColor: settings.cardBackground,
       ...cardBorderStyle,

--- a/admin-ui/plugins/admin/components/Webhook/WebhookFormPage.tsx
+++ b/admin-ui/plugins/admin/components/Webhook/WebhookFormPage.tsx
@@ -10,6 +10,7 @@ import { usePermission } from '@/cedarling/hooks/usePermission'
 import { ADMIN_UI_RESOURCES } from '@/cedarling/utility'
 import { ROUTES } from '@/helpers/navigation'
 import SetTitle from 'Utils/SetTitle'
+import GluuText from 'Routes/Apps/Gluu/GluuText'
 import WebhookForm from './WebhookForm'
 import { useStyles } from './styles/WebhookFormPage.style'
 
@@ -40,6 +41,9 @@ const WebhookFormPage: React.FC = () => {
   return (
     <GluuPageContent>
       <GluuViewWrapper canShow={viewOnly ? canReadWebhooks : canWriteWebhooks}>
+        <GluuText variant="h1" className={classes.mobilePageTitle}>
+          {t(titleKey)}
+        </GluuText>
         <div className={classes.formCard}>
           <div className={classes.content}>
             <WebhookForm viewOnly={viewOnly} />

--- a/admin-ui/plugins/admin/components/Webhook/styles/WebhookFormPage.style.ts
+++ b/admin-ui/plugins/admin/components/Webhook/styles/WebhookFormPage.style.ts
@@ -1,4 +1,5 @@
 import { makeStyles } from 'tss-react/mui'
+import { createMobilePageTitleStyle } from '@/constants'
 import type { Theme } from '@mui/material/styles'
 import {
   SPACING,
@@ -60,6 +61,7 @@ export const useStyles = makeStyles<WebhookFormPageStylesParams>()((
   })
 
   return {
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     formCard: {
       backgroundColor: cardBg,
       ...cardBorderStyle,

--- a/admin-ui/plugins/admin/components/Webhook/styles/WebhookListPage.style.ts
+++ b/admin-ui/plugins/admin/components/Webhook/styles/WebhookListPage.style.ts
@@ -1,10 +1,11 @@
 import { useMemo } from 'react'
+import { createMobilePageTitleStyle } from '@/constants'
 import { makeStyles } from 'tss-react/mui'
 import type { ThemeConfig } from '@/context/theme/config'
 import { BORDER_RADIUS, ICON_SIZE, MOBILE_MEDIA_QUERY, SPACING } from '@/constants'
 import { getCardBorderStyle } from '@/styles/cardBorderStyles'
 import { createSearchCardStyle } from '@/styles/searchCardStyle'
-import { fontFamily, fontWeights } from '@/styles/fonts'
+import { fontFamily } from '@/styles/fonts'
 import customColors from '@/customColors'
 
 const useStylesBase = makeStyles<{ isDark: boolean; themeColors: ThemeConfig }>()((
@@ -25,20 +26,7 @@ const useStylesBase = makeStyles<{ isDark: boolean; themeColors: ThemeConfig }>(
         boxSizing: 'border-box',
       },
     },
-    mobilePageTitle: {
-      display: 'none',
-      [`@media ${MOBILE_MEDIA_QUERY}`]: {
-        display: 'block',
-        fontFamily,
-        fontSize: '28px',
-        fontStyle: 'normal',
-        fontWeight: fontWeights.bold,
-        lineHeight: 'normal',
-        color: themeColors.fontColor,
-        margin: 0,
-        marginBottom: SPACING.PAGE,
-      },
-    },
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     cellDisplayName: { color: themeColors.fontColor, fontWeight: 500 },
     cellUrl: {
       wordBreak: 'break-all',

--- a/admin-ui/plugins/auth-server/common/JsonPropertyBuilder.style.ts
+++ b/admin-ui/plugins/auth-server/common/JsonPropertyBuilder.style.ts
@@ -1,5 +1,11 @@
 import { makeStyles } from 'tss-react/mui'
-import { BORDER_RADIUS, CEDARLING_CONFIG_SPACING, MAPPING_SPACING, SPACING } from '@/constants'
+import {
+  BORDER_RADIUS,
+  CEDARLING_CONFIG_SPACING,
+  MAPPING_SPACING,
+  MOBILE_MEDIA_QUERY,
+  SPACING,
+} from '@/constants'
 
 const sharedInputStyles = {
   '& input, & select, & .custom-select, & .form-control': {
@@ -69,6 +75,9 @@ export const useStyles = makeStyles()(() => ({
   },
   accordionSpacing: {
     marginBottom: SPACING.CARD_CONTENT_GAP,
+    [`@media ${MOBILE_MEDIA_QUERY}`]: {
+      marginBottom: 0,
+    },
   },
   removeButtonIcon: {
     fontSize: '16px',
@@ -87,6 +96,9 @@ export const useStyles = makeStyles()(() => ({
     width: '100%',
     alignItems: 'start',
     paddingTop: 0,
+    [`@media ${MOBILE_MEDIA_QUERY}`]: {
+      gridTemplateColumns: '1fr',
+    },
   },
   objectFieldItem: {
     minWidth: 0,

--- a/admin-ui/plugins/auth-server/common/propertiesPageStyles.ts
+++ b/admin-ui/plugins/auth-server/common/propertiesPageStyles.ts
@@ -1,6 +1,13 @@
 import type { Theme } from '@mui/material/styles'
 import type { ThemeConfig } from '@/context/theme/config'
-import { BORDER_RADIUS, CEDARLING_CONFIG_SPACING, OPACITY, SPACING } from '@/constants'
+import {
+  BORDER_RADIUS,
+  CEDARLING_CONFIG_SPACING,
+  MOBILE_MEDIA_QUERY,
+  OPACITY,
+  SPACING,
+  createMobilePageTitleStyle,
+} from '@/constants'
 import customColors, { hexToRgb } from '@/customColors'
 import { getCardBorderStyle } from '@/styles/cardBorderStyles'
 import { createFormGroupOverrides, createFormLabelStyles } from '@/styles/formStyles'
@@ -26,6 +33,7 @@ export const createPropertiesPageStyles = (
     : inputBorderColor
 
   return {
+    mobilePageTitle: createMobilePageTitleStyle(fontColor),
     searchCard: createSearchCardStyle({ cardBg, isDark }),
     searchCardContent: {
       position: 'relative' as const,
@@ -50,6 +58,12 @@ export const createPropertiesPageStyles = (
     },
     formContent: {
       'padding': SPACING.CONTENT_PADDING,
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        'padding': `${SPACING.PAGE}px 0`,
+        '& input, & select, & textarea, & .custom-select, & .form-control, & .react-toggle': {
+          pointerEvents: 'none' as const,
+        },
+      },
       ...createFormGroupOverrides(),
       ...createFormLabelStyles(fontColor),
       '& .form-group > label': {
@@ -163,6 +177,11 @@ export const createPropertiesPageStyles = (
       'paddingLeft': SPACING.CONTENT_PADDING,
       'paddingRight': SPACING.CONTENT_PADDING,
       'paddingBottom': SPACING.CONTENT_PADDING,
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        paddingLeft: 0,
+        paddingRight: 0,
+        paddingBottom: SPACING.PAGE,
+      },
       '& hr, & .MuiDivider-root': {
         display: 'none !important',
       },

--- a/admin-ui/plugins/auth-server/components/AuthServerProperties/components/AuthServerPropertiesPage.tsx
+++ b/admin-ui/plugins/auth-server/components/AuthServerProperties/components/AuthServerPropertiesPage.tsx
@@ -74,6 +74,8 @@ import type {
 } from '../types'
 import type { GluuCommitDialogOperation, JsonValue } from 'Routes/Apps/Gluu/types/index'
 import type { UserAction } from 'Utils/types'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { MOBILE_MEDIA_QUERY } from '@/constants'
 
 const propertiesResourceId = ADMIN_UI_RESOURCES.AuthenticationServerConfiguration
 const createUserAction = (): UserAction => ({
@@ -97,6 +99,7 @@ const AuthServerPropertiesPage: React.FC = () => {
     [themeState?.theme],
   )
   const { classes } = useStyles({ isDark, themeColors })
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
   const { canRead: canReadProperties, canWrite: canWriteProperties } =
     usePermission(propertiesResourceId)
   const { logAcrUpdate } = useAcrAudit()
@@ -613,6 +616,9 @@ const AuthServerPropertiesPage: React.FC = () => {
     >
       <GluuViewWrapper canShow={canReadProperties}>
         <GluuPageContent>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {t('titles.jans_json_property')}
+          </GluuText>
           <div className={classes.searchCard}>
             <div className={classes.searchCardContent}>
               <GluuSearchToolbar
@@ -690,10 +696,10 @@ const AuthServerPropertiesPage: React.FC = () => {
                       showBack
                       onBack={handleBack}
                       backButtonLabel={t('actions.back')}
-                      showCancel
+                      showCancel={!isMobile}
                       onCancel={handleCancel}
                       disableCancel={!hasChanges}
-                      showApply
+                      showApply={!isMobile}
                       disableApply={!hasChanges}
                       applyButtonType="button"
                       onApply={toggle}

--- a/admin-ui/plugins/auth-server/components/AuthServerProperties/components/JsonPropertyBuilder.tsx
+++ b/admin-ui/plugins/auth-server/components/AuthServerProperties/components/JsonPropertyBuilder.tsx
@@ -16,6 +16,8 @@ import { REGEX_LEADING_SLASH, REGEX_NON_LOWERCASE_ALPHA } from '@/utils/regex'
 import { getFieldPlaceholder } from '@/utils/placeholderUtils'
 import type { AutocompleteOption } from 'Routes/Apps/Gluu/types/GluuAutocomplete.types'
 import { useStyles } from '../../../common/JsonPropertyBuilder.style'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { MOBILE_MEDIA_QUERY } from '@/constants'
 import type {
   JsonPropertyBuilderProps,
   AccordionWithSubComponents,
@@ -171,6 +173,7 @@ const JsonPropertyBuilder = ({
 }: JsonPropertyBuilderProps): JSX.Element => {
   const { t, i18n } = useTranslation()
   const { classes } = useStyles()
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
   const [show, setShow] = useState<boolean>(true)
 
   const getLocalizedLabelKey = useCallback(
@@ -412,7 +415,7 @@ const JsonPropertyBuilder = ({
           <AccordionBody>
             {paired.map(([leftItem, rightItem]) => (
               <FormGroup row key={`pair-${leftItem.index}-${rightItem?.index ?? 'none'}`}>
-                <Col sm={6}>
+                <Col sm={12} md={6}>
                   <ArrayItemSelect
                     index={leftItem.index}
                     values={leftItem.nestedValue}
@@ -424,7 +427,7 @@ const JsonPropertyBuilder = ({
                     allowCustom={!schema?.items?.enum}
                   />
                 </Col>
-                <Col sm={6}>
+                <Col sm={12} md={6}>
                   {rightItem && (
                     <ArrayItemSelect
                       index={rightItem.index}
@@ -485,7 +488,7 @@ const JsonPropertyBuilder = ({
             <AccordionHeader>
               <div className={classes.accordionHeaderRow}>
                 <GluuText variant="span">{t(getLocalizedLabelKey(propKey))}</GluuText>
-                {parentIsArray && (
+                {parentIsArray && !isMobile && (
                   <GluuButton
                     type="button"
                     className="remove-btn"

--- a/admin-ui/plugins/auth-server/components/ConfigApiProperties/components/ConfigApiPropertiesForm.tsx
+++ b/admin-ui/plugins/auth-server/components/ConfigApiProperties/components/ConfigApiPropertiesForm.tsx
@@ -14,6 +14,8 @@ import getThemeColor from '@/context/theme/config'
 import { THEME_DARK } from '@/context/theme/constants'
 import GluuCommitDialog from 'Routes/Apps/Gluu/GluuCommitDialog'
 import GluuThemeFormFooter from 'Routes/Apps/Gluu/GluuThemeFormFooter'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { MOBILE_MEDIA_QUERY } from '@/constants'
 import type { GluuCommitDialogOperation } from 'Routes/Apps/Gluu/types/index'
 import type { FormikTouched } from 'formik'
 import JsonPropertyBuilderConfigApi from './JsonPropertyBuilderConfigApi'
@@ -57,6 +59,7 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
     [themeState?.theme],
   )
   const { classes } = useStyles({ isDark, themeColors })
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
 
   const [modal, setModal] = useState(false)
   const [patches, setPatches] = useState<JsonPatch[]>([])
@@ -476,10 +479,10 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
               showBack
               onBack={handleBack}
               backButtonLabel={t('actions.back')}
-              showCancel
+              showCancel={!isMobile}
               onCancel={handleCancel}
               disableCancel={!hasChanges}
-              showApply
+              showApply={!isMobile}
               disableApply={!hasChanges || (patches.length === 0 && !formik.isValid)}
               applyButtonType="submit"
             />

--- a/admin-ui/plugins/auth-server/components/ConfigApiProperties/components/ConfigApiPropertiesPage.tsx
+++ b/admin-ui/plugins/auth-server/components/ConfigApiProperties/components/ConfigApiPropertiesPage.tsx
@@ -123,6 +123,9 @@ const ConfigApiPropertiesPage = (): JSX.Element => {
     <GluuLoader blocking={loading}>
       <GluuViewWrapper canShow={canReadConfigApi}>
         <GluuPageContent>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {t('titles.config_api_configuration')}
+          </GluuText>
           <div className={classes.searchCard}>
             <div className={classes.searchCardContent}>
               <GluuSearchToolbar

--- a/admin-ui/plugins/auth-server/components/ConfigApiProperties/components/JsonPropertyBuilderConfigApi.tsx
+++ b/admin-ui/plugins/auth-server/components/ConfigApiProperties/components/JsonPropertyBuilderConfigApi.tsx
@@ -22,6 +22,8 @@ import {
   ERROR_TEXT_STYLE,
 } from './styles'
 import type { AutocompleteOption } from 'Routes/Apps/Gluu/types/GluuAutocomplete.types'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { MOBILE_MEDIA_QUERY } from '@/constants'
 import type { JsonPropertyBuilderConfigApiProps, AccordionWithSubComponents } from '../types'
 import type { JsonPatch } from 'JansConfigApi'
 import {
@@ -66,6 +68,7 @@ const JsonPropertyBuilderConfigApi = ({
 }: JsonPropertyBuilderConfigApiProps): JSX.Element => {
   const { t, i18n } = useTranslation()
   const { classes } = useStyles()
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
   const [show, setShow] = useState(true)
 
   const getLocalizedLabelKey = useCallback(
@@ -396,7 +399,7 @@ const JsonPropertyBuilderConfigApi = ({
             <AccordionHeader>
               <div className={classes.accordionHeaderRow}>
                 <GluuText variant="span">{displayLabel}</GluuText>
-                {parentIsArray && (
+                {parentIsArray && !isMobile && (
                   <GluuButton
                     type="button"
                     className="remove-btn"

--- a/admin-ui/plugins/auth-server/components/Scopes/components/ScopeAddPage.tsx
+++ b/admin-ui/plugins/auth-server/components/Scopes/components/ScopeAddPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useMemo } from 'react'
 import ScopeForm from './ScopeForm'
+import GluuText from 'Routes/Apps/Gluu/GluuText'
 import GluuLoader from 'Routes/Apps/Gluu/GluuLoader'
 import GluuAlert from 'Routes/Apps/Gluu/GluuAlert'
 import { useTranslation } from 'react-i18next'
@@ -56,6 +57,9 @@ const ScopeAddPage: React.FC = () => {
   return (
     <GluuPageContent>
       <GluuLoader blocking={loading}>
+        <GluuText variant="h1" className={classes.mobilePageTitle}>
+          {t('messages.add_scope')}
+        </GluuText>
         <GluuAlert
           severity="error"
           message={errorMessage || t('messages.error_in_saving')}

--- a/admin-ui/plugins/auth-server/components/Scopes/components/ScopeEditPage.tsx
+++ b/admin-ui/plugins/auth-server/components/Scopes/components/ScopeEditPage.tsx
@@ -1,6 +1,10 @@
 import React, { useState, useCallback, useMemo } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useMatch } from 'react-router-dom'
+import { usePermission } from '@/cedarling/hooks/usePermission'
+import { ADMIN_UI_RESOURCES } from '@/cedarling/utility'
+import { ROUTES } from '@/helpers/navigation'
 import GluuLoader from 'Routes/Apps/Gluu/GluuLoader'
+import GluuText from 'Routes/Apps/Gluu/GluuText'
 import ScopeForm from './ScopeForm'
 import GluuAlert from 'Routes/Apps/Gluu/GluuAlert'
 import { useTranslation } from 'react-i18next'
@@ -21,7 +25,11 @@ import SetTitle from 'Utils/SetTitle'
 const ScopeEditPage: React.FC = () => {
   const { t } = useTranslation()
 
-  SetTitle(t('messages.edit_scope'))
+  const { canWrite } = usePermission(ADMIN_UI_RESOURCES.Scopes)
+  const viewMatch = useMatch(ROUTES.AUTH_SERVER_SCOPE_VIEW_TEMPLATE)
+  const viewOnly = !!viewMatch || !canWrite
+
+  SetTitle(t(viewOnly ? 'titles.view_scope' : 'messages.edit_scope'))
 
   const { id } = useParams<{ id: string }>()
 
@@ -100,6 +108,9 @@ const ScopeEditPage: React.FC = () => {
   return (
     <GluuPageContent>
       <GluuLoader blocking={loading}>
+        <GluuText variant="h1" className={classes.mobilePageTitle}>
+          {t(viewOnly ? 'titles.view_scope' : 'messages.edit_scope')}
+        </GluuText>
         <GluuAlert severity="error" message={displayError} show={!!displayError} />
         <div className={classes.formCard}>
           <div className={classes.content}>
@@ -110,6 +121,7 @@ const ScopeEditPage: React.FC = () => {
               handleSubmit={handleSubmit}
               modifiedFields={modifiedFields}
               setModifiedFields={setModifiedFields}
+              viewOnly={viewOnly}
             />
           </div>
         </div>

--- a/admin-ui/plugins/auth-server/components/Scopes/components/ScopeForm.tsx
+++ b/admin-ui/plugins/auth-server/components/Scopes/components/ScopeForm.tsx
@@ -52,6 +52,7 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
   handleSubmit,
   modifiedFields,
   setModifiedFields,
+  viewOnly = false,
 }) => {
   const { t } = useTranslation()
   const theme = useTheme()
@@ -282,6 +283,7 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
                     errorMessage={formikProps.errors.id ? t(formikProps.errors.id) : undefined}
                     showError={!!(formikProps.errors.id && formikProps.touched.id)}
                     required
+                    disabled={viewOnly}
                     handleChange={(e) => {
                       setModifiedFields({
                         ...modifiedFields,
@@ -309,6 +311,7 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
                       !!(formikProps.errors.displayName && formikProps.touched.displayName)
                     }
                     required
+                    disabled={viewOnly}
                     handleChange={(e) => {
                       setModifiedFields({
                         ...modifiedFields,
@@ -330,6 +333,7 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
                     doc_entry="description"
                     placeholder={getFieldPlaceholder(t, 'fields.description')}
                     rows={3}
+                    disabled={viewOnly}
                     handleChange={(e) => {
                       setModifiedFields({
                         ...modifiedFields,
@@ -372,6 +376,7 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
                       }
                       showError={!!(formikProps.errors.scopeType && formikProps.touched.scopeType)}
                       required
+                      disabled={viewOnly}
                       handleChange={(
                         e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
                       ) => {
@@ -396,6 +401,7 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
                       rsize={12}
                       value={formikProps.values.attributes?.showInConfigurationEndpoint}
                       doc_category={SCOPE}
+                      disabled={viewOnly}
                       handler={(e: React.ChangeEvent<HTMLInputElement>) => {
                         setModifiedFields({
                           ...modifiedFields,
@@ -416,6 +422,7 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
                       rsize={12}
                       value={formikProps.values.defaultScope}
                       doc_category={SCOPE}
+                      disabled={viewOnly}
                       handler={(e: React.ChangeEvent<HTMLInputElement>) => {
                         setModifiedFields({
                           ...modifiedFields,
@@ -441,6 +448,8 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
                       doc_entry="claims"
                       placeholder={t('placeholders.search_claims')}
                       helperText={t('placeholders.typeahead_holder_message')}
+                      disabled={viewOnly}
+                      viewOnly={viewOnly}
                     />
                     {formikProps.errors.claims && formikProps.touched.claims && (
                       <div style={errorTextStyle}>{t(formikProps.errors.claims as string)}</div>
@@ -464,6 +473,8 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
                       doc_category={SCOPE}
                       doc_entry="dynamicScopeScripts"
                       helperText={t('placeholders.typeahead_holder_message')}
+                      disabled={viewOnly}
+                      viewOnly={viewOnly}
                     />
                     {formikProps.errors.dynamicScopeScripts &&
                       formikProps.touched.dynamicScopeScripts && (
@@ -488,6 +499,8 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
                       doc_entry="claims"
                       placeholder={t('placeholders.search_claims')}
                       helperText={t('placeholders.typeahead_holder_message')}
+                      disabled={viewOnly}
+                      viewOnly={viewOnly}
                     />
                     {formikProps.errors.claims && formikProps.touched.claims && (
                       <div style={errorTextStyle}>{t(formikProps.errors.claims as string)}</div>
@@ -543,6 +556,7 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
                         doc_entry="umaAuthorizationPolicies"
                         helperText={t('placeholders.typeahead_holder_message')}
                         disabled={scope.inum ? true : false}
+                        viewOnly={viewOnly}
                       />
                       {formikProps.errors.umaAuthorizationPolicies &&
                         formikProps.touched.umaAuthorizationPolicies && (
@@ -672,10 +686,10 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
               <GluuThemeFormFooter
                 showBack={true}
                 onBack={handleNavigateBack}
-                showCancel={true}
+                showCancel={!viewOnly}
                 onCancel={handleCancel}
                 disableCancel={!hasActualChanges(formikProps.values, initialFormValues)}
-                showApply={true}
+                showApply={!viewOnly}
                 applyButtonType="button"
                 onApply={() => {
                   formikProps.setTouched(

--- a/admin-ui/plugins/auth-server/components/Scopes/components/ScopeListPage.tsx
+++ b/admin-ui/plugins/auth-server/components/Scopes/components/ScopeListPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, use, useCallback, useMemo, memo } from 'react'
-import { Add, DeleteOutlined, Edit } from '@/components/icons'
+import { Add, DeleteOutlined, Edit, VisibilityOutlined } from '@/components/icons'
 import { Link } from 'react-router-dom'
 import { useAppDispatch } from '@/redux/hooks'
 import GluuText from 'Routes/Apps/Gluu/GluuText'
@@ -28,6 +28,8 @@ import { useScopes, useScopeActions, invalidateScopeQueries } from '../hooks'
 import { toScopeJsonRecord } from '../helper/utils'
 import { useAppNavigation, ROUTES } from '@/helpers/navigation'
 import { useDebounce } from '@/utils/hooks/useDebounce'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { MOBILE_MEDIA_QUERY } from '@/constants'
 import { getRowsPerPageOptions, usePaginationState } from '@/utils/pagingUtils'
 import { GluuDetailGrid, type GluuDetailGridField } from '@/components/GluuDetailGrid'
 import { SCOPE } from 'Utils/ApiResources'
@@ -86,6 +88,7 @@ const ScopeListPage: React.FC = () => {
 
   const [modal, setModal] = useState(false)
   const [itemToDelete, setItemToDelete] = useState<Scope | null>(null)
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
 
   const startIndex = useMemo(() => pageNumber * limit, [pageNumber, limit])
 
@@ -137,6 +140,15 @@ const ScopeListPage: React.FC = () => {
     (row: ScopeTableRow) => {
       if (row.inum) {
         navigateToRoute(ROUTES.AUTH_SERVER_SCOPE_EDIT(row.inum))
+      }
+    },
+    [navigateToRoute],
+  )
+
+  const handleView = useCallback(
+    (row: ScopeTableRow) => {
+      if (row.inum) {
+        navigateToRoute(ROUTES.AUTH_SERVER_SCOPE_VIEW(row.inum))
       }
     },
     [navigateToRoute],
@@ -367,6 +379,14 @@ const ScopeListPage: React.FC = () => {
       id?: string
       onClick: (row: ScopeTableRow) => void
     }> = []
+    if (!canRead) return list
+    list.push({
+      icon: <VisibilityOutlined className={classes.viewIcon} />,
+      tooltip: t('actions.view'),
+      id: 'viewScope',
+      onClick: handleView,
+    })
+    if (isMobile) return list
     if (canWrite) {
       list.push({
         icon: <Edit className={classes.editIcon} />,
@@ -384,7 +404,17 @@ const ScopeListPage: React.FC = () => {
       })
     }
     return list
-  }, [canWrite, canDelete, t, handleEdit, handleDeleteClick, classes])
+  }, [
+    isMobile,
+    canRead,
+    canWrite,
+    canDelete,
+    t,
+    handleView,
+    handleEdit,
+    handleDeleteClick,
+    classes,
+  ])
 
   // Pagination
   const effectivePage = useMemo(() => {
@@ -559,6 +589,9 @@ const ScopeListPage: React.FC = () => {
     <GluuLoader blocking={loading}>
       <div className={classes.page}>
         <GluuViewWrapper canShow={canRead}>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {t('titles.scopes')}
+          </GluuText>
           <div className={classes.searchCard}>
             <div className={classes.searchCardContent}>
               <GluuSearchToolbar
@@ -571,7 +604,7 @@ const ScopeListPage: React.FC = () => {
                 filters={filters}
                 onRefresh={canRead ? handleRefresh : undefined}
                 refreshLoading={isLoading}
-                primaryAction={primaryAction}
+                primaryAction={isMobile ? undefined : primaryAction}
                 disabled={loading}
               />
             </div>

--- a/admin-ui/plugins/auth-server/components/Scopes/components/styles/ScopeFormPage.style.ts
+++ b/admin-ui/plugins/auth-server/components/Scopes/components/styles/ScopeFormPage.style.ts
@@ -1,4 +1,5 @@
 import type { CSSProperties } from 'react'
+import { createMobilePageTitleStyle } from '@/constants'
 import { makeStyles } from 'tss-react/mui'
 import { SPACING, BORDER_RADIUS, OPACITY } from '@/constants'
 import { fontFamily, fontWeights, fontSizes, lineHeights } from '@/styles/fonts'
@@ -30,6 +31,7 @@ export const useStyles = makeStyles<ScopeFormPageStylesParams>()((_, { isDark, t
   const formInputBg = themeColors.settings?.formInputBackground ?? themeColors.inputBackground
 
   return {
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     formCard: {
       backgroundColor: cardBg,
       ...cardBorderStyle,
@@ -58,7 +60,11 @@ export const useStyles = makeStyles<ScopeFormPageStylesParams>()((_, { isDark, t
       rowGap: SPACING.CARD_CONTENT_GAP,
       width: '100%',
       [`@media (max-width: ${MOBILE_BREAKPOINT}px)`]: {
-        gridTemplateColumns: '1fr',
+        'gridTemplateColumns': '1fr',
+        'rowGap': SPACING.SECTION_GAP,
+        '& + &': {
+          marginTop: SPACING.SECTION_GAP,
+        },
       },
     },
     accordionSpacing: {
@@ -104,6 +110,17 @@ export const useStyles = makeStyles<ScopeFormPageStylesParams>()((_, { isDark, t
         position: 'absolute',
         fontSize: `${fontSizes.sm} !important`,
       },
+      [`@media (max-width: ${MOBILE_BREAKPOINT}px)`]: {
+        '& .form-group [class*="col"]': {
+          paddingBottom: 0,
+        },
+        '& [data-field-error]': {
+          top: '100%',
+          left: 0,
+          margin: 0,
+          lineHeight: 1.2,
+        },
+      },
       '& .input-group': {
         margin: 0,
       },
@@ -118,6 +135,9 @@ export const useStyles = makeStyles<ScopeFormPageStylesParams>()((_, { isDark, t
     },
     autocompleteField: {
       marginBottom: 20,
+      [`@media (max-width: ${MOBILE_BREAKPOINT}px)`]: {
+        marginBottom: 0,
+      },
     },
     inumFullWidth: {
       'gridColumn': '1 / -1',
@@ -164,6 +184,12 @@ export const useStyles = makeStyles<ScopeFormPageStylesParams>()((_, { isDark, t
         maxWidth: '100%',
         paddingLeft: 0,
         paddingRight: 0,
+        paddingBottom: 20,
+      },
+      [`@media (max-width: ${MOBILE_BREAKPOINT}px)`]: {
+        '& .form-group [class*="col"]': {
+          paddingBottom: 0,
+        },
       },
       '& .react-toggle--disabled': {
         opacity: `${OPACITY.DISABLED} !important`,

--- a/admin-ui/plugins/auth-server/components/Scopes/components/styles/ScopeListPage.style.ts
+++ b/admin-ui/plugins/auth-server/components/Scopes/components/styles/ScopeListPage.style.ts
@@ -1,8 +1,9 @@
 import { useMemo } from 'react'
+import { createMobilePageTitleStyle } from '@/constants'
 import { makeStyles } from 'tss-react/mui'
 import customColors from '@/customColors'
 import type { ThemeConfig } from '@/context/theme/config'
-import { BORDER_RADIUS, ICON_SIZE, SPACING } from '@/constants'
+import { BORDER_RADIUS, ICON_SIZE, MOBILE_MEDIA_QUERY, SPACING } from '@/constants'
 import { getCardBorderStyle } from '@/styles/cardBorderStyles'
 import { createSearchCardStyle } from '@/styles/searchCardStyle'
 import { fontFamily, fontWeights, lineHeights } from '@/styles/fonts'
@@ -20,7 +21,15 @@ const useStylesBase = makeStyles<{ isDark: boolean; themeColors: ThemeConfig }>(
   })
   const cardBg = themeColors.settings?.cardBackground ?? themeColors.card.background
   return {
-    page: { fontFamily, paddingTop: SPACING.PAGE },
+    page: {
+      fontFamily,
+      paddingTop: SPACING.PAGE,
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        paddingBottom: `${SPACING.CONTENT_PADDING}px`,
+        boxSizing: 'border-box',
+      },
+    },
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     cellDescription: {
       display: 'block',
       minWidth: 0,
@@ -32,6 +41,7 @@ const useStylesBase = makeStyles<{ isDark: boolean; themeColors: ThemeConfig }>(
       color: themeColors.fontColor,
     },
     scopeTypeBadge: { minWidth: SCOPE_TYPE_MIN_WIDTH },
+    viewIcon: { fontSize: ICON_SIZE.SM },
     editIcon: { fontSize: ICON_SIZE.SM },
     deleteIcon: { fontSize: ICON_SIZE.SM },
     addIcon: { fontSize: ICON_SIZE.MD },

--- a/admin-ui/plugins/auth-server/components/Scopes/types/componentTypes.ts
+++ b/admin-ui/plugins/auth-server/components/Scopes/types/componentTypes.ts
@@ -18,6 +18,7 @@ export type ScopeFormProps = {
   handleSubmit: (data: string) => void
   modifiedFields: ModifiedFields
   setModifiedFields: (fields: ModifiedFields) => void
+  viewOnly?: boolean
 }
 
 export type ScopeTableRow = ScopeWithClients

--- a/admin-ui/plugins/auth-server/plugin-metadata.tsx
+++ b/admin-ui/plugins/auth-server/plugin-metadata.tsx
@@ -157,6 +157,12 @@ const pluginMetadata = {
       resourceKey: ADMIN_UI_RESOURCES.Scopes,
     },
     {
+      component: ScopeEditPage,
+      path: ROUTES.AUTH_SERVER_SCOPE_VIEW_TEMPLATE,
+      action: CEDAR_ACTIONS.READ,
+      resourceKey: ADMIN_UI_RESOURCES.Scopes,
+    },
+    {
       component: PropertiesPage,
       path: ROUTES.AUTH_SERVER_CONFIG_PROPERTIES,
       action: CEDAR_ACTIONS.READ,

--- a/admin-ui/plugins/user-claims/components/UserClaimsForm.tsx
+++ b/admin-ui/plugins/user-claims/components/UserClaimsForm.tsx
@@ -64,7 +64,7 @@ const UserClaimsForm = memo(function UserClaimsForm(props: AttributeFormProps) {
         {t(labelKey)}:{required && <span className={classes.outerLabelStar}>&nbsp;*</span>}
       </span>
       <GluuTooltip tooltipOnly doc_entry={docEntry} doc_category={ATTRIBUTE} place="right" />
-      <HelpOutline tabIndex={-1} data-tooltip-id={docEntry} data-for={docEntry} />
+      <HelpOutline data-tooltip-id={docEntry} data-for={docEntry} />
     </div>
   )
 

--- a/admin-ui/sonar-project.properties
+++ b/admin-ui/sonar-project.properties
@@ -12,7 +12,7 @@ sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 sonar.sourceEncoding=UTF-8
 
 # Exclusions
-sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**
+sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**,**/styles/miltonbo/**
 
 # Test coverage configuration
 sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
### feat(admin-ui): implement responsive mobile layout for Scopes, Auth Server Properties, and Config API Configuration pages (#2931)

#### Summary
This PR continues the Admin UI mobile redesign by implementing responsive layouts for the Scopes, Auth Server Properties, and Config API Configuration pages.

The update optimizes these pages for phone and small-tablet viewports by introducing mobile-friendly search and filtering, view-only experiences where appropriate, responsive table layouts, improved form presentation, and consistent page titles. Desktop and tablet behavior remains unchanged.

---

#### Fix Summary
- Implemented responsive mobile layout for the Scopes page
- Added compact mobile search bar with Filters bottom sheet
- Added mobile filter options for Scope Type and Sort By
- Converted the Scopes list to a view-only experience on mobile
- Added a dedicated read-only Scope details page with a Back-only footer
- Optimized table layouts to prevent excessive horizontal scrolling
- Improved expanded row layouts to better utilize available screen width
- Implemented responsive mobile layout for Auth Server Properties
- Implemented responsive mobile layout for Config API Configuration
- Converted properties pages to single-column, view-only layouts on mobile
- Removed mobile editing controls, including Remove actions and editable multi-select search fields
- Improved alignment, spacing, typography, and label presentation across forms
- Added mobile page titles for:
  - Scopes
  - Audit Logs
  - Webhook forms
  - Scope forms
  - Auth Server Properties
  - Config API Configuration
- Preserved existing desktop and tablet layouts and functionality
- Maintained consistency with the shared Admin UI mobile design system

---

#### Verification

```bash
npm run check:all
```

passes successfully.

- Verified the Scopes page renders correctly on mobile devices
- Verified mobile search and Filters bottom sheet function as expected
- Verified Scope details display in read-only mode with a Back-only footer
- Verified tables no longer require excessive horizontal scrolling
- Verified Auth Server Properties render correctly in a single-column, view-only layout
- Verified Config API Configuration renders correctly in a single-column, view-only layout
- Verified mobile page titles display correctly on all affected pages
- Verified desktop and tablet layouts remain unchanged
- Verified no regressions in existing functionality

---

#### 🔗 Ticket

Closes: #2931

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only Scope view route with localized “View Scope” titles and matching navigation.
  * Enabled view-only mode in Gluu autocomplete and scope forms.
  * Added mobile-specific page headings across multiple admin screens.
* **Bug Fixes**
  * Improved responsive table/grid layouts for small screens and mobile-aware column sizing.
  * Hid or disabled mobile controls to reduce unintended interactions.
  * Updated collapsed navigation behavior using `inert`, plus improved focusability for help/info icons.
* **Documentation**
  * Added “View Scope” translations (EN/ES/FR/PT).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->