### PR TITLE
feat(admin-ui): implement responsive mobile layout for SSA, Services Module Cache, and Persistence pages (#2935)

### DIFF
--- a/admin-ui/plugins/admin/components/Assets/JansAssetFormPage.style.ts
+++ b/admin-ui/plugins/admin/components/Assets/JansAssetFormPage.style.ts
@@ -240,7 +240,7 @@ export const useStyles = makeStyles<AssetFormPageStylesParams>()((
           border: `1px solid ${inputBorderColor} !important`,
           color: `${themeColors.fontColor} !important`,
           WebkitTextFillColor: `${themeColors.fontColor} !important`,
-          opacity: `${OPACITY.DISABLED} !important`,
+          opacity: `${OPACITY.FULL} !important`,
           cursor: 'not-allowed',
         },
       '& input:not(.MuiInputBase-input)::placeholder': {

--- a/admin-ui/plugins/admin/components/Assets/JansAssetListPage.tsx
+++ b/admin-ui/plugins/admin/components/Assets/JansAssetListPage.tsx
@@ -328,7 +328,7 @@ const JansAssetListPage: React.FC = () => {
                 searchOnType
                 onSearch={setPattern}
                 onSearchSubmit={handleSearchSubmit}
-                onRefresh={canReadAssets ? handleRefresh : undefined}
+                onRefresh={!isMobile && canReadAssets ? handleRefresh : undefined}
                 primaryAction={isMobile ? undefined : primaryAction}
                 actionsLabel={`${t(T_KEYS.FIELD_ACTIONS)}:`}
                 disabled={loading}

--- a/admin-ui/plugins/admin/components/Assets/JansAssetListPage.tsx
+++ b/admin-ui/plugins/admin/components/Assets/JansAssetListPage.tsx
@@ -70,6 +70,15 @@ const JansAssetListPage: React.FC = () => {
   const [deleteData, setDeleteData] = useState<Document | null>(null)
   const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
 
+  // Delete is not offered on mobile, so resizing into it discards any pending
+  // confirmation rather than leaving the dialog actionable.
+  useEffect(() => {
+    if (isMobile) {
+      setModal(false)
+      setDeleteData(null)
+    }
+  }, [isMobile])
+
   SetTitle(t(T_KEYS.TITLE_ASSETS))
   const pageTitle = usePageTitle()
 

--- a/admin-ui/plugins/auth-server/components/Ssa/components/SsaAddPage.tsx
+++ b/admin-ui/plugins/auth-server/components/Ssa/components/SsaAddPage.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import GluuLoader from 'Routes/Apps/Gluu/GluuLoader'
+import GluuText from 'Routes/Apps/Gluu/GluuText'
 import { GluuPageContent } from '@/components'
 import SetTitle from 'Utils/SetTitle'
 import { useGetProperties } from 'JansConfigApi'
@@ -30,7 +31,8 @@ const SsaAddPage: React.FC = () => {
   const isDark = themeState.theme === THEME_DARK
   const { classes } = useStyles({ isDark, themeColors })
 
-  SetTitle(t('titles.ssa_management'))
+  const pageTitle = t('titles.ssa_management')
+  SetTitle(pageTitle)
 
   const { data: configuration, isLoading } = useGetProperties()
   const customAttributes = useMemo(
@@ -69,6 +71,9 @@ const SsaAddPage: React.FC = () => {
   return (
     <GluuPageContent>
       <div className={classes.page}>
+        <GluuText variant="h1" className={classes.mobilePageTitle} disableThemeColor>
+          {pageTitle}
+        </GluuText>
         <div className={classes.formCard}>
           <GluuLoader blocking={isLoading || isSubmitting}>
             <SsaForm

--- a/admin-ui/plugins/auth-server/components/Ssa/components/SsaListPage.tsx
+++ b/admin-ui/plugins/auth-server/components/Ssa/components/SsaListPage.tsx
@@ -67,6 +67,15 @@ const SsaListPage: React.FC = () => {
   const { limit, setLimit, pageNumber, setPageNumber, onPagingSizeSync } = usePaginationState()
   const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
 
+  // Delete is not offered on mobile, so resizing into it discards any pending
+  // confirmation rather than leaving the dialog actionable.
+  useEffect(() => {
+    if (isMobile) {
+      setModal(false)
+      setDeleteData(null)
+    }
+  }, [isMobile])
+
   const pageTitle = t('titles.ssa_management')
   SetTitle(pageTitle)
 
@@ -98,7 +107,10 @@ const SsaListPage: React.FC = () => {
   const totalItems = filteredRows.length
   const { classes, cx } = useStyles({ isDark, themeColors })
 
-  const toggle = useCallback((): void => setModal((prev) => !prev), [])
+  const toggle = useCallback((): void => {
+    if (isMobile) return
+    setModal((prev) => !prev)
+  }, [isMobile])
 
   const handleRefresh = useCallback((): void => {
     setPattern('')
@@ -149,7 +161,7 @@ const SsaListPage: React.FC = () => {
 
   const submitForm = useCallback(
     async (userMessage: string) => {
-      if (!deleteData) return
+      if (isMobile || !deleteData) return
       try {
         await revokeSsa(deleteData.ssa.jti, userMessage, {
           jti: deleteData.ssa.jti,
@@ -160,7 +172,7 @@ const SsaListPage: React.FC = () => {
         logger.error('Delete SSA failed:', error instanceof Error ? error : String(error))
       }
     },
-    [deleteData, revokeSsa],
+    [deleteData, revokeSsa, isMobile],
   )
 
   const handlePageChange = useCallback((page: number) => setPageNumber(page), [setPageNumber])

--- a/admin-ui/plugins/auth-server/components/Ssa/components/SsaListPage.tsx
+++ b/admin-ui/plugins/auth-server/components/Ssa/components/SsaListPage.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from 'react-i18next'
 import GluuViewWrapper from 'Routes/Apps/Gluu/GluuViewWrapper'
 import GluuCommitDialog from 'Routes/Apps/Gluu/GluuCommitDialog'
 import GluuLoader from 'Routes/Apps/Gluu/GluuLoader'
+import GluuText from 'Routes/Apps/Gluu/GluuText'
+import useMediaQuery from '@mui/material/useMediaQuery'
 import SetTitle from 'Utils/SetTitle'
 import { SSA } from 'Utils/ApiResources'
 import { useTheme } from '@/context/theme/themeContext'
@@ -18,7 +20,7 @@ import { GluuTable, COLUMN_WIDTHS } from '@/components/GluuTable'
 import { GluuSearchToolbar } from '@/components/GluuSearchToolbar'
 import { GluuDetailGrid, type GluuDetailGridField } from '@/components/GluuDetailGrid'
 import type { ColumnDef, PaginationConfig } from '@/components/GluuTable'
-import { BORDER_RADIUS } from '@/constants'
+import { BORDER_RADIUS, MOBILE_MEDIA_QUERY } from '@/constants'
 import { getRowsPerPageOptions, usePaginationState } from '@/utils/pagingUtils'
 import { GluuBadge } from '@/components/GluuBadge'
 import { JsonViewerDialog } from '../../JsonViewer'
@@ -63,8 +65,10 @@ const SsaListPage: React.FC = () => {
   const isDark = selectedTheme === THEME_DARK
 
   const { limit, setLimit, pageNumber, setPageNumber, onPagingSizeSync } = usePaginationState()
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
 
-  SetTitle(t('titles.ssa_management'))
+  const pageTitle = t('titles.ssa_management')
+  SetTitle(pageTitle)
 
   const { data: items = [], isLoading: loading } = useGetAllSsas()
   const downloadSsaJwtMutation = useGetSsaJwt()
@@ -271,6 +275,9 @@ const SsaListPage: React.FC = () => {
       })
     }
 
+    // Mobile is view-only, so the destructive action is not offered there.
+    if (isMobile) return list
+
     if (canDeleteSsa) {
       list.push({
         icon: <DeleteOutlined className={classes.actionIcon} />,
@@ -285,6 +292,7 @@ const SsaListPage: React.FC = () => {
 
     return list
   }, [
+    isMobile,
     canReadSsa,
     canWriteSsa,
     canDeleteSsa,
@@ -427,6 +435,9 @@ const SsaListPage: React.FC = () => {
     <GluuLoader blocking={loading || isDeleting || downloadSsaJwtMutation.isPending}>
       <div className={classes.page}>
         <GluuViewWrapper canShow={canReadSsa}>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {pageTitle}
+          </GluuText>
           <div className={classes.searchCard}>
             <div className={classes.searchCardContent}>
               <GluuSearchToolbar
@@ -435,8 +446,9 @@ const SsaListPage: React.FC = () => {
                 searchValue={pattern}
                 searchOnType
                 onSearch={setPattern}
-                onRefresh={canReadSsa ? handleRefresh : undefined}
-                primaryAction={primaryAction}
+                onRefresh={!isMobile && canReadSsa ? handleRefresh : undefined}
+                primaryAction={isMobile ? undefined : primaryAction}
+                actionsLabel={`${t('fields.actions')}:`}
               />
             </div>
           </div>

--- a/admin-ui/plugins/auth-server/components/Ssa/components/styles/SsaForm.style.ts
+++ b/admin-ui/plugins/auth-server/components/Ssa/components/styles/SsaForm.style.ts
@@ -1,6 +1,6 @@
 import { makeStyles } from 'tss-react/mui'
 import type { ThemeConfig } from '@/context/theme/config'
-import { BORDER_RADIUS, OPACITY, SPACING } from '@/constants'
+import { BORDER_RADIUS, SPACING } from '@/constants'
 import { fontFamily, fontSizes } from '@/styles/fonts'
 import {
   createFormGroupOverrides,
@@ -9,6 +9,7 @@ import {
   createFormInputFocusStyles,
   createFormInputAutofillStyles,
 } from '@/styles/formStyles'
+import { createDisabledInputStyles } from '@/styles/disabledFieldStyles'
 
 type SsaFormStylesParams = {
   isDark: boolean
@@ -56,10 +57,8 @@ export const useStyles = makeStyles<SsaFormStylesParams>()((_, { isDark, themeCo
       '& input:focus, & input:active, & select:focus, & select:active, & textarea:focus, & textarea:active, & .custom-select:focus, & .custom-select:active, & .form-control:focus, & .form-control:active':
         createFormInputFocusStyles(inputColors),
 
-      '& input:disabled, & select:disabled, & textarea:disabled, & .custom-select:disabled': {
-        opacity: OPACITY.DISABLED,
-        cursor: 'not-allowed',
-      },
+      '& input:disabled, & select:disabled, & textarea:disabled, & .custom-select:disabled':
+        createDisabledInputStyles(themeColors.fontColor),
 
       '& input:-webkit-autofill, & input:-webkit-autofill:hover, & input:-webkit-autofill:focus, & input:-webkit-autofill:active':
         createFormInputAutofillStyles(inputColors),
@@ -174,9 +173,14 @@ export const useStyles = makeStyles<SsaFormStylesParams>()((_, { isDark, themeCo
       '& .MuiInputBase-root': {
         backgroundColor: `${inputBg} !important`,
       },
+      // The picker renders its value in section spans rather than an input, so the
+      // solid disabled colour has to be applied there too.
       '& .MuiPickersInputBase-root.Mui-disabled': {
-        opacity: OPACITY.DISABLED,
-        cursor: 'not-allowed',
+        ...createDisabledInputStyles(themeColors.fontColor),
+        '& .MuiPickersInputBase-sectionContent, & .MuiPickersSectionList-sectionContent': {
+          color: `${themeColors.fontColor} !important`,
+          WebkitTextFillColor: `${themeColors.fontColor} !important`,
+        },
       },
       '& .MuiInputLabel-root, & .MuiPickersInputBase-root .MuiInputLabel-root': {
         display: 'none',

--- a/admin-ui/plugins/auth-server/components/Ssa/components/styles/SsaFormPage.style.ts
+++ b/admin-ui/plugins/auth-server/components/Ssa/components/styles/SsaFormPage.style.ts
@@ -1,6 +1,6 @@
 import { makeStyles } from 'tss-react/mui'
 import type { ThemeConfig } from '@/context/theme/config'
-import { BORDER_RADIUS, SPACING } from '@/constants'
+import { BORDER_RADIUS, SPACING, createMobilePageTitleStyle } from '@/constants'
 import { fontFamily } from '@/styles/fonts'
 import { getCardBorderStyle } from '@/styles/cardBorderStyles'
 
@@ -19,6 +19,7 @@ export const useStyles = makeStyles<SsaFormPageStylesParams>()((_, { isDark, the
       fontFamily,
       paddingTop: SPACING.PAGE,
     },
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     formCard: {
       width: '100%',
       backgroundColor: cardBg,

--- a/admin-ui/plugins/auth-server/components/Ssa/components/styles/SsaListPage.style.ts
+++ b/admin-ui/plugins/auth-server/components/Ssa/components/styles/SsaListPage.style.ts
@@ -1,6 +1,12 @@
 import { makeStyles } from 'tss-react/mui'
 import type { ThemeConfig } from '@/context/theme/config'
-import { BORDER_RADIUS, ICON_SIZE, SPACING } from '@/constants'
+import {
+  BORDER_RADIUS,
+  ICON_SIZE,
+  MOBILE_MEDIA_QUERY,
+  SPACING,
+  createMobilePageTitleStyle,
+} from '@/constants'
 import { getCardBorderStyle } from '@/styles/cardBorderStyles'
 import { fontFamily, lineHeights } from '@/styles/fonts'
 import { createSearchCardStyle } from '@/styles/searchCardStyle'
@@ -21,7 +27,12 @@ export const useStyles = makeStyles<SsaListPageStylesParams>()((_, { isDark, the
     page: {
       fontFamily,
       paddingTop: SPACING.PAGE,
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        paddingBottom: `${SPACING.CONTENT_PADDING}px`,
+        boxSizing: 'border-box' as const,
+      },
     },
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     searchCard: createSearchCardStyle({ cardBg, isDark }),
     searchCardContent: {
       position: 'relative',

--- a/admin-ui/plugins/services/components/CachePage.tsx
+++ b/admin-ui/plugins/services/components/CachePage.tsx
@@ -12,7 +12,9 @@ import CacheRedis from './CacheRedis'
 import CacheNative from './CacheNative'
 import CacheMemcached from './CacheMemcached'
 import { useFormik } from 'formik'
+import useMediaQuery from '@mui/material/useMediaQuery'
 import { useTranslation } from 'react-i18next'
+import { MOBILE_MEDIA_QUERY } from '@/constants'
 import { CACHE } from 'Utils/ApiResources'
 import SetTitle from 'Utils/SetTitle'
 import { useTheme } from '@/context/theme/themeContext'
@@ -44,7 +46,7 @@ import {
   CacheConfigurationCacheProviderType,
 } from 'JansConfigApi'
 import { useCacheAudit } from './hooks'
-import type { CacheFormValues, CacheProviderType } from './types'
+import type { CacheFormValues, CacheProviderType, CacheSubComponentBaseProps } from './types'
 import {
   isInMemoryCache,
   isMemcachedCache,
@@ -55,6 +57,19 @@ import {
 } from '../helper'
 import { useStyles } from './styles/CachePage.style'
 import { queryDefaults } from '@/utils/queryUtils'
+
+const PROVIDER_SECTIONS: Record<
+  CacheProviderType,
+  { titleKey: string; Fields: React.FC<CacheSubComponentBaseProps> }
+> = {
+  IN_MEMORY: { titleKey: 'fields.in_memory_configuration', Fields: CacheInMemory },
+  MEMCACHED: { titleKey: 'fields.memcached_configuration', Fields: CacheMemcached },
+  REDIS: { titleKey: 'fields.redis_configuration', Fields: CacheRedis },
+  NATIVE_PERSISTENCE: {
+    titleKey: 'fields.native_persistence_configuration',
+    Fields: CacheNative,
+  },
+}
 
 const CachePage: React.FC = () => {
   const { t } = useTranslation()
@@ -72,6 +87,18 @@ const CachePage: React.FC = () => {
   const [modal, setModal] = useState(false)
 
   const { canRead: canReadCache, canWrite: canWriteCache } = usePermission(ADMIN_UI_RESOURCES.Cache)
+
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
+  // Mobile is a view-only layout, so treat it as read-only for every control
+  // and submission path, not just for action visibility.
+  const isReadOnly = !canWriteCache || isMobile
+
+  // Entering read-only (e.g. resizing to mobile) discards any in-flight commit.
+  useEffect(() => {
+    if (isReadOnly) {
+      setModal(false)
+    }
+  }, [isReadOnly])
 
   const pageTitle = t('fields.cache_configuration')
   SetTitle(pageTitle)
@@ -200,7 +227,7 @@ const CachePage: React.FC = () => {
     initialValues,
     enableReinitialize: true,
     onSubmit: async (values, { resetForm }) => {
-      if (!canWriteCache) return
+      if (isReadOnly) return
 
       try {
         if (isNativePersistenceCache(values)) {
@@ -287,16 +314,13 @@ const CachePage: React.FC = () => {
   })
 
   const toggle = useCallback(() => {
+    if (isReadOnly) return
     setModal((prev) => !prev)
-  }, [])
+  }, [isReadOnly])
 
   const handleCancel = useCallback(() => {
     formik.resetForm()
   }, [formik])
-
-  const handleApply = useCallback(() => {
-    toggle()
-  }, [toggle])
 
   const commitOperations = useMemo(
     () => buildCacheChangedFieldOperations(initialValues, formik.values, t),
@@ -305,12 +329,13 @@ const CachePage: React.FC = () => {
 
   const submitForm = useCallback(
     (_userMessage: string) => {
+      if (isReadOnly) return
       formik.handleSubmit()
     },
-    [formik],
+    [formik, isReadOnly],
   )
 
-  const cacheProviderType = formik.values.cacheProviderType
+  const providerSection = PROVIDER_SECTIONS[formik.values.cacheProviderType]
 
   const renderSectionTitle = (title: string) => (
     <div className={classes.sectionHeader}>
@@ -324,12 +349,15 @@ const CachePage: React.FC = () => {
     <GluuLoader blocking={loading || isMutating}>
       <GluuViewWrapper canShow={canReadCache}>
         <GluuPageContent>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {pageTitle}
+          </GluuText>
           <div className={classes.cacheCard}>
             <div className={`${classes.content} ${classes.formLabels}`}>
               <Form
                 onSubmit={(e) => {
                   e.preventDefault()
-                  handleApply()
+                  toggle()
                 }}
                 className={classes.formSection}
               >
@@ -347,76 +375,37 @@ const CachePage: React.FC = () => {
                       rsize={12}
                       doc_category={CACHE}
                       doc_entry="cacheProviderType"
+                      // Stays interactive on mobile: it only switches which
+                      // provider's settings are shown, and nothing below it can
+                      // be edited or submitted from there anyway.
                       disabled={!canWriteCache}
                       isDark={isDark}
                     />
                   </div>
                 </div>
 
-                {cacheProviderType === 'IN_MEMORY' && (
+                {providerSection && (
                   <div
                     className={`${classes.sectionBox} ${classes.formWithInputs} ${classes.formLabels}`}
                   >
-                    {renderSectionTitle(`${t('fields.in_memory_configuration')}:`)}
-                    <CacheInMemory
+                    {renderSectionTitle(`${t(providerSection.titleKey)}:`)}
+                    <providerSection.Fields
                       formik={formik}
                       classes={classes}
                       isDark={isDark}
-                      disabled={!canWriteCache}
-                    />
-                  </div>
-                )}
-
-                {cacheProviderType === 'MEMCACHED' && (
-                  <div
-                    className={`${classes.sectionBox} ${classes.formWithInputs} ${classes.formLabels}`}
-                  >
-                    {renderSectionTitle(`${t('fields.memcached_configuration')}:`)}
-                    <CacheMemcached
-                      formik={formik}
-                      classes={classes}
-                      isDark={isDark}
-                      disabled={!canWriteCache}
-                    />
-                  </div>
-                )}
-
-                {cacheProviderType === 'REDIS' && (
-                  <div
-                    className={`${classes.sectionBox} ${classes.formWithInputs} ${classes.formLabels}`}
-                  >
-                    {renderSectionTitle(`${t('fields.redis_configuration')}:`)}
-                    <CacheRedis
-                      formik={formik}
-                      classes={classes}
-                      isDark={isDark}
-                      disabled={!canWriteCache}
-                    />
-                  </div>
-                )}
-
-                {cacheProviderType === 'NATIVE_PERSISTENCE' && (
-                  <div
-                    className={`${classes.sectionBox} ${classes.formWithInputs} ${classes.formLabels}`}
-                  >
-                    {renderSectionTitle(`${t('fields.native_persistence_configuration')}:`)}
-                    <CacheNative
-                      formik={formik}
-                      classes={classes}
-                      isDark={isDark}
-                      disabled={!canWriteCache}
+                      disabled={isReadOnly}
                     />
                   </div>
                 )}
 
                 <GluuThemeFormFooter
                   showBack
-                  showCancel={canWriteCache}
+                  showCancel={!isReadOnly}
                   onCancel={handleCancel}
                   disableCancel={!formik.dirty}
-                  showApply={canWriteCache}
-                  onApply={handleApply}
-                  disableApply={!formik.isValid || !formik.dirty || !canWriteCache}
+                  showApply={!isReadOnly}
+                  onApply={toggle}
+                  disableApply={!formik.isValid || !formik.dirty}
                   applyButtonType="button"
                 />
               </Form>

--- a/admin-ui/plugins/services/components/PersistenceDetail.tsx
+++ b/admin-ui/plugins/services/components/PersistenceDetail.tsx
@@ -6,6 +6,7 @@ import SetTitle from 'Utils/SetTitle'
 import GluuInputRow from 'Routes/Apps/Gluu/GluuInputRow'
 import GluuLoader from 'Routes/Apps/Gluu/GluuLoader'
 import GluuViewWrapper from 'Routes/Apps/Gluu/GluuViewWrapper'
+import GluuText from 'Routes/Apps/Gluu/GluuText'
 import GluuThemeFormFooter from '@/routes/Apps/Gluu/GluuThemeFormFooter'
 import { GluuPageContent } from 'Components'
 import { usePermission } from '@/cedarling/hooks/usePermission'
@@ -25,7 +26,8 @@ const PersistenceDetail = () => {
 
   const { canRead: canReadPersistence } = usePermission(ADMIN_UI_RESOURCES.Persistence)
 
-  SetTitle(t('menus.persistence'))
+  const pageTitle = t('menus.persistence')
+  SetTitle(pageTitle)
 
   const { data: persistenceData, isLoading } = useGetPropertiesPersistence({
     query: { staleTime: queryDefaults.queryOptions.staleTime, enabled: canReadPersistence },
@@ -37,6 +39,9 @@ const PersistenceDetail = () => {
     <GluuLoader blocking={isLoading}>
       <GluuViewWrapper canShow={canReadPersistence}>
         <GluuPageContent>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {pageTitle}
+          </GluuText>
           <div className={classes.persistenceCard}>
             <div className={`${classes.content} ${classes.formLabels} ${classes.formWithInputs}`}>
               <div className={classes.fieldsGrid}>

--- a/admin-ui/plugins/services/components/styles/CachePage.style.ts
+++ b/admin-ui/plugins/services/components/styles/CachePage.style.ts
@@ -1,7 +1,13 @@
 import { makeStyles } from 'tss-react/mui'
-import { alpha } from '@mui/material/styles'
 import type { Theme } from '@mui/material/styles'
-import { SPACING, BORDER_RADIUS, OPACITY } from '@/constants'
+import {
+  SPACING,
+  BORDER_RADIUS,
+  OPACITY,
+  MOBILE_MEDIA_QUERY,
+  TINY_MAX_MEDIA_QUERY,
+  createMobilePageTitleStyle,
+} from '@/constants'
 import { fontFamily, fontWeights, fontSizes, lineHeights } from '@/styles/fonts'
 import { getCardBorderStyle } from '@/styles/cardBorderStyles'
 import type { ThemeConfig } from '@/context/theme/config'
@@ -20,6 +26,7 @@ const LABEL_MARGIN_BOTTOM = 2
 const ERROR_SPACE = 12
 const SECTION_BOX_TOP_PADDING = 12
 const SECTION_HEADER_MB = 16
+const TINY_HELP_ICON_SIZE = 16
 
 export const useStyles = makeStyles<CachePageStylesParams>()((
   theme: Theme,
@@ -33,7 +40,23 @@ export const useStyles = makeStyles<CachePageStylesParams>()((
   const sectionBoxBg = formInputBg
   const sectionInputBg = settings?.cardBackground ?? themeColors.card.background
 
+  const twoColumnGrid = {
+    display: 'grid' as const,
+    gridTemplateColumns: '1fr 1fr',
+    columnGap: SPACING.SECTION_GAP,
+    rowGap: SPACING.CARD_CONTENT_GAP,
+    width: '100%',
+    alignItems: 'start' as const,
+    [theme.breakpoints.down('md')]: {
+      gridTemplateColumns: '1fr',
+    },
+    [`@media ${MOBILE_MEDIA_QUERY}`]: {
+      rowGap: SPACING.SECTION_GAP,
+    },
+  }
+
   return {
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     cacheCard: {
       backgroundColor: settings?.cardBackground ?? themeColors.card.background,
       ...cardBorderStyle,
@@ -63,6 +86,18 @@ export const useStyles = makeStyles<CachePageStylesParams>()((
         lineHeight: `${lineHeights.normal} !important`,
         margin: '0 !important',
       },
+      // On the narrowest phones the label fills the field width, leaving no room
+      // for the trailing help icon, which then wraps to its own line. The icon
+      // is sized by an inline style, hence !important.
+      [`@media ${TINY_MAX_MEDIA_QUERY}`]: {
+        '& label, & label h5, & label h5 span': {
+          fontSize: `${fontSizes.sm} !important`,
+        },
+        '& label .MuiSvgIcon-root': {
+          width: `${TINY_HELP_ICON_SIZE}px !important`,
+          height: `${TINY_HELP_ICON_SIZE}px !important`,
+        },
+      },
     },
     formSection: {
       'display': 'flex',
@@ -73,16 +108,8 @@ export const useStyles = makeStyles<CachePageStylesParams>()((
       },
     },
     fieldsGrid: {
-      display: 'grid',
-      gridTemplateColumns: '1fr 1fr',
-      columnGap: SPACING.SECTION_GAP,
-      rowGap: SPACING.CARD_CONTENT_GAP,
-      width: '100%',
-      alignItems: 'start',
+      ...twoColumnGrid,
       minWidth: 0,
-      [theme.breakpoints.down('md')]: {
-        gridTemplateColumns: '1fr',
-      },
     },
     fieldItem: {
       'width': '100%',
@@ -131,6 +158,13 @@ export const useStyles = makeStyles<CachePageStylesParams>()((
         position: 'absolute',
         fontSize: `${fontSizes.sm} !important`,
       },
+      // Nothing is editable on mobile, so no validation errors can appear and
+      // the space reserved for them would only add a gap between fields.
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& .form-group [class*="col"]': {
+          paddingBottom: 0,
+        },
+      },
     },
     fieldItemFullWidth: {
       width: '100%',
@@ -162,10 +196,11 @@ export const useStyles = makeStyles<CachePageStylesParams>()((
           boxShadow: 'none !important',
         },
       '& input:disabled, & select:disabled': {
-        backgroundColor: `${alpha(formInputBg, OPACITY.DISABLED)} !important`,
+        backgroundColor: `${formInputBg} !important`,
         border: `1px solid ${inputBorderColor} !important`,
         color: `${themeColors.fontColor} !important`,
-        opacity: OPACITY.DISABLED,
+        WebkitTextFillColor: `${themeColors.fontColor} !important`,
+        opacity: `${OPACITY.FULL} !important`,
         cursor: 'not-allowed',
       },
       '& input::placeholder': {
@@ -186,6 +221,13 @@ export const useStyles = makeStyles<CachePageStylesParams>()((
       'padding': `${SECTION_BOX_TOP_PADDING}px ${SPACING.CARD_PADDING}px ${SPACING.CARD_PADDING}px`,
       'width': '100%',
       'boxSizing': 'border-box',
+      // Scoped to the provider panels rather than the whole form so the provider
+      // select above them stays tappable on mobile.
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& input, & select, & textarea, & .custom-select, & .form-control, & .react-toggle': {
+          pointerEvents: 'none' as const,
+        },
+      },
       '& input, & input:focus, & input:focus-visible, & input:active, & input:disabled, & .form-control:focus':
         {
           backgroundColor: `${sectionInputBg} !important`,
@@ -196,7 +238,9 @@ export const useStyles = makeStyles<CachePageStylesParams>()((
           color: `${themeColors.fontColor} !important`,
         },
       '& input:disabled': {
-        opacity: OPACITY.DISABLED,
+        WebkitTextFillColor: `${themeColors.fontColor} !important`,
+        opacity: `${OPACITY.FULL} !important`,
+        cursor: 'not-allowed',
       },
       '& select, & select:focus, & select:focus-visible, & select:active, & select:disabled, & .custom-select':
         {
@@ -207,7 +251,10 @@ export const useStyles = makeStyles<CachePageStylesParams>()((
           boxShadow: 'none !important',
         },
       '& select:disabled, & .custom-select:disabled': {
-        opacity: OPACITY.DISABLED,
+        color: `${themeColors.fontColor} !important`,
+        WebkitTextFillColor: `${themeColors.fontColor} !important`,
+        opacity: `${OPACITY.FULL} !important`,
+        cursor: 'not-allowed',
       },
     },
     sectionHeader: {
@@ -227,16 +274,6 @@ export const useStyles = makeStyles<CachePageStylesParams>()((
       margin: 0,
       padding: 0,
     },
-    sectionGrid: {
-      display: 'grid',
-      gridTemplateColumns: '1fr 1fr',
-      columnGap: SPACING.SECTION_GAP,
-      rowGap: SPACING.CARD_CONTENT_GAP,
-      width: '100%',
-      alignItems: 'start',
-      [theme.breakpoints.down('md')]: {
-        gridTemplateColumns: '1fr',
-      },
-    },
+    sectionGrid: twoColumnGrid,
   }
 })

--- a/admin-ui/plugins/services/components/styles/PersistenceDetail.style.ts
+++ b/admin-ui/plugins/services/components/styles/PersistenceDetail.style.ts
@@ -1,11 +1,15 @@
 import { makeStyles } from 'tss-react/mui'
-import { alpha } from '@mui/material/styles'
 import type { Theme } from '@mui/material/styles'
-import { SPACING, BORDER_RADIUS, OPACITY } from '@/constants'
+import {
+  SPACING,
+  BORDER_RADIUS,
+  OPACITY,
+  MOBILE_MEDIA_QUERY,
+  createMobilePageTitleStyle,
+} from '@/constants'
 import { fontFamily, fontWeights, fontSizes, lineHeights } from '@/styles/fonts'
 import { getCardBorderStyle } from '@/styles/cardBorderStyles'
 import type { ThemeConfig } from '@/context/theme/config'
-import customColors from '@/customColors'
 
 interface PersistenceDetailStylesParams {
   isDark: boolean
@@ -29,6 +33,7 @@ export const useStyles = makeStyles<PersistenceDetailStylesParams>()((
   const inputBorderColor = settings?.inputBorder ?? themeColors.borderColor
 
   return {
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     persistenceCard: {
       backgroundColor: settings?.cardBackground ?? themeColors.card.background,
       ...cardBorderStyle,
@@ -58,6 +63,9 @@ export const useStyles = makeStyles<PersistenceDetailStylesParams>()((
       minWidth: 0,
       [theme.breakpoints.down('md')]: {
         gridTemplateColumns: '1fr',
+      },
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        rowGap: SPACING.SECTION_GAP,
       },
     },
     fieldItem: {
@@ -107,6 +115,13 @@ export const useStyles = makeStyles<PersistenceDetailStylesParams>()((
         position: 'absolute',
         fontSize: `${fontSizes.sm} !important`,
       },
+      // The page is read-only, so no validation error can appear here and the
+      // space reserved for one would only add a gap between fields on mobile.
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& .form-group [class*="col"]': {
+          paddingBottom: 0,
+        },
+      },
     },
     formLabels: {
       '& label, & label h5, & label h5 span, & label .MuiSvgIcon-root': {
@@ -145,10 +160,11 @@ export const useStyles = makeStyles<PersistenceDetailStylesParams>()((
           boxShadow: 'none !important',
         },
       '& input:disabled, & select:disabled': {
-        backgroundColor: `${alpha(formInputBg, OPACITY.DISABLED)} !important`,
+        backgroundColor: `${formInputBg} !important`,
         border: `1px solid ${inputBorderColor} !important`,
         color: `${themeColors.fontColor} !important`,
-        opacity: OPACITY.DISABLED,
+        WebkitTextFillColor: `${themeColors.fontColor} !important`,
+        opacity: `${OPACITY.FULL} !important`,
         cursor: 'not-allowed',
       },
       '& input::placeholder': {
@@ -161,12 +177,6 @@ export const useStyles = makeStyles<PersistenceDetailStylesParams>()((
         backgroundColor: `${formInputBg} !important`,
         transition: 'background-color 5000s ease-in-out 0s',
       },
-    },
-    divider: {
-      height: 1,
-      backgroundColor: isDark ? customColors.darkBorder : customColors.lightBorder,
-      border: 'none',
-      margin: 0,
     },
   }
 })


### PR DESCRIPTION
### feat(admin-ui): implement responsive mobile layout for SSA, Services Module Cache, and Persistence pages (#2935)

#### Summary
This PR continues the Admin UI mobile redesign by implementing responsive, view-only layouts for the SSA, Services Module Cache, and Persistence pages.

The update optimizes these modules for phone and small-tablet viewports by introducing mobile-specific view-only behavior, improving responsive layouts, standardizing disabled field styling, and adding mobile page titles. Desktop and tablet layouts and functionality remain unchanged.

---

#### Fix Summary
- Implemented responsive mobile layouts for:
  - SSA
  - Services Module Cache
  - Persistence
- Converted the SSA list to a view-only experience on mobile
- Removed Add, Refresh, and Delete actions from the SSA list on mobile
- Preserved View and Download actions for SSA records
- Added mobile page titles for:
  - SSA list
  - SSA Add page
  - Cache
  - Persistence
- Converted Cache configuration to a view-only experience on mobile
- Disabled editable fields while keeping the Cache Provider Type selector available for viewing different provider configurations
- Removed Apply and Cancel actions from Cache and Persistence pages, leaving a Back-only footer
- Prevented commit dialog access from mobile view-only pages
- Discarded pending commit operations when switching to the mobile layout during an active commit
- Converted Persistence configuration to a read-only layout on mobile
- Standardized disabled field styling to use a single consistent text color
- Improved responsive field layouts by:
  - stacking fields into a single column
  - removing unused validation spacing
  - applying consistent vertical spacing
- Optimized label and help icon alignment to remain on a single line on narrow screens
- Preserved existing desktop and tablet layouts and functionality
- Maintained consistency with the shared Admin UI mobile design system

---

#### Verification

```bash
npm run check:all
```

passes successfully.

- Verified the SSA page renders correctly in mobile view
- Verified Add, Refresh, and Delete actions are hidden on the SSA list
- Verified View and Download actions continue to function correctly
- Verified Cache configuration is view-only on mobile
- Verified Cache Provider Type remains selectable while all provider fields remain read-only
- Verified the commit dialog cannot be opened from mobile
- Verified pending commits are discarded when switching to mobile view
- Verified Persistence renders correctly as a read-only page
- Verified disabled field styling is consistent across all affected pages
- Verified fields stack correctly with consistent spacing on mobile
- Verified page titles display correctly on all affected pages
- Verified desktop and tablet layouts remain unchanged

---

#### 🔗 Ticket

Closes: #2935

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved mobile layouts across asset, SSA, cache, and persistence pages.
  * Added visible mobile page headings for easier navigation.
  * Improved readability and appearance of disabled form controls.
  * Adjusted mobile spacing, labels, grids, and touch interactions.

* **Behavior Changes**
  * Restricted destructive or editing actions on mobile where appropriate.
  * Disabled cache editing and submission on mobile devices.
  * Limited asset refresh actions to supported desktop layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->