### PR TITLE
feat(admin-ui): responsive mobile view-only layout for Public Keys, Logging, SMTP, SCIM, and User Claims

### DIFF
--- a/admin-ui/app/components/GluuSearchToolbar/GluuSearchToolbar.style.ts
+++ b/admin-ui/app/components/GluuSearchToolbar/GluuSearchToolbar.style.ts
@@ -140,7 +140,7 @@ export const useStyles = makeStyles<GluuSearchToolbarStyleParams>()((
     },
     sheetPillSelected: {
       color: accentColor,
-      borderColor: accentColor,
+      border: `${FILTER_SHEET.PILL_BORDER_WIDTH}px solid ${accentColor}`,
     },
     sheetActions: {
       display: 'flex',

--- a/admin-ui/app/components/GluuSearchToolbar/GluuSearchToolbar.tsx
+++ b/admin-ui/app/components/GluuSearchToolbar/GluuSearchToolbar.tsx
@@ -23,7 +23,7 @@ import {
 import type { Dayjs } from '@/utils/dayjsUtils'
 import { useDebounce } from '@/utils/hooks/useDebounce'
 import { useStyles, DEFAULT_INPUT_HEIGHT } from './GluuSearchToolbar.style'
-import type { GluuSearchToolbarProps } from './types'
+import type { FilterDef, GluuSearchToolbarProps } from './types'
 
 const DEFAULT_LAYOUT = 'row' as const
 
@@ -74,7 +74,7 @@ const GluuSearchToolbar: React.FC<GluuSearchToolbarProps> = (props) => {
   const { state } = useTheme()
   const themeColors = useMemo(() => getThemeColor(state.theme), [state.theme])
   const isDark = state.theme === THEME_DARK
-  const { classes } = useStyles({ themeColors, isDark, searchFieldWidth })
+  const { classes, cx } = useStyles({ themeColors, isDark, searchFieldWidth })
 
   const effectivePlaceholder =
     searchPlaceholder ?? t(PLACEHOLDER_KEY, { defaultValue: 'Search pattern' })
@@ -172,19 +172,28 @@ const GluuSearchToolbar: React.FC<GluuSearchToolbarProps> = (props) => {
     setSheetOpen(true)
   }, [filters])
   const closeSheet = useCallback(() => setSheetOpen(false), [])
+  const commitFilters = useCallback(
+    (resolveValue: (filter: FilterDef) => string | undefined) => {
+      filters?.forEach((f) => {
+        const next = resolveValue(f)
+        if (next !== undefined && next !== f.value) f.onChange(next)
+      })
+      setSheetOpen(false)
+    },
+    [filters],
+  )
+  const cancelSheet = useCallback(() => {
+    commitFilters((f) => f.defaultValue)
+  }, [commitFilters])
   const applySheet = useCallback(() => {
     if (showBuiltInDateRange && dateValidation.invalid) return
-    filters?.forEach((f) => {
-      const next = draftFilters[f.key]
-      if (next !== undefined && next !== f.value) f.onChange(next)
-    })
+    commitFilters((f) => draftFilters[f.key])
     if (showBuiltInDateRange) {
       onSearch?.(localSearch)
       onSearchSubmit?.(localSearch)
     }
-    setSheetOpen(false)
   }, [
-    filters,
+    commitFilters,
     draftFilters,
     showBuiltInDateRange,
     dateValidation.invalid,
@@ -276,9 +285,7 @@ const GluuSearchToolbar: React.FC<GluuSearchToolbarProps> = (props) => {
                           key={option.value}
                           type="button"
                           aria-pressed={selected}
-                          className={`${classes.sheetPill} ${
-                            selected ? classes.sheetPillSelected : ''
-                          }`.trim()}
+                          className={cx(classes.sheetPill, selected && classes.sheetPillSelected)}
                           onClick={() =>
                             setDraftFilters((prev) => ({ ...prev, [filter.key]: option.value }))
                           }
@@ -360,7 +367,7 @@ const GluuSearchToolbar: React.FC<GluuSearchToolbarProps> = (props) => {
                     size="md"
                     block
                     outlined
-                    onClick={closeSheet}
+                    onClick={cancelSheet}
                     textColor={sheetCancel.textColor}
                     borderColor={sheetCancel.borderColor}
                     borderRadius={FILTER_SHEET.BUTTON_RADIUS}
@@ -439,7 +446,7 @@ const GluuSearchToolbar: React.FC<GluuSearchToolbarProps> = (props) => {
               onChange={handleSearchChange}
               onKeyDown={handleKeyDown}
               disabled={disabled}
-              className={`${classes.searchInput}${disabled ? ` ${classes.searchInputDisabled}` : ''}`}
+              className={cx(classes.searchInput, disabled && classes.searchInputDisabled)}
               aria-label={searchLabel ?? effectivePlaceholder ?? 'search'}
             />
           </div>

--- a/admin-ui/app/components/GluuSearchToolbar/GluuSearchToolbar.tsx
+++ b/admin-ui/app/components/GluuSearchToolbar/GluuSearchToolbar.tsx
@@ -68,6 +68,7 @@ const GluuSearchToolbar: React.FC<GluuSearchToolbarProps> = (props) => {
     refreshLoading = false,
     refreshButtonVariant = 'outlined',
     disabled = false,
+    className,
   } = props
 
   const { t } = useTranslation()
@@ -403,7 +404,7 @@ const GluuSearchToolbar: React.FC<GluuSearchToolbarProps> = (props) => {
   }
 
   return (
-    <div className={classes.container}>
+    <div className={cx(classes.container, className)}>
       <div className={classes.fieldGroupSearch}>
         {searchLabel && (
           <GluuText variant="span" className={classes.fieldLabel} disableThemeColor>

--- a/admin-ui/app/components/GluuSearchToolbar/GluuSearchToolbar.tsx
+++ b/admin-ui/app/components/GluuSearchToolbar/GluuSearchToolbar.tsx
@@ -229,7 +229,7 @@ const GluuSearchToolbar: React.FC<GluuSearchToolbarProps> = (props) => {
 
   if (useCompactMobile) {
     return (
-      <div className={classes.container}>
+      <div className={cx(classes.container, className)}>
         <div className={classes.mobileRow}>
           <input
             type="text"

--- a/admin-ui/app/components/GluuSearchToolbar/types.ts
+++ b/admin-ui/app/components/GluuSearchToolbar/types.ts
@@ -66,6 +66,8 @@ type GluuSearchToolbarBaseProps = {
   refreshLoading?: boolean
   refreshButtonVariant?: 'primary' | 'outlined'
   disabled?: boolean
+  /** Optional class on the toolbar root, for page-specific layout overrides. */
+  className?: string
 }
 
 type GluuSearchToolbarInputProps = GluuSearchToolbarBaseProps & {

--- a/admin-ui/app/components/GluuSearchToolbar/types.ts
+++ b/admin-ui/app/components/GluuSearchToolbar/types.ts
@@ -13,6 +13,8 @@ export type FilterDef = {
   options: FilterOption[]
   onChange: (value: string) => void
   width?: string | number
+  /** Value the sheet's Cancel resets this filter to. When omitted, Cancel only discards edits. */
+  defaultValue?: string
 }
 
 type DateInputDef = {

--- a/admin-ui/app/constants/ui.ts
+++ b/admin-ui/app/constants/ui.ts
@@ -63,6 +63,10 @@ export const TINY_MAX_MEDIA_QUERY = '(max-width:379.98px)'
 
 export const TABLET_MAX_MEDIA_QUERY = '(max-width:1024px)'
 
+export const NAVBAR_TITLE_LG_MEDIA_QUERY = '(max-width:1200px)'
+
+export const NAVBAR_TITLE_MD_MEDIA_QUERY = '(max-width:992px)'
+
 export const WIDE_MAX_MEDIA_QUERY = '(max-width:1400px)'
 
 export const TABLET_BAND_MEDIA_QUERY = '(min-width:768px) and (max-width:1024px)'

--- a/admin-ui/app/routes/Apps/Gluu/GluuSelectRow.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/GluuSelectRow.tsx
@@ -174,7 +174,12 @@ const GluuSelectRow: React.FC<GluuSelectRowProps> = ({
               )
             })}
           </CustomInput>
-          <span className={classes.chevronWrapper} aria-hidden>
+          <span
+            className={`${classes.chevronWrapper}${
+              disabled || isReadOnlySelect ? ` ${classes.chevronDisabled}` : ''
+            }`}
+            aria-hidden
+          >
             <ChevronIcon width={20} height={20} direction="down" />
           </span>
         </div>

--- a/admin-ui/app/routes/Apps/Gluu/styles/GluuNavBar.style.ts
+++ b/admin-ui/app/routes/Apps/Gluu/styles/GluuNavBar.style.ts
@@ -4,6 +4,8 @@ import {
   MOBILE_PAGE_PADDING_X,
   SPACING,
   TABLET_COLLAPSE_BAND_MEDIA_QUERY,
+  NAVBAR_TITLE_LG_MEDIA_QUERY,
+  NAVBAR_TITLE_MD_MEDIA_QUERY,
 } from '@/constants'
 import { fontFamily, fontWeights, fontSizes, letterSpacing } from '@/styles/fonts'
 
@@ -22,7 +24,7 @@ const useStyles = makeStyles<{ navbarColors: NavbarColors }>()((theme, { navbarC
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    padding: '0px 60px',
+    padding: `0px 60px 0px ${SPACING.PAGE}px`,
     position: 'relative',
     marginTop: '-1px',
     borderBottom: `1px solid ${navbarColors.border}`,
@@ -55,14 +57,11 @@ const useStyles = makeStyles<{ navbarColors: NavbarColors }>()((theme, { navbarC
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
-    [theme.breakpoints.down('lg')]: {
-      fontSize: fontSizes['2xl'],
+    [`@media ${NAVBAR_TITLE_LG_MEDIA_QUERY}`]: {
+      fontSize: fontSizes['2.5xl'],
     },
-    [theme.breakpoints.down('md')]: {
-      fontSize: fontSizes.xl,
-    },
-    [theme.breakpoints.down('sm')]: {
-      fontSize: fontSizes.lg,
+    [`@media ${NAVBAR_TITLE_MD_MEDIA_QUERY}`]: {
+      fontSize: fontSizes.pageTitle,
     },
     [`@media ${MOBILE_MEDIA_QUERY}`]: {
       display: 'none',

--- a/admin-ui/app/routes/Apps/Gluu/styles/GluuSelectRow.style.ts
+++ b/admin-ui/app/routes/Apps/Gluu/styles/GluuSelectRow.style.ts
@@ -67,6 +67,9 @@ export const useStyles = makeStyles<GluuSelectRowStyleParams>()((
       color: fontColor,
       zIndex: 6,
     },
+    chevronDisabled: {
+      opacity: OPACITY.DISABLED,
+    },
     error: {
       display: 'block',
       color: customColors.accentRed,

--- a/admin-ui/plugins/admin/components/Assets/JansAssetFormPage.style.ts
+++ b/admin-ui/plugins/admin/components/Assets/JansAssetFormPage.style.ts
@@ -234,13 +234,15 @@ export const useStyles = makeStyles<AssetFormPageStylesParams>()((
           outline: OUTLINE_NONE,
           boxShadow: OUTLINE_NONE,
         },
-      '& input:not(.MuiInputBase-input):disabled, & select:disabled, & .custom-select:disabled': {
-        backgroundColor: `${formInputBg} !important`,
-        border: `1px solid ${inputBorderColor} !important`,
-        color: `${themeColors.fontColor} !important`,
-        opacity: OPACITY.DISABLED,
-        cursor: 'not-allowed',
-      },
+      '& input:not(.MuiInputBase-input):disabled, & select:disabled, & .custom-select:disabled, & textarea:disabled':
+        {
+          backgroundColor: `${formInputBg} !important`,
+          border: `1px solid ${inputBorderColor} !important`,
+          color: `${themeColors.fontColor} !important`,
+          WebkitTextFillColor: `${themeColors.fontColor} !important`,
+          opacity: `${OPACITY.DISABLED} !important`,
+          cursor: 'not-allowed',
+        },
       '& input:not(.MuiInputBase-input)::placeholder': {
         color: themeColors.textMuted,
       },

--- a/admin-ui/plugins/admin/components/Webhook/WebhookListPage.tsx
+++ b/admin-ui/plugins/admin/components/Webhook/WebhookListPage.tsx
@@ -65,7 +65,7 @@ const WebhookListPage: React.FC = () => {
   SetTitle(t(PAGE_TITLE_KEY))
   const pageTitle = t(PAGE_TITLE_KEY)
 
-  const { data, isLoading, refetch } = useGetAllWebhooks(
+  const { data, isLoading, isFetching, refetch } = useGetAllWebhooks(
     {
       limit,
       pattern: pattern || undefined,
@@ -76,6 +76,7 @@ const WebhookListPage: React.FC = () => {
     {
       query: {
         enabled: canReadWebhooks,
+        staleTime: 0,
       },
     },
   )
@@ -178,6 +179,7 @@ const WebhookListPage: React.FC = () => {
         options: sortOptions,
         onChange: handleSortByFilter,
         width: TOOLBAR.CONTROL_WIDTH,
+        defaultValue: DEFAULT_SERVER_SORT.column,
       },
     ],
     [t, serverSort.column, handleSortByFilter, sortOptions],
@@ -350,7 +352,7 @@ const WebhookListPage: React.FC = () => {
     return t('messages.no_data')
   }, [pattern, totalItems, t])
 
-  const loading = isLoading || isDeleting
+  const loading = isFetching || isDeleting
 
   return (
     <GluuLoader blocking={loading}>

--- a/admin-ui/plugins/admin/components/Webhook/WebhookListPage.tsx
+++ b/admin-ui/plugins/admin/components/Webhook/WebhookListPage.tsx
@@ -372,7 +372,7 @@ const WebhookListPage: React.FC = () => {
                 onSearchSubmit={handleSearchSubmit}
                 filters={filters}
                 onRefresh={canReadWebhooks ? handleRefresh : undefined}
-                refreshLoading={isLoading}
+                refreshLoading={isFetching}
                 primaryAction={primaryAction}
                 actionsLabel={`${t('fields.actions')}:`}
                 disabled={loading}

--- a/admin-ui/plugins/auth-server/common/propertiesPageStyles.ts
+++ b/admin-ui/plugins/auth-server/common/propertiesPageStyles.ts
@@ -96,7 +96,9 @@ export const createPropertiesPageStyles = (
           opacity: OPACITY.PLACEHOLDER,
         },
         '&:disabled': {
-          opacity: OPACITY.DISABLED,
+          color: `${fontColor} !important`,
+          WebkitTextFillColor: `${fontColor} !important`,
+          opacity: `${OPACITY.FULL} !important`,
           cursor: 'not-allowed',
         },
       },

--- a/admin-ui/plugins/auth-server/components/AuthServerProperties/components/AuthServerPropertiesPage.tsx
+++ b/admin-ui/plugins/auth-server/components/AuthServerProperties/components/AuthServerPropertiesPage.tsx
@@ -501,6 +501,7 @@ const AuthServerPropertiesPage: React.FC = () => {
             onChange={(vals) => patchHandler({ op: 'replace', path: `/${propKey}`, value: vals })}
             options={arrayMultiSelectOptions[propKey] || []}
             allowCustom
+            disabled={isMobile}
           />
         )
       }
@@ -516,6 +517,7 @@ const AuthServerPropertiesPage: React.FC = () => {
             handler={patchHandler}
             lSize={12}
             formResetKey={resetKey}
+            disabled={isMobile}
           />
         )
       }
@@ -534,6 +536,7 @@ const AuthServerPropertiesPage: React.FC = () => {
             rsize={12}
             doc_category="json_properties"
             doc_entry={model.propKey}
+            disabled={isMobile}
           />
         )
       }
@@ -553,6 +556,7 @@ const AuthServerPropertiesPage: React.FC = () => {
           path={`/${model.propKey}`}
           showSaveButtons={false}
           placeholder={getFieldPlaceholder(t, model.label)}
+          disabled={isMobile}
         />
       )
     },
@@ -563,6 +567,7 @@ const AuthServerPropertiesPage: React.FC = () => {
       loggingLevelFormikAdapters,
       resetKey,
       t,
+      isMobile,
     ],
   )
 
@@ -637,6 +642,8 @@ const AuthServerPropertiesPage: React.FC = () => {
               <Form
                 onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
                   e.preventDefault()
+                  // Mobile is view-only, so never open the commit dialog.
+                  if (isMobile) return
                   toggle()
                 }}
                 className={classes.form}
@@ -662,6 +669,7 @@ const AuthServerPropertiesPage: React.FC = () => {
                               options={authScripts}
                               path={DEFAULT_ACR_PATH}
                               showSaveButtons={false}
+                              disabled={isMobile}
                             />
                           </div>
                           <div className={classes.fieldItem}>

--- a/admin-ui/plugins/auth-server/components/AuthServerProperties/components/DefaultAcrInput.tsx
+++ b/admin-ui/plugins/auth-server/components/AuthServerProperties/components/DefaultAcrInput.tsx
@@ -13,6 +13,7 @@ const DefaultAcrInput = ({
   handler,
   options,
   path,
+  disabled = false,
 }: DefaultAcrInputProps): ReactElement => {
   const [data, setData] = useState<string>(value ?? '')
 
@@ -60,6 +61,7 @@ const DefaultAcrInput = ({
       required={required}
       doc_category="json_properties"
       doc_entry={name}
+      disabled={disabled}
     />
   )
 }

--- a/admin-ui/plugins/auth-server/components/AuthServerProperties/components/JsonPropertyBuilder.tsx
+++ b/admin-ui/plugins/auth-server/components/AuthServerProperties/components/JsonPropertyBuilder.tsx
@@ -66,6 +66,7 @@ const ArrayItemSelect = React.memo(
     handler,
     formResetKey,
     allowCustom,
+    disabled = false,
   }: ArrayItemSelectProps) => {
     return (
       <GluuAutocomplete
@@ -76,6 +77,7 @@ const ArrayItemSelect = React.memo(
         onChange={(newValues) => handler({ op: 'replace', path, value: newValues })}
         options={options}
         allowCustom={allowCustom}
+        disabled={disabled}
       />
     )
   },
@@ -91,6 +93,7 @@ export const NumberField = React.memo(
     lSize,
     formResetKey,
     docCategory = 'json_properties',
+    disabled = false,
   }: {
     propKey: string
     value: number
@@ -100,6 +103,7 @@ export const NumberField = React.memo(
     lSize: number
     formResetKey: number
     docCategory?: string
+    disabled?: boolean
   }) => {
     const [localValue, setLocalValue] = useState<number>(value)
 
@@ -128,6 +132,7 @@ export const NumberField = React.memo(
         doc_category={docCategory}
         doc_entry={propKey}
         handleChange={handleChange}
+        disabled={disabled}
       />
     )
   },
@@ -143,6 +148,7 @@ const StringArrayField = React.memo(
     handler,
     formResetKey,
     allowCustom,
+    disabled = false,
   }: StringArrayFieldProps) => {
     return (
       <GluuAutocomplete
@@ -153,6 +159,7 @@ const StringArrayField = React.memo(
         onChange={(newValues) => handler({ op: 'replace', path, value: newValues })}
         options={options}
         allowCustom={allowCustom}
+        disabled={disabled}
       />
     )
   },
@@ -298,6 +305,7 @@ const JsonPropertyBuilder = ({
           parentIsArray={parentIsArray}
           path={path}
           showSaveButtons={false}
+          disabled={isMobile}
         />
         {renderError()}
       </>
@@ -322,6 +330,7 @@ const JsonPropertyBuilder = ({
           doc_entry={propKey}
           showError={fieldTouched && typeof fieldError === 'string'}
           errorMessage={typeof fieldError === 'string' ? fieldError : undefined}
+          disabled={isMobile}
         />
       )
     }
@@ -341,6 +350,7 @@ const JsonPropertyBuilder = ({
           path={path}
           showSaveButtons={false}
           placeholder={getFieldPlaceholder(t, getLocalizedLabelKey(propKey))}
+          disabled={isMobile}
         />
         {renderError()}
       </>
@@ -358,6 +368,7 @@ const JsonPropertyBuilder = ({
           handler={handler}
           lSize={lSize}
           formResetKey={formResetKey}
+          disabled={isMobile}
         />
         {renderError()}
       </>
@@ -382,6 +393,7 @@ const JsonPropertyBuilder = ({
           handler={handler}
           formResetKey={formResetKey}
           allowCustom={!schema?.items?.enum}
+          disabled={isMobile}
         />
         {renderError()}
       </>
@@ -425,6 +437,7 @@ const JsonPropertyBuilder = ({
                     handler={handler}
                     formResetKey={formResetKey}
                     allowCustom={!schema?.items?.enum}
+                    disabled={isMobile}
                   />
                 </Col>
                 <Col sm={12} md={6}>
@@ -438,6 +451,7 @@ const JsonPropertyBuilder = ({
                       handler={handler}
                       formResetKey={formResetKey}
                       allowCustom={!schema?.items?.enum}
+                      disabled={isMobile}
                     />
                   )}
                 </Col>

--- a/admin-ui/plugins/auth-server/components/AuthServerProperties/types/index.ts
+++ b/admin-ui/plugins/auth-server/components/AuthServerProperties/types/index.ts
@@ -26,6 +26,7 @@ export type StringArrayFieldProps = {
   handler: (patch: JsonPatch) => void
   formResetKey: number
   allowCustom?: boolean
+  disabled?: boolean
 }
 
 export type ArrayItemSelectProps = {
@@ -37,10 +38,17 @@ export type ArrayItemSelectProps = {
   handler: (patch: JsonPatch) => void
   formResetKey: number
   allowCustom?: boolean
+  disabled?: boolean
 }
 
 export type PropertyValue =
-  string | number | boolean | string[] | AppConfiguration | null | undefined
+  | string
+  | number
+  | boolean
+  | string[]
+  | AppConfiguration
+  | null
+  | undefined
 
 export type JsonPropertyBuilderProps = {
   propKey: string
@@ -73,6 +81,7 @@ export type DefaultAcrInputProps = {
   options: (string | DefaultAcrInputOption)[]
   path: string
   showSaveButtons?: boolean
+  disabled?: boolean
 }
 
 export type AcrPutOperation = {

--- a/admin-ui/plugins/auth-server/components/ConfigApiProperties/components/ConfigApiPropertiesForm.tsx
+++ b/admin-ui/plugins/auth-server/components/ConfigApiProperties/components/ConfigApiPropertiesForm.tsx
@@ -80,7 +80,8 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
   })
 
   const handleFormSubmit = useCallback(async () => {
-    if (patches.length === 0) {
+    // Mobile is view-only, so never open the commit dialog from a form submit.
+    if (isMobile || patches.length === 0) {
       return
     }
 
@@ -93,7 +94,7 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
     }
 
     setModal(true)
-  }, [patches, formik.validateForm, formik.isValid])
+  }, [patches, formik.validateForm, formik.isValid, isMobile])
 
   useEffect(() => {
     const configChanged =
@@ -384,6 +385,9 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
   )
 
   const readOnlySet = useMemo(() => new Set(READ_ONLY_FIELDS), [])
+  // Mobile is a view-only layout, so fields are disabled to be semantically
+  // non-editable for keyboard and assistive tech, not just unclickable.
+  const isFieldDisabled = (key: string) => isMobile || readOnlySet.has(key)
 
   return (
     <>
@@ -399,7 +403,7 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
                     lSize={12}
                     handler={patchHandler}
                     doc_category="config_api_properties"
-                    disabled={readOnlySet.has(leftKey)}
+                    disabled={isFieldDisabled(leftKey)}
                     errors={formik.errors}
                     touched={formik.touched}
                   />
@@ -414,7 +418,7 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
                       lSize={12}
                       handler={patchHandler}
                       doc_category="config_api_properties"
-                      disabled={readOnlySet.has(rightKey)}
+                      disabled={isFieldDisabled(rightKey)}
                       errors={formik.errors}
                       touched={formik.touched}
                     />
@@ -432,7 +436,7 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
                     lSize={12}
                     handler={patchHandler}
                     doc_category="config_api_properties"
-                    disabled={readOnlySet.has(leftKey)}
+                    disabled={isFieldDisabled(leftKey)}
                     errors={formik.errors}
                     touched={formik.touched}
                   />
@@ -447,7 +451,7 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
                       lSize={12}
                       handler={patchHandler}
                       doc_category="config_api_properties"
-                      disabled={readOnlySet.has(rightKey)}
+                      disabled={isFieldDisabled(rightKey)}
                       errors={formik.errors}
                       touched={formik.touched}
                     />
@@ -464,7 +468,7 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
                   lSize={6}
                   handler={patchHandler}
                   doc_category="config_api_properties"
-                  disabled={readOnlySet.has(propKey)}
+                  disabled={isFieldDisabled(propKey)}
                   errors={formik.errors}
                   touched={formik.touched}
                 />

--- a/admin-ui/plugins/auth-server/components/Keys/components/KeysPage.tsx
+++ b/admin-ui/plugins/auth-server/components/Keys/components/KeysPage.tsx
@@ -6,6 +6,7 @@ import { usePermission } from '@/cedarling/hooks/usePermission'
 import { ADMIN_UI_RESOURCES } from '@/cedarling/utility'
 import GluuViewWrapper from 'Routes/Apps/Gluu/GluuViewWrapper'
 import GluuThemeFormFooter from 'Routes/Apps/Gluu/GluuThemeFormFooter'
+import GluuText from 'Routes/Apps/Gluu/GluuText'
 import { GluuPageContent } from '@/components'
 import { useTheme } from '@/context/theme/themeContext'
 import getThemeColor from '@/context/theme/config'
@@ -39,6 +40,9 @@ const KeysPage: React.FC = () => {
   return (
     <GluuPageContent>
       <GluuViewWrapper canShow={canReadKeys}>
+        <GluuText variant="h1" className={classes.mobilePageTitle}>
+          {t('titles.public_keys')}
+        </GluuText>
         <div className={classes.pageCard}>
           <JwkListPage classes={classes} />
         </div>

--- a/admin-ui/plugins/auth-server/components/Keys/components/styles/KeysPage.style.ts
+++ b/admin-ui/plugins/auth-server/components/Keys/components/styles/KeysPage.style.ts
@@ -1,7 +1,14 @@
 import { makeStyles } from 'tss-react/mui'
 import type { Theme } from '@mui/material/styles'
 import type { ThemeConfig } from '@/context/theme/config'
-import { SPACING, BORDER_RADIUS, MAPPING_SPACING, OPACITY } from '@/constants'
+import {
+  SPACING,
+  BORDER_RADIUS,
+  MAPPING_SPACING,
+  OPACITY,
+  MOBILE_MEDIA_QUERY,
+  createMobilePageTitleStyle,
+} from '@/constants'
 import { fontSizes, fontWeights } from '@/styles/fonts'
 import { getCardBorderStyle } from '@/styles/cardBorderStyles'
 import {
@@ -28,6 +35,7 @@ export const useStyles = makeStyles<StyleProps>()((theme: Theme, { isDark, theme
   const inputColors = { inputBg: formInputBg, inputBorderColor, fontColor, textMuted }
 
   return {
+    mobilePageTitle: createMobilePageTitleStyle(fontColor),
     pageCard: {
       backgroundColor: cardBg,
       borderRadius: BORDER_RADIUS.DEFAULT,
@@ -108,6 +116,11 @@ export const useStyles = makeStyles<StyleProps>()((theme: Theme, { isDark, theme
       '& textarea': {
         height: 'auto',
         overflow: 'auto',
+      },
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& textarea': {
+          resize: 'none' as const,
+        },
       },
       '& input:focus, & input:focus-visible, & input:active, & textarea:focus, & textarea:focus-visible':
         {

--- a/admin-ui/plugins/auth-server/components/Logging/components/LoggingPage.tsx
+++ b/admin-ui/plugins/auth-server/components/Logging/components/LoggingPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react'
+import useMediaQuery from '@mui/material/useMediaQuery'
 import { Form } from 'Components'
 import GluuLoader from 'Routes/Apps/Gluu/GluuLoader'
 import GluuViewWrapper from 'Routes/Apps/Gluu/GluuViewWrapper'
@@ -6,6 +7,7 @@ import GluuCommitDialog from 'Routes/Apps/Gluu/GluuCommitDialog'
 import GluuSelectRow from 'Routes/Apps/Gluu/GluuSelectRow'
 import GluuToggleRow from 'Routes/Apps/Gluu/GluuToggleRow'
 import GluuThemeFormFooter from 'Routes/Apps/Gluu/GluuThemeFormFooter'
+import GluuText from 'Routes/Apps/Gluu/GluuText'
 import type { GluuCommitDialogOperation } from 'Routes/Apps/Gluu/types/index'
 import { JSON_CONFIG } from 'Utils/ApiResources'
 import {
@@ -27,6 +29,7 @@ import type { PendingValues } from '../types'
 import { useAppDispatch } from '@/redux/hooks'
 import { updateToast } from 'Redux/features/toastSlice'
 import { GluuPageContent } from '@/components'
+import { MOBILE_MEDIA_QUERY } from '@/constants'
 import { useTheme } from '@/context/theme/themeContext'
 import getThemeColor from '@/context/theme/config'
 import { THEME_DARK, THEME_LIGHT } from '@/context/theme/constants'
@@ -47,6 +50,7 @@ const LoggingPage = (): React.ReactElement => {
   const dispatch = useAppDispatch()
   const { canRead: canReadLogging, canWrite: canWriteLogging } = usePermission(LOGGING_RESOURCE_ID)
   const { navigateBack } = useAppNavigation()
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
 
   const { data: logging, isLoading: queryLoading } = useLoggingConfig()
   const updateLoggingMutation = useUpdateLoggingConfig()
@@ -161,6 +165,9 @@ const LoggingPage = (): React.ReactElement => {
     <GluuLoader blocking={loading}>
       <GluuPageContent>
         <GluuViewWrapper canShow={canReadLogging}>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {t('titles.logging', 'Logging')}
+          </GluuText>
           <div className={classes.pageCard}>
             <Formik
               initialValues={initialValues}
@@ -267,10 +274,10 @@ const LoggingPage = (): React.ReactElement => {
                       showBack
                       onBack={handleBack}
                       backButtonLabel={t('actions.back')}
-                      showCancel
+                      showCancel={!isMobile}
                       onCancel={() => formik.resetForm()}
                       disableCancel={!formik.dirty}
-                      showApply
+                      showApply={!isMobile}
                       onApply={formik.handleSubmit}
                       disableApply={!formik.isValid || !formik.dirty}
                       applyButtonType="button"

--- a/admin-ui/plugins/auth-server/components/Logging/components/LoggingPage.tsx
+++ b/admin-ui/plugins/auth-server/components/Logging/components/LoggingPage.tsx
@@ -197,6 +197,7 @@ const LoggingPage = (): React.ReactElement => {
                               ? t(formik.errors.loggingLevel as string)
                               : undefined
                           }
+                          disabled={isMobile}
                         />
                       </div>
                       <div className={classes.fieldItem}>
@@ -219,6 +220,7 @@ const LoggingPage = (): React.ReactElement => {
                               ? t(formik.errors.loggingLayout as string)
                               : undefined
                           }
+                          disabled={isMobile}
                         />
                       </div>
                       <div className={classes.fieldItem}>
@@ -234,6 +236,7 @@ const LoggingPage = (): React.ReactElement => {
                           doc_category={JSON_CONFIG}
                           formik={formik}
                           isDark={isDark}
+                          disabled={isMobile}
                         />
                       </div>
                       <div className={classes.fieldItem}>
@@ -249,6 +252,7 @@ const LoggingPage = (): React.ReactElement => {
                           value={formik.values.disableJdkLogger}
                           formik={formik}
                           isDark={isDark}
+                          disabled={isMobile}
                         />
                       </div>
                       <div className={classes.fieldItem}>
@@ -264,26 +268,25 @@ const LoggingPage = (): React.ReactElement => {
                           value={formik.values.enabledOAuthAuditLogging}
                           formik={formik}
                           isDark={isDark}
+                          disabled={isMobile}
                         />
                       </div>
                     </div>
                   </div>
 
-                  {canWriteLogging && (
-                    <GluuThemeFormFooter
-                      showBack
-                      onBack={handleBack}
-                      backButtonLabel={t('actions.back')}
-                      showCancel={!isMobile}
-                      onCancel={() => formik.resetForm()}
-                      disableCancel={!formik.dirty}
-                      showApply={!isMobile}
-                      onApply={formik.handleSubmit}
-                      disableApply={!formik.isValid || !formik.dirty}
-                      applyButtonType="button"
-                      isLoading={loading}
-                    />
-                  )}
+                  <GluuThemeFormFooter
+                    showBack
+                    onBack={handleBack}
+                    backButtonLabel={t('actions.back')}
+                    showCancel={canWriteLogging && !isMobile}
+                    onCancel={() => formik.resetForm()}
+                    disableCancel={!formik.dirty}
+                    showApply={canWriteLogging && !isMobile}
+                    onApply={formik.handleSubmit}
+                    disableApply={!formik.isValid || !formik.dirty}
+                    applyButtonType="button"
+                    isLoading={loading}
+                  />
                 </Form>
               )}
             </Formik>

--- a/admin-ui/plugins/auth-server/components/Logging/components/LoggingPage.tsx
+++ b/admin-ui/plugins/auth-server/components/Logging/components/LoggingPage.tsx
@@ -78,6 +78,14 @@ const LoggingPage = (): React.ReactElement => {
     setShowCommitDialog(false)
   }, [])
 
+  // Resizing below the mobile breakpoint discards any in-flight commit.
+  useEffect(() => {
+    if (isMobile) {
+      setShowCommitDialog(false)
+      setPendingValues(null)
+    }
+  }, [isMobile])
+
   const handleBack = useCallback(() => {
     navigateBack(ROUTES.AUTH_SERVER_CONFIG_PROPERTIES)
   }, [navigateBack])
@@ -118,6 +126,9 @@ const LoggingPage = (): React.ReactElement => {
 
   const handleSubmit = useCallback(
     (values: LoggingFormValues): void => {
+      // Mobile is view-only, so never open the commit dialog.
+      if (isMobile) return
+
       if (!logging) {
         logger.warn('Cannot submit: logging data not loaded')
         return
@@ -133,11 +144,13 @@ const LoggingPage = (): React.ReactElement => {
       setPendingValues({ mergedValues, changedFields })
       openCommitDialog()
     },
-    [logging, openCommitDialog],
+    [logging, openCommitDialog, isMobile],
   )
 
   const handleAccept = useCallback(
     async (userMessage: string): Promise<void> => {
+      // Blocks a dialog opened on desktop from mutating after a resize to mobile.
+      if (isMobile) return
       if (!pendingValues) return
 
       const { mergedValues, changedFields } = pendingValues
@@ -158,7 +171,7 @@ const LoggingPage = (): React.ReactElement => {
         dispatch(updateToast(true, 'error', t('messages.error_processing_request')))
       }
     },
-    [pendingValues, updateLoggingMutation, closeCommitDialog, dispatch, t],
+    [pendingValues, updateLoggingMutation, closeCommitDialog, dispatch, t, isMobile],
   )
 
   return (
@@ -292,12 +305,14 @@ const LoggingPage = (): React.ReactElement => {
             </Formik>
           </div>
 
-          <GluuCommitDialog
-            handler={closeCommitDialog}
-            modal={showCommitDialog}
-            onAccept={handleAccept}
-            operations={commitDialogOperations}
-          />
+          {!isMobile && (
+            <GluuCommitDialog
+              handler={closeCommitDialog}
+              modal={showCommitDialog}
+              onAccept={handleAccept}
+              operations={commitDialogOperations}
+            />
+          )}
         </GluuViewWrapper>
       </GluuPageContent>
     </GluuLoader>

--- a/admin-ui/plugins/auth-server/components/Logging/components/styles/LoggingPage.style.ts
+++ b/admin-ui/plugins/auth-server/components/Logging/components/styles/LoggingPage.style.ts
@@ -2,7 +2,14 @@ import { makeStyles } from 'tss-react/mui'
 import { alpha } from '@mui/material/styles'
 import type { Theme } from '@mui/material/styles'
 import type { ThemeConfig } from '@/context/theme/config'
-import { SPACING, BORDER_RADIUS, OPACITY, CEDARLING_CONFIG_SPACING } from '@/constants'
+import {
+  SPACING,
+  BORDER_RADIUS,
+  OPACITY,
+  CEDARLING_CONFIG_SPACING,
+  MOBILE_MEDIA_QUERY,
+  createMobilePageTitleStyle,
+} from '@/constants'
 import { getCardBorderStyle } from '@/styles/cardBorderStyles'
 import { createFormGroupOverrides, createFormLabelStyles } from '@/styles/formStyles'
 
@@ -24,6 +31,7 @@ export const useStyles = makeStyles<StyleProps>()((theme: Theme, { isDark, theme
   const inputBorderColor = themeColors.settings?.inputBorder ?? themeColors.borderColor
 
   return {
+    mobilePageTitle: createMobilePageTitleStyle(fontColor),
     pageCard: {
       backgroundColor: cardBg,
       borderRadius: BORDER_RADIUS.DEFAULT,
@@ -31,8 +39,13 @@ export const useStyles = makeStyles<StyleProps>()((theme: Theme, { isDark, theme
       padding: SPACING.CARD_PADDING,
     },
     formContent: {
-      ...createFormGroupOverrides({ columnPaddingBottom: 20 }),
+      ...createFormGroupOverrides(),
       ...createFormLabelStyles(fontColor),
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& input, & select, & textarea, & .custom-select, & .form-control, & .react-toggle': {
+          pointerEvents: 'none' as const,
+        },
+      },
       '& select, & .custom-select, & .form-control': {
         backgroundColor: `${formInputBg} !important`,
         border: `1px solid ${inputBorderColor} !important`,
@@ -64,7 +77,7 @@ export const useStyles = makeStyles<StyleProps>()((theme: Theme, { isDark, theme
       display: 'grid',
       gridTemplateColumns: '1fr 1fr',
       columnGap: SPACING.SECTION_GAP,
-      rowGap: SPACING.CARD_CONTENT_GAP,
+      rowGap: SPACING.SECTION_GAP,
       [theme.breakpoints.down('md')]: {
         gridTemplateColumns: '1fr',
       },

--- a/admin-ui/plugins/auth-server/components/Logging/components/styles/LoggingPage.style.ts
+++ b/admin-ui/plugins/auth-server/components/Logging/components/styles/LoggingPage.style.ts
@@ -1,5 +1,4 @@
 import { makeStyles } from 'tss-react/mui'
-import { alpha } from '@mui/material/styles'
 import type { Theme } from '@mui/material/styles'
 import type { ThemeConfig } from '@/context/theme/config'
 import {
@@ -66,7 +65,7 @@ export const useStyles = makeStyles<StyleProps>()((theme: Theme, { isDark, theme
         boxShadow: 'none',
       },
       '& select:disabled, & .custom-select:disabled, & .form-control:disabled': {
-        backgroundColor: `${alpha(formInputBg, OPACITY.DISABLED)} !important`,
+        backgroundColor: `${formInputBg} !important`,
         border: `1px solid ${inputBorderColor} !important`,
         color: `${fontColor} !important`,
         opacity: OPACITY.DISABLED,

--- a/admin-ui/plugins/auth-server/components/Scopes/components/ScopeListPage.tsx
+++ b/admin-ui/plugins/auth-server/components/Scopes/components/ScopeListPage.tsx
@@ -106,7 +106,7 @@ const ScopeListPage: React.FC = () => {
     [limit, startIndex, debouncedPattern, scopeType, sortBy],
   )
 
-  const { data: scopesResponse, isLoading, refetch } = useScopes(scopesQueryParams)
+  const { data: scopesResponse, isLoading, isFetching, refetch } = useScopes(scopesQueryParams)
 
   const deleteScope = useDeleteOauthScopesByInum({
     mutation: {
@@ -131,7 +131,6 @@ const ScopeListPage: React.FC = () => {
 
   SetTitle(t('titles.scopes'))
 
-  // Navigation handlers
   const handleAdd = useCallback(() => {
     navigateToRoute(ROUTES.AUTH_SERVER_SCOPE_ADD)
   }, [navigateToRoute])
@@ -154,7 +153,6 @@ const ScopeListPage: React.FC = () => {
     [navigateToRoute],
   )
 
-  // Delete handlers
   const handleDeleteClick = useCallback((row: ScopeTableRow) => {
     setItemToDelete(row as Scope)
     setModal(true)
@@ -187,7 +185,6 @@ const ScopeListPage: React.FC = () => {
     [itemToDelete, deleteScope, logScopeDeletion, dispatch],
   )
 
-  // Filter/search handlers
   const handlePatternSearch = useCallback(
     (value: string) => {
       setPattern(value)
@@ -239,7 +236,6 @@ const ScopeListPage: React.FC = () => {
     [setLimit, setPageNumber],
   )
 
-  // Filter definitions
   const scopeTypeOptions = useMemo(
     () => [
       { value: '', label: t('options.all') },
@@ -269,6 +265,7 @@ const ScopeListPage: React.FC = () => {
         options: scopeTypeOptions,
         onChange: handleScopeTypeChange,
         width: 180,
+        defaultValue: '',
       },
       {
         key: 'sortBy',
@@ -277,6 +274,7 @@ const ScopeListPage: React.FC = () => {
         options: sortOptions,
         onChange: handleSortByChange,
         width: 180,
+        defaultValue: DEFAULT_SCOPE_SORT_BY,
       },
     ],
     [
@@ -303,7 +301,6 @@ const ScopeListPage: React.FC = () => {
     [t, handleAdd, canWrite, classes],
   )
 
-  // Table columns
   const columns: ColumnDef<ScopeTableRow>[] = useMemo(
     () => [
       {
@@ -371,7 +368,6 @@ const ScopeListPage: React.FC = () => {
     [t, classes, badgeStyles],
   )
 
-  // Table actions
   const actions = useMemo(() => {
     const list: Array<{
       icon: React.ReactNode
@@ -416,7 +412,6 @@ const ScopeListPage: React.FC = () => {
     classes,
   ])
 
-  // Pagination
   const effectivePage = useMemo(() => {
     const maxPage = totalItems > 0 ? Math.max(0, Math.ceil(totalItems / limit) - 1) : 0
     return Math.min(pageNumber, maxPage)
@@ -445,7 +440,6 @@ const ScopeListPage: React.FC = () => {
     [],
   )
 
-  // Expandable row detail
   const detailLabelStyle = useMemo(
     () => ({ color: themeColors.fontColor }),
     [themeColors.fontColor],
@@ -564,7 +558,6 @@ const ScopeListPage: React.FC = () => {
     [getScopeDetailFields, detailLabelStyle],
   )
 
-  // Delete dialog
   const deleteDialogLabel = useMemo(
     () =>
       itemToDelete
@@ -581,8 +574,8 @@ const ScopeListPage: React.FC = () => {
   }, [pattern, scopes.length, t])
 
   const loading = useMemo(
-    () => isLoading || deleteScope.isPending,
-    [isLoading, deleteScope.isPending],
+    () => isFetching || deleteScope.isPending,
+    [isFetching, deleteScope.isPending],
   )
 
   return (

--- a/admin-ui/plugins/auth-server/components/Scopes/components/ScopeListPage.tsx
+++ b/admin-ui/plugins/auth-server/components/Scopes/components/ScopeListPage.tsx
@@ -376,13 +376,16 @@ const ScopeListPage: React.FC = () => {
       onClick: (row: ScopeTableRow) => void
     }> = []
     if (!canRead) return list
-    list.push({
-      icon: <VisibilityOutlined className={classes.viewIcon} />,
-      tooltip: t('actions.view'),
-      id: 'viewScope',
-      onClick: handleView,
-    })
-    if (isMobile) return list
+    if (isMobile) {
+      // Mobile has no row primaryAction, so View is the only way in.
+      list.push({
+        icon: <VisibilityOutlined className={classes.viewIcon} />,
+        tooltip: t('actions.view'),
+        id: 'viewScope',
+        onClick: handleView,
+      })
+      return list
+    }
     if (canWrite) {
       list.push({
         icon: <Edit className={classes.editIcon} />,

--- a/admin-ui/plugins/auth-server/components/Scopes/components/styles/ScopeFormPage.style.ts
+++ b/admin-ui/plugins/auth-server/components/Scopes/components/styles/ScopeFormPage.style.ts
@@ -23,6 +23,9 @@ const INPUT_PADDING_HORIZONTAL = 21
 const SELECT_ARROW_SPACE = 44
 const LABEL_MARGIN_BOTTOM = 2
 const MOBILE_BREAKPOINT = 768
+const MOBILE_ERROR_LINE_HEIGHT = 1.2
+// Two lines of 12px error text (12 * 1.2 * 2), so a wrapped message clears the next field.
+const MOBILE_ERROR_RESERVED_SPACE = 29
 
 export const useStyles = makeStyles<ScopeFormPageStylesParams>()((_, { isDark, themeColors }) => {
   const cardBorderStyle = getCardBorderStyle({ isDark })
@@ -114,11 +117,17 @@ export const useStyles = makeStyles<ScopeFormPageStylesParams>()((_, { isDark, t
         '& .form-group [class*="col"]': {
           paddingBottom: 0,
         },
+        // The error is absolutely positioned at the col's bottom edge, so it
+        // reserves no height. Margin (not padding) keeps that edge put while
+        // making room below for a wrapped, multi-line message.
+        '& .form-group [class*="col"]:has([data-field-error])': {
+          marginBottom: MOBILE_ERROR_RESERVED_SPACE,
+        },
         '& [data-field-error]': {
           top: '100%',
           left: 0,
           margin: 0,
-          lineHeight: 1.2,
+          lineHeight: MOBILE_ERROR_LINE_HEIGHT,
         },
       },
       '& .input-group': {

--- a/admin-ui/plugins/auth-server/components/Scopes/components/styles/ScopeFormPage.style.ts
+++ b/admin-ui/plugins/auth-server/components/Scopes/components/styles/ScopeFormPage.style.ts
@@ -144,9 +144,9 @@ export const useStyles = makeStyles<ScopeFormPageStylesParams>()((_, { isDark, t
       '& input:disabled': {
         backgroundColor: `${formInputBg} !important`,
         border: `1px solid ${inputBorderColor} !important`,
-        color: `${themeColors.textMuted} !important`,
-        WebkitTextFillColor: `${themeColors.textMuted} !important`,
-        opacity: `${OPACITY.DISABLED} !important`,
+        color: `${themeColors.fontColor} !important`,
+        WebkitTextFillColor: `${themeColors.fontColor} !important`,
+        opacity: `${OPACITY.FULL} !important`,
         cursor: 'not-allowed',
       },
     },
@@ -238,7 +238,8 @@ export const useStyles = makeStyles<ScopeFormPageStylesParams>()((_, { isDark, t
           backgroundColor: `${formInputBg} !important`,
           border: `1px solid ${inputBorderColor} !important`,
           color: `${themeColors.fontColor} !important`,
-          opacity: `${OPACITY.DISABLED} !important`,
+          WebkitTextFillColor: `${themeColors.fontColor} !important`,
+          opacity: `${OPACITY.FULL} !important`,
           cursor: 'not-allowed',
         },
       '& input:not([type="checkbox"]).is-valid, & input:not([type="checkbox"]).is-invalid, & select.is-valid, & select.is-invalid, & textarea.is-valid, & textarea.is-invalid':

--- a/admin-ui/plugins/auth-server/components/Scopes/hooks/useScopeQueries.ts
+++ b/admin-ui/plugins/auth-server/components/Scopes/hooks/useScopeQueries.ts
@@ -9,7 +9,7 @@ export const useScopes = (params: GetOauthScopesParams) => {
   const queryOptions = useMemo(
     () => ({
       query: {
-        staleTime: SCOPE_CACHE_CONFIG.staleTime,
+        staleTime: 0,
         gcTime: SCOPE_CACHE_CONFIG.gcTime,
         refetchOnWindowFocus: false,
         retry: false,

--- a/admin-ui/plugins/saml/components/WebsiteSsoServiceProviderForm.tsx
+++ b/admin-ui/plugins/saml/components/WebsiteSsoServiceProviderForm.tsx
@@ -118,10 +118,12 @@ const WebsiteSsoServiceProviderForm = ({
   const attributesList = useMemo<ScopeOption[]>(
     () =>
       attributesData?.entries
-        ? attributesData.entries.map((item): ScopeOption => ({
-            dn: String(item?.dn || ''),
-            name: String(item?.displayName || ''),
-          }))
+        ? attributesData.entries.map(
+            (item): ScopeOption => ({
+              dn: String(item?.dn || ''),
+              name: String(item?.displayName || ''),
+            }),
+          )
         : [],
     [attributesData],
   )

--- a/admin-ui/plugins/scim/components/ScimConfiguration.tsx
+++ b/admin-ui/plugins/scim/components/ScimConfiguration.tsx
@@ -1,9 +1,10 @@
 import { useFormik, FormikProps } from 'formik'
 import React, { useState, useCallback, useMemo } from 'react'
+import useMediaQuery from '@mui/material/useMediaQuery'
 import { useTranslation } from 'react-i18next'
 import { Form } from 'Components'
 import GluuWebhookCommitDialog from 'Routes/Apps/Gluu/GluuWebhookCommitDialog'
-import { adminUiFeatures } from '@/constants'
+import { adminUiFeatures, MOBILE_MEDIA_QUERY } from '@/constants'
 import GluuThemeFormFooter from 'Routes/Apps/Gluu/GluuThemeFormFooter'
 import { getScimConfigurationSchema } from '../helper'
 import { transformToFormValues, buildScimChangedFieldOperations } from '../helper'
@@ -19,6 +20,7 @@ const ScimConfiguration: React.FC<ScimConfigurationProps> = ({
   classes,
 }) => {
   const { t } = useTranslation()
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
   const [modal, setModal] = useState<boolean>(false)
   const validationSchema = useMemo(() => getScimConfigurationSchema(t), [t])
 
@@ -83,8 +85,8 @@ const ScimConfiguration: React.FC<ScimConfigurationProps> = ({
 
       <GluuThemeFormFooter
         showBack
-        showCancel
-        showApply={canWriteScim}
+        showCancel={!isMobile}
+        showApply={canWriteScim && !isMobile}
         onApply={toggle}
         onCancel={handleCancel}
         disableCancel={!formik.dirty}

--- a/admin-ui/plugins/scim/components/ScimConfiguration.tsx
+++ b/admin-ui/plugins/scim/components/ScimConfiguration.tsx
@@ -1,5 +1,5 @@
 import { useFormik, FormikProps } from 'formik'
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { useTranslation } from 'react-i18next'
 import { Form } from 'Components'
@@ -25,6 +25,13 @@ const ScimConfiguration: React.FC<ScimConfigurationProps> = ({
   // and submission path, not just for action visibility.
   const isReadOnly = !canWriteScim || isMobile
   const [modal, setModal] = useState<boolean>(false)
+
+  // Entering read-only (e.g. resizing to mobile) discards any in-flight commit.
+  useEffect(() => {
+    if (isReadOnly) {
+      setModal(false)
+    }
+  }, [isReadOnly])
   const validationSchema = useMemo(() => getScimConfigurationSchema(t), [t])
 
   const toggle = useCallback((): void => {

--- a/admin-ui/plugins/scim/components/ScimConfiguration.tsx
+++ b/admin-ui/plugins/scim/components/ScimConfiguration.tsx
@@ -21,12 +21,16 @@ const ScimConfiguration: React.FC<ScimConfigurationProps> = ({
 }) => {
   const { t } = useTranslation()
   const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
+  // Mobile is a view-only layout, so treat it as read-only for every control
+  // and submission path, not just for action visibility.
+  const isReadOnly = !canWriteScim || isMobile
   const [modal, setModal] = useState<boolean>(false)
   const validationSchema = useMemo(() => getScimConfigurationSchema(t), [t])
 
   const toggle = useCallback((): void => {
+    if (isReadOnly) return
     setModal((prev) => !prev)
-  }, [])
+  }, [isReadOnly])
 
   const initialFormValues = useMemo(
     () => transformToFormValues(scimConfiguration),
@@ -47,12 +51,13 @@ const ScimConfiguration: React.FC<ScimConfigurationProps> = ({
 
   const submitForm = useCallback(
     async (userMessage: string): Promise<void> => {
+      if (isReadOnly) return
       await handleSubmit({
         ...formik.values,
         action_message: userMessage,
       })
     },
-    [handleSubmit, formik.values],
+    [handleSubmit, formik.values, isReadOnly],
   )
 
   const handleCancel = useCallback(() => {
@@ -78,6 +83,7 @@ const ScimConfiguration: React.FC<ScimConfigurationProps> = ({
               formik={formik}
               fieldItemClass={classes.fieldItem}
               fieldItemFullWidthClass={classes.fieldItemFullWidth}
+              disabled={isReadOnly}
             />
           ))}
         </div>
@@ -85,8 +91,8 @@ const ScimConfiguration: React.FC<ScimConfigurationProps> = ({
 
       <GluuThemeFormFooter
         showBack
-        showCancel={!isMobile}
-        showApply={canWriteScim && !isMobile}
+        showCancel={!isReadOnly}
+        showApply={!isReadOnly}
         onApply={toggle}
         onCancel={handleCancel}
         disableCancel={!formik.dirty}

--- a/admin-ui/plugins/scim/components/ScimFieldRenderer.tsx
+++ b/admin-ui/plugins/scim/components/ScimFieldRenderer.tsx
@@ -16,9 +16,18 @@ const ScimFieldRenderer: React.FC<ScimFieldRendererProps> = ({
   formik,
   fieldItemClass,
   fieldItemFullWidthClass,
+  disabled: disabledOverride = false,
 }) => {
   const { t } = useTranslation()
-  const { name, label, type, disabled = false, selectOptions, colSize = 12 } = config
+  const {
+    name,
+    label,
+    type,
+    disabled: configDisabled = false,
+    selectOptions,
+    colSize = 12,
+  } = config
+  const disabled = configDisabled || disabledOverride
 
   const value = formik.values[name]
   const error = formik.errors[name]

--- a/admin-ui/plugins/scim/components/ScimPage.tsx
+++ b/admin-ui/plugins/scim/components/ScimPage.tsx
@@ -5,6 +5,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import SetTitle from 'Utils/SetTitle'
 import GluuLoader from 'Routes/Apps/Gluu/GluuLoader'
 import GluuViewWrapper from 'Routes/Apps/Gluu/GluuViewWrapper'
+import GluuText from 'Routes/Apps/Gluu/GluuText'
 import { Card, CardBody } from 'Components'
 import { GluuPageContent } from '@/components'
 import ScimConfiguration from './ScimConfiguration'
@@ -136,6 +137,9 @@ const ScimPage: React.FC = () => {
     <GluuPageContent>
       <GluuViewWrapper canShow={canReadScim}>
         <GluuLoader blocking={isLoading || patchScimMutation.isPending}>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {t('titles.scim_management')}
+          </GluuText>
           <Card className={classes.formCard}>
             <CardBody className={classes.content}>
               <ScimConfiguration

--- a/admin-ui/plugins/scim/components/styles/ScimFormPage.style.ts
+++ b/admin-ui/plugins/scim/components/styles/ScimFormPage.style.ts
@@ -1,7 +1,13 @@
 import { makeStyles } from 'tss-react/mui'
 import { alpha } from '@mui/material/styles'
 import type { Theme } from '@mui/material/styles'
-import { SPACING, BORDER_RADIUS, OPACITY } from '@/constants'
+import {
+  SPACING,
+  BORDER_RADIUS,
+  OPACITY,
+  MOBILE_MEDIA_QUERY,
+  createMobilePageTitleStyle,
+} from '@/constants'
 import type { ThemeConfig } from '@/context/theme/config'
 import { getCardBorderStyle } from '@/styles/cardBorderStyles'
 import {
@@ -37,6 +43,7 @@ export const useStyles = makeStyles<ScimFormPageStylesParams>()((
   }
 
   return {
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     formCard: {
       'backgroundColor': `${cardBg} !important`,
       ...getCardBorderStyle({ isDark }),
@@ -65,6 +72,11 @@ export const useStyles = makeStyles<ScimFormPageStylesParams>()((
       flexDirection: 'column',
       gap: 0,
       width: '100%',
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& input, & select, & textarea, & .custom-select, & .form-control, & .react-toggle': {
+          pointerEvents: 'none' as const,
+        },
+      },
     },
     fieldsGrid: {
       display: 'grid',
@@ -77,6 +89,9 @@ export const useStyles = makeStyles<ScimFormPageStylesParams>()((
       [theme.breakpoints.down('md')]: {
         gridTemplateColumns: '1fr',
       },
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        rowGap: SPACING.SECTION_GAP,
+      },
     },
     fieldItem: {
       'width': '100%',
@@ -88,6 +103,11 @@ export const useStyles = makeStyles<ScimFormPageStylesParams>()((
         position: 'relative',
         paddingBottom: ERROR_SPACE,
       },
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& .form-group [class*="col"]': {
+          paddingBottom: 0,
+        },
+      },
     },
     fieldItemFullWidth: {
       'width': '100%',
@@ -98,6 +118,11 @@ export const useStyles = makeStyles<ScimFormPageStylesParams>()((
         ...formGroupBase['& .form-group [class*="col"]'],
         position: 'relative',
         paddingBottom: ERROR_SPACE,
+      },
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& .form-group [class*="col"]': {
+          paddingBottom: 0,
+        },
       },
     },
     togglesRow: {

--- a/admin-ui/plugins/scim/components/styles/ScimFormPage.style.ts
+++ b/admin-ui/plugins/scim/components/styles/ScimFormPage.style.ts
@@ -1,5 +1,4 @@
 import { makeStyles } from 'tss-react/mui'
-import { alpha } from '@mui/material/styles'
 import type { Theme } from '@mui/material/styles'
 import {
   SPACING,
@@ -157,8 +156,9 @@ export const useStyles = makeStyles<ScimFormPageStylesParams>()((
       '& input:disabled, & select:disabled': {
         backgroundColor: `${formInputBg} !important`,
         border: `1px solid ${inputBorderColor} !important`,
-        color: `${alpha(themeColors.fontColor, OPACITY.PLACEHOLDER)} !important`,
-        opacity: OPACITY.DISABLED,
+        color: `${themeColors.fontColor} !important`,
+        WebkitTextFillColor: `${themeColors.fontColor} !important`,
+        opacity: `${OPACITY.FULL} !important`,
         cursor: 'not-allowed',
       },
       '& input::placeholder': {

--- a/admin-ui/plugins/scim/types/index.ts
+++ b/admin-ui/plugins/scim/types/index.ts
@@ -73,4 +73,5 @@ export type ScimFieldRendererProps = {
   formik: FormikProps<ScimFormValues>
   fieldItemClass: string
   fieldItemFullWidthClass: string
+  disabled?: boolean
 }

--- a/admin-ui/plugins/smtp/components/SmtpEditPage.tsx
+++ b/admin-ui/plugins/smtp/components/SmtpEditPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState, useRef, useEffect, useMemo } from 'react'
 import { FormikProps } from 'formik'
 import GluuLoader from 'Routes/Apps/Gluu/GluuLoader'
 import GluuViewWrapper from 'Routes/Apps/Gluu/GluuViewWrapper'
+import GluuText from 'Routes/Apps/Gluu/GluuText'
 import { GluuPageContent } from '@/components'
 import SetTitle from 'Utils/SetTitle'
 import { useTranslation } from 'react-i18next'
@@ -191,6 +192,9 @@ const SmtpEditPage = () => {
       )}
       <GluuViewWrapper canShow={canReadSmtp}>
         <GluuLoader blocking={isBlocking}>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {t('menus.stmp_management')}
+          </GluuText>
           <div className={classes.formCard}>
             <div className={classes.content}>
               <SmtpForm

--- a/admin-ui/plugins/smtp/components/SmtpForm.tsx
+++ b/admin-ui/plugins/smtp/components/SmtpForm.tsx
@@ -47,6 +47,9 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
   const dispatch = useAppDispatch()
   const { navigateBack } = useAppNavigation()
   const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
+  // Mobile is a view-only layout, so treat it as read-only for every
+  // control, handler and commit path, not just for action visibility.
+  const isReadOnly = readOnly || isMobile
   const { state: themeState } = useTheme()
   const { themeColors, isDark } = useMemo(
     () => ({
@@ -84,9 +87,9 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
   }, [allowSmtpKeystoreEdit, loadingConfig])
 
   const toggle = useCallback(() => {
-    if (readOnly) return
+    if (isReadOnly) return
     setModal((prev) => !prev)
-  }, [readOnly])
+  }, [isReadOnly])
 
   const initialValues: SmtpFormValues = useMemo(() => transformToFormValues(item), [item])
   const smtpValidationSchema = useMemo(() => getSmtpValidationSchema(t), [t])
@@ -94,7 +97,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
   const formik = useFormik<SmtpFormValues>({
     initialValues,
     onSubmit: () => {
-      if (readOnly) return
+      if (isReadOnly) return
       setCommitOperations(buildSmtpChangedFieldOperations(initialValues, formik.values, t))
       toggle()
     },
@@ -123,7 +126,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
 
   const submitForm = useCallback(
     async (userMessage: string) => {
-      if (readOnly) return
+      if (isReadOnly) return
       const errors = await formik.validateForm()
       if (Object.keys(errors).length > 0) {
         const touched: Record<string, boolean> = {}
@@ -145,11 +148,11 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
       }
       handleSubmit(toSmtpConfiguration(trimmedValues), userMessage)
     },
-    [readOnly, formik, handleSubmit, t, dispatch],
+    [isReadOnly, formik, handleSubmit, t, dispatch],
   )
 
   const testSmtpConfig = useCallback(() => {
-    if (readOnly) return
+    if (isReadOnly) return
     if (formik.isValid) {
       onTestSmtp({
         sign: true,
@@ -159,7 +162,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
     } else {
       dispatch(updateToast(true, 'error', t('messages.mandatory_fields_required')))
     }
-  }, [readOnly, formik.isValid, onTestSmtp, t, dispatch])
+  }, [isReadOnly, formik.isValid, onTestSmtp, t, dispatch])
 
   const keystoreTooltip = useCallback(
     (fieldLabel: string) =>
@@ -180,7 +183,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
 
   return (
     <>
-      {!readOnly && !optimisticKeystoreEdit && (
+      {!isReadOnly && !optimisticKeystoreEdit && (
         <>
           <GluuTooltip
             tooltipOnly
@@ -231,7 +234,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               showError={formik.touched.host && !!formik.errors.host}
               errorMessage={formik.errors.host as string}
               required
-              disabled={readOnly}
+              disabled={isReadOnly}
               isDark={isDark}
               doc_category={smtpConstants.DOC_CATEGORY}
               doc_entry="host"
@@ -250,7 +253,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               errorMessage={formik.errors.port as string}
               type="number"
               required
-              disabled={readOnly}
+              disabled={isReadOnly}
               isDark={isDark}
               doc_category={smtpConstants.DOC_CATEGORY}
               doc_entry="port"
@@ -270,7 +273,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               showError={formik.touched.connect_protection && !!formik.errors.connect_protection}
               errorMessage={formik.errors.connect_protection as string}
               required
-              disabled={readOnly}
+              disabled={isReadOnly}
               isDark={isDark}
               doc_category={smtpConstants.DOC_CATEGORY}
               doc_entry="connect_protection"
@@ -287,7 +290,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               showError={formik.touched.from_name && !!formik.errors.from_name}
               errorMessage={formik.errors.from_name as string}
               required
-              disabled={readOnly}
+              disabled={isReadOnly}
               isDark={isDark}
               doc_category={smtpConstants.DOC_CATEGORY}
               doc_entry="from_name"
@@ -306,7 +309,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               showError={formik.touched.from_email_address && !!formik.errors.from_email_address}
               errorMessage={formik.errors.from_email_address as string}
               required
-              disabled={readOnly}
+              disabled={isReadOnly}
               isDark={isDark}
               doc_category={smtpConstants.DOC_CATEGORY}
               doc_entry="from_email_address"
@@ -327,7 +330,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               }
               errorMessage={formik.errors.smtp_authentication_account_username as string}
               required={formik.values.requires_authentication}
-              disabled={readOnly}
+              disabled={isReadOnly}
               isDark={isDark}
               doc_category={smtpConstants.DOC_CATEGORY}
               doc_entry="smtp_authentication_account_username"
@@ -350,7 +353,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               errorMessage={formik.errors.smtp_authentication_account_password as string}
               type="password"
               required={formik.values.requires_authentication}
-              disabled={readOnly}
+              disabled={isReadOnly}
               isDark={isDark}
               doc_category={smtpConstants.DOC_CATEGORY}
               doc_entry="smtp_authentication_account_password"
@@ -367,13 +370,13 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               rsize={12}
               showError={formik.touched.key_store && !!formik.errors.key_store}
               errorMessage={formik.errors.key_store as string}
-              disabled={readOnly || !optimisticKeystoreEdit}
+              disabled={isReadOnly || !optimisticKeystoreEdit}
               isDark={isDark}
               doc_category={smtpConstants.DOC_CATEGORY}
               doc_entry="key_store"
               placeholder={getFieldPlaceholder(t, 'fields.key_store')}
             />
-            {!readOnly && !optimisticKeystoreEdit && (
+            {!isReadOnly && !optimisticKeystoreEdit && (
               <div
                 className={classes.keystoreOverlay}
                 data-tooltip-id="keystoreDisabled-key_store"
@@ -392,13 +395,13 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               showError={formik.touched.key_store_password && !!formik.errors.key_store_password}
               errorMessage={formik.errors.key_store_password as string}
               type="password"
-              disabled={readOnly || !optimisticKeystoreEdit}
+              disabled={isReadOnly || !optimisticKeystoreEdit}
               isDark={isDark}
               doc_category={smtpConstants.DOC_CATEGORY}
               doc_entry="key_store_password"
               placeholder={getFieldPlaceholder(t, 'fields.key_store_password')}
             />
-            {!readOnly && !optimisticKeystoreEdit && (
+            {!isReadOnly && !optimisticKeystoreEdit && (
               <div
                 className={classes.keystoreOverlay}
                 data-tooltip-id="keystoreDisabled-key_store_password"
@@ -415,13 +418,13 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               rsize={12}
               showError={formik.touched.key_store_alias && !!formik.errors.key_store_alias}
               errorMessage={formik.errors.key_store_alias as string}
-              disabled={readOnly || !optimisticKeystoreEdit}
+              disabled={isReadOnly || !optimisticKeystoreEdit}
               isDark={isDark}
               doc_category={smtpConstants.DOC_CATEGORY}
               doc_entry="key_store_alias"
               placeholder={getFieldPlaceholder(t, 'fields.key_store_alias')}
             />
-            {!readOnly && !optimisticKeystoreEdit && (
+            {!isReadOnly && !optimisticKeystoreEdit && (
               <div
                 className={classes.keystoreOverlay}
                 data-tooltip-id="keystoreDisabled-key_store_alias"
@@ -439,13 +442,13 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               rsize={12}
               showError={formik.touched.signing_algorithm && !!formik.errors.signing_algorithm}
               errorMessage={formik.errors.signing_algorithm as string}
-              disabled={readOnly || !optimisticKeystoreEdit}
+              disabled={isReadOnly || !optimisticKeystoreEdit}
               isDark={isDark}
               doc_category={smtpConstants.DOC_CATEGORY}
               doc_entry="signing_algorithm"
               placeholder={getFieldPlaceholder(t, 'fields.signing_algorithm')}
             />
-            {!readOnly && !optimisticKeystoreEdit && (
+            {!isReadOnly && !optimisticKeystoreEdit && (
               <div
                 className={classes.keystoreOverlay}
                 data-tooltip-id="keystoreDisabled-signing_algorithm"
@@ -466,7 +469,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
                 name="trust_host"
                 formik={formik}
                 value={Boolean(formik.values.trust_host)}
-                disabled={readOnly}
+                disabled={isReadOnly}
               />
             </FormGroup>
           </div>
@@ -501,7 +504,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
                       )
                     }
                   }}
-                  disabled={readOnly || loadingConfig}
+                  disabled={isReadOnly || loadingConfig}
                 />
               </GluuLoader>
             </FormGroup>
@@ -520,12 +523,12 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
                 name="requires_authentication"
                 formik={formik}
                 value={Boolean(formik.values.requires_authentication)}
-                disabled={readOnly}
+                disabled={isReadOnly}
               />
             </FormGroup>
           </div>
 
-          {!readOnly && !isMobile && (
+          {!isReadOnly && (
             <div className={classes.testButtonRow}>
               <GluuButton
                 type="button"
@@ -548,17 +551,17 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
         <GluuThemeFormFooter
           showBack
           onBack={handleNavigateBack}
-          showCancel={!readOnly && !isMobile}
+          showCancel={!isReadOnly}
           onCancel={handleCancel}
           disableCancel={!formik.dirty}
-          showApply={!readOnly && !isMobile}
+          showApply={!isReadOnly}
           onApply={handleApply}
           disableApply={!formik.isValid || !formik.dirty}
           applyButtonType="button"
           isLoading={formik.isSubmitting ?? false}
         />
 
-        {!readOnly && (
+        {!isReadOnly && (
           <GluuCommitDialog
             feature={adminUiFeatures.smtp_configuration_edit}
             handler={toggle}

--- a/admin-ui/plugins/smtp/components/SmtpForm.tsx
+++ b/admin-ui/plugins/smtp/components/SmtpForm.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
+import useMediaQuery from '@mui/material/useMediaQuery'
 import { Form, FormGroup } from 'Components'
 import GluuToggle from 'Routes/Apps/Gluu/GluuToggle'
 import GluuInputRow from 'Routes/Apps/Gluu/GluuInputRow'
@@ -16,7 +17,7 @@ import { useTheme } from '@/context/theme/themeContext'
 import getThemeColor from '@/context/theme/config'
 import { THEME_DARK } from '@/context/theme/constants'
 import { useAppDispatch, useAppSelector } from '@/redux/hooks'
-import { adminUiFeatures, OPACITY } from '@/constants'
+import { adminUiFeatures, OPACITY, MOBILE_MEDIA_QUERY } from '@/constants'
 import { putConfigWorker } from 'Redux/features/authSlice'
 import { updateToast } from 'Redux/features/toastSlice'
 import { SmtpFormValues, SmtpFormProps } from 'Plugins/smtp/types'
@@ -45,6 +46,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const { navigateBack } = useAppNavigation()
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
   const { state: themeState } = useTheme()
   const { themeColors, isDark } = useMemo(
     () => ({
@@ -523,7 +525,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
             </FormGroup>
           </div>
 
-          {!readOnly && (
+          {!readOnly && !isMobile && (
             <div className={classes.testButtonRow}>
               <GluuButton
                 type="button"
@@ -546,10 +548,10 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
         <GluuThemeFormFooter
           showBack
           onBack={handleNavigateBack}
-          showCancel={!readOnly}
+          showCancel={!readOnly && !isMobile}
           onCancel={handleCancel}
           disableCancel={!formik.dirty}
-          showApply={!readOnly}
+          showApply={!readOnly && !isMobile}
           onApply={handleApply}
           disableApply={!formik.isValid || !formik.dirty}
           applyButtonType="button"

--- a/admin-ui/plugins/smtp/components/SmtpForm.tsx
+++ b/admin-ui/plugins/smtp/components/SmtpForm.tsx
@@ -73,6 +73,14 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
   )
 
   const [modal, setModal] = useState(false)
+
+  // Entering read-only (e.g. resizing to mobile) discards any in-flight commit,
+  // so the conditionally rendered dialog cannot restore stale state on return.
+  useEffect(() => {
+    if (isReadOnly) {
+      setModal(false)
+    }
+  }, [isReadOnly])
   const [commitOperations, setCommitOperations] = useState<
     ReturnType<typeof buildSmtpChangedFieldOperations>
   >([])

--- a/admin-ui/plugins/smtp/components/styles/SmtpFormPage.style.ts
+++ b/admin-ui/plugins/smtp/components/styles/SmtpFormPage.style.ts
@@ -1,5 +1,4 @@
 import { makeStyles } from 'tss-react/mui'
-import { alpha } from '@mui/material/styles'
 import type { Theme } from '@mui/material/styles'
 import {
   SPACING,
@@ -210,10 +209,11 @@ export const useStyles = makeStyles<SmtpFormPageStylesParams>()((
           boxShadow: 'none !important',
         },
       '& input:disabled, & select:disabled': {
-        backgroundColor: `${alpha(formInputBg, OPACITY.DISABLED)} !important`,
+        backgroundColor: `${formInputBg} !important`,
         border: `1px solid ${inputBorderColor} !important`,
         color: `${themeColors.fontColor} !important`,
-        opacity: OPACITY.DISABLED,
+        WebkitTextFillColor: `${themeColors.fontColor} !important`,
+        opacity: `${OPACITY.FULL} !important`,
         cursor: 'not-allowed',
       },
       '& input::placeholder': {

--- a/admin-ui/plugins/smtp/components/styles/SmtpFormPage.style.ts
+++ b/admin-ui/plugins/smtp/components/styles/SmtpFormPage.style.ts
@@ -1,7 +1,13 @@
 import { makeStyles } from 'tss-react/mui'
 import { alpha } from '@mui/material/styles'
 import type { Theme } from '@mui/material/styles'
-import { SPACING, BORDER_RADIUS, OPACITY } from '@/constants'
+import {
+  SPACING,
+  BORDER_RADIUS,
+  OPACITY,
+  MOBILE_MEDIA_QUERY,
+  createMobilePageTitleStyle,
+} from '@/constants'
 import { fontFamily, fontWeights, fontSizes, lineHeights } from '@/styles/fonts'
 import { getCardBorderStyle } from '@/styles/cardBorderStyles'
 import type { ThemeConfig } from '@/context/theme/config'
@@ -73,6 +79,7 @@ export const useStyles = makeStyles<SmtpFormPageStylesParams>()((
     (isDark ? customColors.darkBorder : customColors.borderInput)
 
   return {
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     formCard: {
       backgroundColor: cardBg,
       ...cardBorderStyle,
@@ -97,6 +104,11 @@ export const useStyles = makeStyles<SmtpFormPageStylesParams>()((
       flexDirection: 'column',
       gap: 0,
       width: '100%',
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& input, & select, & textarea, & .custom-select, & .form-control, & .react-toggle': {
+          pointerEvents: 'none' as const,
+        },
+      },
     },
     fieldsGrid: {
       display: 'grid',
@@ -108,6 +120,9 @@ export const useStyles = makeStyles<SmtpFormPageStylesParams>()((
       minWidth: 0,
       [theme.breakpoints.down('md')]: {
         gridTemplateColumns: '1fr',
+      },
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        rowGap: SPACING.SECTION_GAP,
       },
     },
     fieldItem: {
@@ -123,6 +138,11 @@ export const useStyles = makeStyles<SmtpFormPageStylesParams>()((
       '& [data-field-error]': {
         position: 'absolute',
         fontSize: `${fontSizes.sm} !important`,
+      },
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& .form-group [class*="col"]': {
+          paddingBottom: 0,
+        },
       },
     },
     fieldItemRelative: {

--- a/admin-ui/plugins/user-claims/components/UserClaimsAddPage.tsx
+++ b/admin-ui/plugins/user-claims/components/UserClaimsAddPage.tsx
@@ -5,6 +5,7 @@ import getThemeColor from '@/context/theme/config'
 import { THEME_DARK } from '@/context/theme/constants'
 import { GluuPageContent } from '@/components'
 import GluuViewWrapper from 'Routes/Apps/Gluu/GluuViewWrapper'
+import GluuText from 'Routes/Apps/Gluu/GluuText'
 import GluuLoader from 'Routes/Apps/Gluu/GluuLoader'
 import { usePermission } from '@/cedarling/hooks/usePermission'
 import { ADMIN_UI_RESOURCES } from '@/cedarling/utility'
@@ -71,6 +72,9 @@ const UserClaimsAddPage = (): JSX.Element => {
     <GluuPageContent>
       <GluuViewWrapper canShow={canWrite}>
         <GluuLoader blocking={createMutation.isPending}>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {t('fields.add_attribute', { defaultValue: 'Add User Claim' })}
+          </GluuText>
           <div className={classes.formCard}>
             <div className={classes.content}>
               <UserClaimsForm item={defaultAttribute as AttributeItem} customOnSubmit={onSubmit} />

--- a/admin-ui/plugins/user-claims/components/UserClaimsEditPage.tsx
+++ b/admin-ui/plugins/user-claims/components/UserClaimsEditPage.tsx
@@ -107,6 +107,9 @@ const UserClaimsEditPage = (): JSX.Element => {
     <GluuPageContent>
       <GluuViewWrapper canShow={canRead}>
         <GluuLoader blocking={isBlocking}>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {t('titles.edit_attribute', { defaultValue: 'Edit User Claim' })}
+          </GluuText>
           <div className={classes.formCard}>
             <div className={classes.content}>
               <UserClaimsForm

--- a/admin-ui/plugins/user-claims/components/UserClaimsEditPage.tsx
+++ b/admin-ui/plugins/user-claims/components/UserClaimsEditPage.tsx
@@ -40,7 +40,9 @@ const UserClaimsEditPage = (): JSX.Element => {
 
   const { canRead } = usePermission(attributeResourceId)
 
-  SetTitle(t('titles.edit_attribute', { defaultValue: 'Edit User Claim' }))
+  const pageTitle = t('titles.edit_attribute', { defaultValue: 'Edit User Claim' })
+
+  SetTitle(pageTitle)
 
   const inum = gid || ''
 
@@ -89,6 +91,9 @@ const UserClaimsEditPage = (): JSX.Element => {
     return (
       <GluuPageContent>
         <GluuViewWrapper canShow={canRead}>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {pageTitle}
+          </GluuText>
           <div className={classes.formCard}>
             <div className={classes.content}>
               <Alert severity="error">
@@ -108,7 +113,7 @@ const UserClaimsEditPage = (): JSX.Element => {
       <GluuViewWrapper canShow={canRead}>
         <GluuLoader blocking={isBlocking}>
           <GluuText variant="h1" className={classes.mobilePageTitle}>
-            {t('titles.edit_attribute', { defaultValue: 'Edit User Claim' })}
+            {pageTitle}
           </GluuText>
           <div className={classes.formCard}>
             <div className={classes.content}>

--- a/admin-ui/plugins/user-claims/components/UserClaimsForm.tsx
+++ b/admin-ui/plugins/user-claims/components/UserClaimsForm.tsx
@@ -80,7 +80,9 @@ const UserClaimsForm = memo(function UserClaimsForm(props: AttributeFormProps) {
 
   const validationSchema = useAttributeValidationSchema(validation)
 
-  const isViewMode = useMemo(() => hideButtons?.save === true, [hideButtons])
+  // Mobile is a view-only layout, so treat it as view mode for every control
+  // and for submission, not just for action visibility.
+  const isViewMode = useMemo(() => hideButtons?.save === true || isMobile, [hideButtons, isMobile])
 
   const toggleModal = useCallback(() => {
     setModal((prev) => !prev)
@@ -103,6 +105,7 @@ const UserClaimsForm = memo(function UserClaimsForm(props: AttributeFormProps) {
 
   const submitForm = useCallback(
     (userMessage: string, formikValues: AttributeFormValues): void => {
+      if (isViewMode) return
       handleAttributeSubmit({
         values: formikValues,
         item,
@@ -111,7 +114,7 @@ const UserClaimsForm = memo(function UserClaimsForm(props: AttributeFormProps) {
         validationEnabled: validation,
       })
     },
-    [item, customOnSubmit, validation],
+    [item, customOnSubmit, validation, isViewMode],
   )
 
   // Uses navigateBack with explicit fallback to attributes list (conforms to global navigation policy)
@@ -142,6 +145,7 @@ const UserClaimsForm = memo(function UserClaimsForm(props: AttributeFormProps) {
       validateOnChange={true}
       validateOnBlur={true}
       onSubmit={(values) => {
+        if (isViewMode) return
         if (!isCreateMode) {
           const modified = computeModifiedFields(initialValues, values)
           setCommitOperations(
@@ -507,10 +511,10 @@ const UserClaimsForm = memo(function UserClaimsForm(props: AttributeFormProps) {
               <GluuThemeFormFooter
                 showBack={!hideButtons?.back}
                 onBack={handleBack}
-                showCancel={!hideButtons?.save && !isMobile}
+                showCancel={!isViewMode}
                 onCancel={() => handleCancel(formik)}
                 disableCancel={!formHasChanged}
-                showApply={!hideButtons?.save && !isMobile}
+                showApply={!isViewMode}
                 applyButtonType="submit"
                 disableApply={!canApply}
                 isLoading={false}

--- a/admin-ui/plugins/user-claims/components/UserClaimsForm.tsx
+++ b/admin-ui/plugins/user-claims/components/UserClaimsForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useCallback, memo } from 'react'
+import useMediaQuery from '@mui/material/useMediaQuery'
 import { Formik, FormikProps } from 'formik'
 import { Form } from 'Components'
 import type { AutocompleteOption } from 'Routes/Apps/Gluu/types/GluuAutocomplete.types'
@@ -15,7 +16,7 @@ import { HelpOutline } from '@/components/icons'
 import { ATTRIBUTE } from 'Utils/ApiResources'
 import { useTranslation } from 'react-i18next'
 import GluuCommitDialog from 'Routes/Apps/Gluu/GluuCommitDialog'
-import { adminUiFeatures } from '@/constants'
+import { adminUiFeatures, MOBILE_MEDIA_QUERY } from '@/constants'
 import { useTheme } from 'Context/theme/themeContext'
 import getThemeColor from 'Context/theme/config'
 import { DEFAULT_THEME, THEME_DARK } from '@/context/theme/constants'
@@ -44,6 +45,7 @@ const UserClaimsForm = memo(function UserClaimsForm(props: AttributeFormProps) {
   const { item, customOnSubmit, hideButtons } = props
   const { t } = useTranslation()
   const { navigateBack } = useAppNavigation()
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
   const [modal, setModal] = useState<boolean>(false)
   const [commitOperations, setCommitOperations] = useState<GluuCommitDialogOperation[]>([])
 
@@ -505,10 +507,10 @@ const UserClaimsForm = memo(function UserClaimsForm(props: AttributeFormProps) {
               <GluuThemeFormFooter
                 showBack={!hideButtons?.back}
                 onBack={handleBack}
-                showCancel={!hideButtons?.save}
+                showCancel={!hideButtons?.save && !isMobile}
                 onCancel={() => handleCancel(formik)}
                 disableCancel={!formHasChanged}
-                showApply={!hideButtons?.save}
+                showApply={!hideButtons?.save && !isMobile}
                 applyButtonType="submit"
                 disableApply={!canApply}
                 isLoading={false}

--- a/admin-ui/plugins/user-claims/components/UserClaimsListPage.tsx
+++ b/admin-ui/plugins/user-claims/components/UserClaimsListPage.tsx
@@ -1,5 +1,7 @@
 import React, { useState, use, useCallback, useMemo, memo } from 'react'
+import useMediaQuery from '@mui/material/useMediaQuery'
 import { Add, DeleteOutlined, Edit, VisibilityOutlined } from '@/components/icons'
+import { MOBILE_MEDIA_QUERY } from '@/constants'
 import { useAppNavigation, ROUTES } from '@/helpers/navigation'
 import { GluuBadge } from '@/components/GluuBadge'
 import { GluuDetailGrid, type GluuDetailGridField } from '@/components/GluuDetailGrid'
@@ -7,6 +9,7 @@ import { GluuTable, COLUMN_WIDTHS } from '@/components/GluuTable'
 import { GluuSearchToolbar } from '@/components/GluuSearchToolbar'
 import GluuLoader from 'Routes/Apps/Gluu/GluuLoader'
 import GluuViewWrapper from 'Routes/Apps/Gluu/GluuViewWrapper'
+import GluuText from 'Routes/Apps/Gluu/GluuText'
 import GluuCommitDialog from 'Routes/Apps/Gluu/GluuCommitDialog'
 import { useTranslation } from 'react-i18next'
 import { ThemeContext } from 'Context/theme/themeContext'
@@ -42,6 +45,7 @@ const UserClaimsListPage: React.FC = () => {
   const { navigateToRoute } = useAppNavigation()
 
   const { canRead, canWrite, canDelete } = usePermission(attributeResourceId)
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
 
   const theme = use(ThemeContext)
   const { themeColors, isDarkTheme } = useMemo(() => {
@@ -304,20 +308,22 @@ const UserClaimsListPage: React.FC = () => {
       onClick: (row: JansAttribute) => void
     }> = []
 
-    if (canWrite) {
-      list.push({
-        icon: <Edit className={classes.editIcon} />,
-        tooltip: t('tooltips.edit_attribute'),
-        id: 'editAttribute',
-        onClick: handleEdit,
-      })
-    }
     if (canRead) {
       list.push({
         icon: <VisibilityOutlined className={classes.viewIcon} />,
         tooltip: t('tooltips.view_attribute'),
         id: 'viewAttribute',
         onClick: handleView,
+      })
+    }
+    if (isMobile) return list
+
+    if (canWrite) {
+      list.unshift({
+        icon: <Edit className={classes.editIcon} />,
+        tooltip: t('tooltips.edit_attribute'),
+        id: 'editAttribute',
+        onClick: handleEdit,
       })
     }
     if (canDelete) {
@@ -329,7 +335,17 @@ const UserClaimsListPage: React.FC = () => {
       })
     }
     return list
-  }, [canWrite, canRead, canDelete, t, handleEdit, handleView, handleDeleteClick, classes])
+  }, [
+    canWrite,
+    canRead,
+    canDelete,
+    isMobile,
+    t,
+    handleEdit,
+    handleView,
+    handleDeleteClick,
+    classes,
+  ])
 
   const pagination: PaginationConfig = useMemo(
     () => ({
@@ -430,6 +446,9 @@ const UserClaimsListPage: React.FC = () => {
     <GluuLoader blocking={loading}>
       <div className={classes.page}>
         <GluuViewWrapper canShow={canRead}>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {t('titles.all_user_claims')}
+          </GluuText>
           <div className={classes.searchCard}>
             <div className={classes.searchCardContent}>
               <GluuSearchToolbar

--- a/admin-ui/plugins/user-claims/components/UserClaimsListPage.tsx
+++ b/admin-ui/plugins/user-claims/components/UserClaimsListPage.tsx
@@ -463,7 +463,7 @@ const UserClaimsListPage: React.FC = () => {
                 filters={filters}
                 onRefresh={canRead ? handleRefresh : undefined}
                 refreshLoading={isFetching}
-                primaryAction={primaryAction}
+                primaryAction={isMobile ? undefined : primaryAction}
                 actionsLabel={`${t('fields.actions')}:`}
                 disabled={loading}
                 className={classes.searchToolbar}

--- a/admin-ui/plugins/user-claims/components/UserClaimsListPage.tsx
+++ b/admin-ui/plugins/user-claims/components/UserClaimsListPage.tsx
@@ -75,6 +75,7 @@ const UserClaimsListPage: React.FC = () => {
   const {
     data: attributesData,
     isLoading,
+    isFetching,
     isError,
     error,
   } = useAttributes({
@@ -237,6 +238,7 @@ const UserClaimsListPage: React.FC = () => {
         options: statusOptions,
         onChange: handleStatusChange,
         width: 140,
+        defaultValue: 'all',
       },
       {
         key: 'sortBy',
@@ -245,6 +247,7 @@ const UserClaimsListPage: React.FC = () => {
         options: sortByOptions,
         onChange: handleSortByChange,
         width: 180,
+        defaultValue: 'none',
       },
     ],
     [t, status, statusOptions, sortBy, sortByOptions, handleStatusChange, handleSortByChange],
@@ -438,8 +441,8 @@ const UserClaimsListPage: React.FC = () => {
   )
 
   const loading = useMemo(
-    () => isLoading || deleteAttributeMutation.isPending,
-    [isLoading, deleteAttributeMutation.isPending],
+    () => isFetching || deleteAttributeMutation.isPending,
+    [isFetching, deleteAttributeMutation.isPending],
   )
 
   return (

--- a/admin-ui/plugins/user-claims/components/UserClaimsListPage.tsx
+++ b/admin-ui/plugins/user-claims/components/UserClaimsListPage.tsx
@@ -74,7 +74,6 @@ const UserClaimsListPage: React.FC = () => {
 
   const {
     data: attributesData,
-    isLoading,
     isFetching,
     isError,
     error,
@@ -463,9 +462,11 @@ const UserClaimsListPage: React.FC = () => {
                 onSearchSubmit={handleSearchSubmit}
                 filters={filters}
                 onRefresh={canRead ? handleRefresh : undefined}
-                refreshLoading={isLoading}
+                refreshLoading={isFetching}
                 primaryAction={primaryAction}
+                actionsLabel={`${t('fields.actions')}:`}
                 disabled={loading}
+                className={classes.searchToolbar}
               />
             </div>
           </div>

--- a/admin-ui/plugins/user-claims/components/UserClaimsViewPage.tsx
+++ b/admin-ui/plugins/user-claims/components/UserClaimsViewPage.tsx
@@ -83,6 +83,9 @@ const UserClaimsViewPage = (): JSX.Element => {
     <GluuPageContent>
       <GluuViewWrapper canShow={canRead}>
         <GluuLoader blocking={isLoading}>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {t('titles.view_attribute', { defaultValue: 'View User Claim' })}
+          </GluuText>
           <div className={classes.formCard}>
             <div className={classes.content}>
               <UserClaimsForm

--- a/admin-ui/plugins/user-claims/components/UserClaimsViewPage.tsx
+++ b/admin-ui/plugins/user-claims/components/UserClaimsViewPage.tsx
@@ -40,7 +40,9 @@ const UserClaimsViewPage = (): JSX.Element => {
 
   const { canRead } = usePermission(attributeResourceId)
 
-  SetTitle(t('titles.view_attribute', { defaultValue: 'View User Claim' }))
+  const pageTitle = t('titles.view_attribute', { defaultValue: 'View User Claim' })
+
+  SetTitle(pageTitle)
 
   const inum = gid || ''
 
@@ -65,6 +67,9 @@ const UserClaimsViewPage = (): JSX.Element => {
     return (
       <GluuPageContent>
         <GluuViewWrapper canShow={canRead}>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {pageTitle}
+          </GluuText>
           <div className={classes.formCard}>
             <div className={classes.content}>
               <Alert severity="error">
@@ -84,7 +89,7 @@ const UserClaimsViewPage = (): JSX.Element => {
       <GluuViewWrapper canShow={canRead}>
         <GluuLoader blocking={isLoading}>
           <GluuText variant="h1" className={classes.mobilePageTitle}>
-            {t('titles.view_attribute', { defaultValue: 'View User Claim' })}
+            {pageTitle}
           </GluuText>
           <div className={classes.formCard}>
             <div className={classes.content}>

--- a/admin-ui/plugins/user-claims/components/styles/UserClaimsFormPage.style.ts
+++ b/admin-ui/plugins/user-claims/components/styles/UserClaimsFormPage.style.ts
@@ -1,4 +1,5 @@
 import { makeStyles } from 'tss-react/mui'
+import type { Theme } from '@mui/material/styles'
 import {
   SPACING,
   BORDER_RADIUS,
@@ -22,7 +23,7 @@ const INPUT_PADDING_HORIZONTAL = 21
 const SELECT_ARROW_SPACE = 44
 const ERROR_SPACE = 20
 export const useStyles = makeStyles<AttributeFormPageStylesParams>()((
-  _,
+  theme: Theme,
   { isDark, themeColors },
 ) => {
   const cardBorderStyle = getCardBorderStyle({ isDark })
@@ -62,8 +63,12 @@ export const useStyles = makeStyles<AttributeFormPageStylesParams>()((
       columnGap: SPACING.SECTION_GAP,
       rowGap: SPACING.CARD_CONTENT_GAP,
       width: '100%',
-      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+      // Collapse to one column on tablet as well, so fields are not squeezed
+      // into ~370px each in portrait. Matches the Webhook form.
+      [theme.breakpoints.down('md')]: {
         gridTemplateColumns: '1fr',
+      },
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
         rowGap: SPACING.SECTION_GAP,
       },
     },

--- a/admin-ui/plugins/user-claims/components/styles/UserClaimsFormPage.style.ts
+++ b/admin-ui/plugins/user-claims/components/styles/UserClaimsFormPage.style.ts
@@ -1,5 +1,11 @@
 import { makeStyles } from 'tss-react/mui'
-import { SPACING, BORDER_RADIUS, OPACITY } from '@/constants'
+import {
+  SPACING,
+  BORDER_RADIUS,
+  OPACITY,
+  MOBILE_MEDIA_QUERY,
+  createMobilePageTitleStyle,
+} from '@/constants'
 import { fontFamily, fontWeights, fontSizes, lineHeights } from '@/styles/fonts'
 import { getCardBorderStyle } from '@/styles/cardBorderStyles'
 import { createFormGroupOverrides } from '@/styles/formStyles'
@@ -25,6 +31,7 @@ export const useStyles = makeStyles<AttributeFormPageStylesParams>()((
   const formInputBg = themeColors.settings?.formInputBackground ?? themeColors.inputBackground
 
   return {
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     formCard: {
       backgroundColor: cardBg,
       ...cardBorderStyle,
@@ -42,6 +49,12 @@ export const useStyles = makeStyles<AttributeFormPageStylesParams>()((
       boxSizing: 'border-box' as const,
       display: 'flex',
       flexDirection: 'column' as const,
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& input, & select, & textarea, & .custom-select, & .form-control, & .react-toggle, & [role="combobox"]':
+          {
+            pointerEvents: 'none' as const,
+          },
+      },
     },
     formGrid: {
       display: 'grid',
@@ -49,12 +62,19 @@ export const useStyles = makeStyles<AttributeFormPageStylesParams>()((
       columnGap: SPACING.SECTION_GAP,
       rowGap: SPACING.CARD_CONTENT_GAP,
       width: '100%',
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        gridTemplateColumns: '1fr',
+        rowGap: SPACING.SECTION_GAP,
+      },
     },
     formGridFullSpan: {
       gridColumn: '1 / -1',
     },
     autocompleteField: {
       marginBottom: ERROR_SPACE,
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        marginBottom: 0,
+      },
     },
     outerLabel: {
       'display': 'flex',
@@ -106,6 +126,11 @@ export const useStyles = makeStyles<AttributeFormPageStylesParams>()((
         opacity: OPACITY.DISABLED,
         cursor: 'not-allowed',
       },
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& .form-group [class*="col"]:has([data-field-error])': {
+          paddingBottom: 0,
+        },
+      },
     },
     inumFullWidth: {
       'gridColumn': '1 / -1',
@@ -113,6 +138,11 @@ export const useStyles = makeStyles<AttributeFormPageStylesParams>()((
         paddingBottom: 12,
         paddingLeft: 0,
         paddingRight: 0,
+      },
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& .form-group [class*="col"]': {
+          paddingBottom: 0,
+        },
       },
       '& input, & input:disabled': {
         backgroundColor: 'var(--theme-input-bg) !important',
@@ -126,6 +156,9 @@ export const useStyles = makeStyles<AttributeFormPageStylesParams>()((
       'minWidth': 0,
       'boxSizing': 'border-box' as const,
       'paddingBottom': 18,
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        paddingBottom: 0,
+      },
       ...createFormGroupOverrides(),
       '& .form-group > label': {
         ...createFormGroupOverrides()['& .form-group > label'],

--- a/admin-ui/plugins/user-claims/components/styles/UserClaimsFormPage.style.ts
+++ b/admin-ui/plugins/user-claims/components/styles/UserClaimsFormPage.style.ts
@@ -112,7 +112,7 @@ export const useStyles = makeStyles<AttributeFormPageStylesParams>()((
         paddingRight: 0,
       },
       '& .form-group [class*="col"]:has([data-field-error])': {
-        paddingBottom: 20,
+        paddingBottom: ERROR_SPACE,
       },
       '& [data-field-error]': {
         position: 'absolute',
@@ -127,8 +127,10 @@ export const useStyles = makeStyles<AttributeFormPageStylesParams>()((
         cursor: 'not-allowed',
       },
       [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        // Errors are absolutely positioned and reserve no height, so the base
+        // bottom padding must stay to keep them clear of the next field.
         '& .form-group [class*="col"]:has([data-field-error])': {
-          paddingBottom: 0,
+          paddingBottom: ERROR_SPACE,
         },
       },
     },

--- a/admin-ui/plugins/user-claims/components/styles/UserClaimsFormPage.style.ts
+++ b/admin-ui/plugins/user-claims/components/styles/UserClaimsFormPage.style.ts
@@ -219,7 +219,8 @@ export const useStyles = makeStyles<AttributeFormPageStylesParams>()((
           backgroundColor: `${formInputBg} !important`,
           border: `1px solid ${inputBorderColor} !important`,
           color: `${themeColors.fontColor} !important`,
-          opacity: OPACITY.DISABLED,
+          WebkitTextFillColor: 'var(--theme-input-color) !important',
+          opacity: `${OPACITY.FULL} !important`,
           cursor: 'not-allowed',
         },
       '& input:not([type="checkbox"]).is-valid, & input:not([type="checkbox"]).is-invalid, & select.is-valid, & select.is-invalid, & textarea.is-valid, & textarea.is-invalid':

--- a/admin-ui/plugins/user-claims/components/styles/UserClaimsListPage.style.ts
+++ b/admin-ui/plugins/user-claims/components/styles/UserClaimsListPage.style.ts
@@ -45,6 +45,49 @@ const useStylesBase = makeStyles<{ isDark: boolean; themeColors: ThemeConfig }>(
       isolation: 'isolate',
       pointerEvents: 'auto',
     },
+    // This page has two filters (Status + Sort By) where most list pages have
+    // one, so below 1200px the shared toolbar's fixed control width leaves the
+    // action buttons no room and clips the last one. Scoped to this page only.
+    searchToolbar: {
+      // The shared toolbar is fluid, but it assumes one filter. This page has
+      // two, so filters + actions are three items competing for one row and the
+      // buttons get squeezed into an ellipsis. Give the actions their own row
+      // and keep everything else stretching, matching the Webhook behaviour.
+      // Selectors are doubled (&&) because the shared rules have equal
+      // specificity and would otherwise win on injection order.
+      '@media (max-width: 1200px)': {
+        // Filters share their row evenly, as the shared toolbar intends.
+        '&& > div:has(> div > select)': {
+          flex: '1 1 0',
+          minWidth: 0,
+        },
+        // The filter definitions set a fixed pixel width, which lands as an
+        // inline style on the select wrapper and stops it stretching. Release
+        // it here so the filters fill their row like the buttons below.
+        '&& > div:has(> div > select) > div': {
+          width: '100% !important',
+        },
+        '&& > div:has(> div > button)': {
+          flex: '1 1 100%',
+          minWidth: 0,
+        },
+        // Stretch the buttons across that row so no dead space is left beside
+        // them; with a full row they never need to truncate.
+        '&& > div:has(> div > button) > div': {
+          width: '100%',
+        },
+        '&& button': {
+          flex: '1 1 0',
+          minWidth: 0,
+          whiteSpace: 'nowrap',
+        },
+        '&& button > span': {
+          minWidth: 0,
+          overflow: 'visible',
+          textOverflow: 'clip',
+        },
+      },
+    },
     tableCard: {
       'width': '100%',
       'maxWidth': '100%',

--- a/admin-ui/plugins/user-claims/components/styles/UserClaimsListPage.style.ts
+++ b/admin-ui/plugins/user-claims/components/styles/UserClaimsListPage.style.ts
@@ -2,7 +2,13 @@ import { useMemo } from 'react'
 import { makeStyles } from 'tss-react/mui'
 import customColors from '@/customColors'
 import type { ThemeConfig } from '@/context/theme/config'
-import { BORDER_RADIUS, ICON_SIZE, SPACING } from '@/constants'
+import {
+  BORDER_RADIUS,
+  ICON_SIZE,
+  SPACING,
+  MOBILE_MEDIA_QUERY,
+  createMobilePageTitleStyle,
+} from '@/constants'
 import { getCardBorderStyle } from '@/styles/cardBorderStyles'
 import { createSearchCardStyle } from '@/styles/searchCardStyle'
 import { fontFamily, fontWeights, fontSizes } from '@/styles/fonts'
@@ -20,6 +26,7 @@ const useStylesBase = makeStyles<{ isDark: boolean; themeColors: ThemeConfig }>(
   })
   const cardBg = themeColors.settings?.cardBackground ?? themeColors.card.background
   return {
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     page: { fontFamily, paddingTop: SPACING.PAGE },
     cellText: {
       color: themeColors.fontColor,
@@ -52,6 +59,9 @@ const useStylesBase = makeStyles<{ isDark: boolean; themeColors: ThemeConfig }>(
       'boxSizing': 'border-box',
       '& table td': { verticalAlign: 'middle' },
       '& table th': { verticalAlign: 'middle' },
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& table td': { verticalAlign: 'top' },
+      },
     },
     expandedGrid: {
       display: 'grid',

--- a/admin-ui/plugins/user-claims/hooks/useAttributeApi.ts
+++ b/admin-ui/plugins/user-claims/hooks/useAttributeApi.ts
@@ -31,7 +31,7 @@ export const useAttributes = (params?: GetAttributesParams) => {
   return useGetAttributes<GetAttributesQueryResult, Error>(params, {
     query: {
       enabled: hasSession === true,
-      staleTime: ATTRIBUTE_CACHE_CONFIG.STALE_TIME,
+      staleTime: 0,
       gcTime: ATTRIBUTE_CACHE_CONFIG.GC_TIME,
       retry: false,
     },


### PR DESCRIPTION
### feat(admin-ui): responsive mobile view-only layout for Public Keys, Logging, SMTP, SCIM, and User Claims (#2933)

#### Summary
This PR continues the Admin UI mobile redesign by implementing responsive, view-only layouts for the Public Keys, Logging, SMTP, SCIM, and User Claims modules.

On mobile viewports (≤767px), these pages are optimized for viewing rather than editing. Form controls become non-interactive, write actions are hidden, mobile page titles are added, and spacing is standardized to provide a consistent mobile experience. Desktop and tablet layouts remain unchanged.

---

#### Fix Summary
- Implemented responsive mobile layouts for:
  - Public Keys
  - Logging
  - SMTP
  - SCIM
  - User Claims
- Added mobile page titles across all affected modules
- Converted forms to view-only mode on mobile
- Disabled inputs, selects, toggles, and other interactive controls where editing is not supported
- Hid write actions including Add, Edit, Delete, Apply, Cancel, and Test where applicable
- Preserved Back navigation on mobile forms
- Standardized spacing, padding, and field alignment across all responsive pages
- Improved User Claims mobile list by:
  - displaying only the View action
  - improving wrapped table cell alignment
  - adding responsive page titles for Add, Edit, and View pages
- Improved Public Keys mobile experience by:
  - adding a mobile page title
  - disabling textarea resize on mobile
- Updated `GluuSelectRow` so the dropdown indicator reflects disabled and read-only states consistently
- Preserved existing desktop and tablet layouts and functionality

---

#### Verification

```bash
npm run check:all
npm run test:all
```

passes successfully.

- Verified responsive rendering for Public Keys, Logging, SMTP, SCIM, and User Claims
- Verified all affected forms render in view-only mode on mobile
- Verified write actions are hidden on supported mobile viewports
- Verified mobile page titles display correctly
- Verified User Claims list and form behavior matches the responsive design
- Verified `GluuSelectRow` disabled/read-only styling behaves consistently
- Verified module test suites pass successfully
- Verified desktop and tablet layouts remain unchanged

---

#### 🔗 Ticket

Closes: #2933

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile-only page headings across administration screens and improved filter-sheet behavior (Cancel restores defaults; Apply commits drafts) with smoother mobile handling.
  * Introduced consistent mobile view-only modes that disable editing, hide commit dialog actions where appropriate, and limit list row actions to viewing.

* **Bug Fixes**
  * Improved loading indicators during background refreshes and deletions, and refined selected filter-pill and disabled control appearance.
  * Fixed mobile form spacing, error placement, and table alignment.

* **Style**
  * Refined responsive navbar title breakpoints/padding and standardized disabled typography and form control styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->