### PR TITLE
fix(admin-ui): point consumers at the nightly release and fail deploy fast

### DIFF
--- a/.github/workflows/build-admin-ui.yml
+++ b/.github/workflows/build-admin-ui.yml
@@ -48,7 +48,7 @@ on:
           - 'false'
         default: auto
       release_tag:
-        description: 'Existing release to upload assets to (e.g. nightly, 5.16.0). Must already exist. Empty = derive (main -> nightly).'
+        description: 'Existing release to upload assets to. Must be nightly or a v-prefixed version tag (e.g. v5.16.0) — the only forms consumers resolve. Must already exist. Empty = derive (main -> nightly).'
         required: false
         type: string
         default: ''
@@ -105,7 +105,7 @@ on:
         type: string
         default: auto
       release_tag:
-        description: 'Existing release to upload assets to. Must already exist unless recreate_release is set.'
+        description: 'Existing release to upload assets to. Must be nightly or a v-prefixed version tag (e.g. v5.16.0). Must already exist unless recreate_release is set.'
         required: false
         type: string
         default: ''
@@ -318,6 +318,11 @@ jobs:
     needs: build
     if: needs.build.outputs.do_publish == 'true'
     runs-on: ubuntu-latest
+    # serialize runs mutating the same release (delete/create/upload) so concurrent
+    # publishes to e.g. nightly can't clobber each other mid-flight
+    concurrency:
+      group: admin-ui-release-${{ needs.build.outputs.release_tag }}
+      cancel-in-progress: false
     permissions:
       contents: read
       packages: write   # GitHub Maven publish uses GITHUB_TOKEN; releases use MOWORKFLOWTOKEN
@@ -574,9 +579,9 @@ jobs:
             # legacy monolith (unit missing + jans container running) is not flex-linux-setup
             if ! $SSH "systemctl cat jans-config-api" >/dev/null 2>&1 \
                && $SSH "docker ps --format '{{.Names}}' 2>/dev/null | grep -q jans"; then
-              echo "::error::VM is running the legacy docker monolith, not flex-linux-setup." >&2
-              echo "::error::Merge easycloud #7570 or pass easycloud_ref=flex-linux-setup-installer." >&2
-              break
+              echo "::error::VM is running the legacy docker monolith, not flex-linux-setup;" >&2
+              echo "::error::check the easycloud jans.sh.tpl or pass a fixed easycloud_ref." >&2
+              exit 1
             fi
             sleep 60
           done

--- a/.github/workflows/build-admin-ui.yml
+++ b/.github/workflows/build-admin-ui.yml
@@ -558,33 +558,40 @@ jobs:
 
       - name: Wait for Flex install
         if: inputs.flex_branch != ''
-        continue-on-error: true
         env:
           IDENTIFIER: ${{ steps.create_env.outputs.identifier }}
           IP: ${{ steps.create_env.outputs.ip }}
         run: |
           SSH="ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -i $IDENTIFIER/private.pem root@$IP"
-          # full install (Java + DB + maven jars) realistically needs ~15-20 min
-          for i in $(seq 1 60); do
+          for i in $(seq 1 10); do
             CONFIG_API=$($SSH "systemctl is-active jans-config-api" 2>/dev/null || true)
             AUTH=$($SSH "systemctl is-active jans-auth" 2>/dev/null || true)
-            echo "jans-config-api=${CONFIG_API:-none} jans-auth=${AUTH:-none} ($i/60)"
+            echo "jans-config-api=${CONFIG_API:-none} jans-auth=${AUTH:-none} ($i/10)"
             if [ "$CONFIG_API" = "active" ]; then
               echo "Flex is up"
               exit 0
             fi
             # legacy monolith (unit missing + jans container running) is not flex-linux-setup
-            if ! $SSH "systemctl cat jans-config-api" >/dev/null 2>&1; then
-              if $SSH "docker ps --format '{{.Names}}' 2>/dev/null | grep -q jans"; then
-                echo "::warning::VM is running the legacy docker monolith, not flex-linux-setup." >&2
-                echo "::warning::Merge easycloud #7570 or pass easycloud_ref=flex-linux-setup-installer." >&2
-                break
-              fi
+            if ! $SSH "systemctl cat jans-config-api" >/dev/null 2>&1 \
+               && $SSH "docker ps --format '{{.Names}}' 2>/dev/null | grep -q jans"; then
+              echo "::error::VM is running the legacy docker monolith, not flex-linux-setup." >&2
+              echo "::error::Merge easycloud #7570 or pass easycloud_ref=flex-linux-setup-installer." >&2
+              break
             fi
             sleep 60
           done
-          echo "jans-config-api not active; continuing with deploy anyway" >&2
-          $SSH "tail -50 /var/log/flex-setup.log /var/log/cloud-init-output.log 2>/dev/null" || true
+          echo "::group::VM diagnostics (jans-config-api never became active)"
+          $SSH '
+            echo "### cloud-init status";      cloud-init status --long 2>/dev/null || true
+            echo "### failed units";           systemctl --failed --no-pager || true
+            echo "### jans units";             systemctl status jans-config-api jans-auth --no-pager 2>&1 | tail -40 || true
+            echo "### log files";              ls -la /var/log/flex-setup.log /var/log/flex-certbot.log /var/log/cloud-init-output.log 2>&1 || true
+            echo "### flex-setup.log tail";     tail -100 /var/log/flex-setup.log 2>/dev/null || echo "(absent)"
+            echo "### cloud-init-output tail";  tail -150 /var/log/cloud-init-output.log 2>/dev/null || echo "(absent)"
+          ' || true
+          echo "::endgroup::"
+          echo "::error::Flex did not become ready in time; failing the deploy." >&2
+          exit 1
 
       - name: Deploy admin-ui to VM
         env:

--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -65,14 +65,15 @@ ENV ADMIN_UI_VERSION=main
 ENV GLUU_BUILD_DATE='2025-11-06 18:51'
 
 # Admin UI assets are published to GitHub Releases by .github/workflows/build-admin-ui.yml:
-# tag builds (v*/nightly) attach to that release; branch builds go to admin-ui-<branch>.
+# v* tag builds attach to that tag's release; everything else (main, nightly, branches)
+# lands on the rolling `nightly` release as admin-ui-nightly-*.tar.gz.
 RUN case "${ADMIN_UI_VERSION}" in \
-        v*|nightly) RELEASE_TAG="${ADMIN_UI_VERSION}" ;; \
-        *) RELEASE_TAG="admin-ui-${ADMIN_UI_VERSION}" ;; \
+        v*) RELEASE_TAG="${ADMIN_UI_VERSION}"; ASSET_VERSION="${ADMIN_UI_VERSION}" ;; \
+        *) RELEASE_TAG="nightly"; ASSET_VERSION="nightly" ;; \
     esac \
-    && { wget -q https://github.com/GluuFederation/flex/releases/download/${RELEASE_TAG}/admin-ui-${ADMIN_UI_VERSION}-built.tar.gz -O /tmp/admin-ui.tar.gz \
-         || { echo "Admin UI asset not found for ${RELEASE_TAG}; falling back to admin-ui-main"; \
-              wget -q https://github.com/GluuFederation/flex/releases/download/admin-ui-main/admin-ui-main-built.tar.gz -O /tmp/admin-ui.tar.gz; }; } \
+    && { wget -q https://github.com/GluuFederation/flex/releases/download/${RELEASE_TAG}/admin-ui-${ASSET_VERSION}-built.tar.gz -O /tmp/admin-ui.tar.gz \
+         || { echo "Admin UI asset not found for ${RELEASE_TAG}; falling back to nightly"; \
+              wget -q https://github.com/GluuFederation/flex/releases/download/nightly/admin-ui-nightly-built.tar.gz -O /tmp/admin-ui.tar.gz; }; } \
     && mkdir -p /opt/flex/admin-ui \
     && tar xvf /tmp/admin-ui.tar.gz -C /opt/flex/admin-ui \
     && rm -rf /tmp/admin-ui.tar.gz

--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -66,14 +66,13 @@ ENV GLUU_BUILD_DATE='2025-11-06 18:51'
 
 # Admin UI assets are published to GitHub Releases by .github/workflows/build-admin-ui.yml:
 # v* tag builds attach to that tag's release; everything else (main, nightly, branches)
-# lands on the rolling `nightly` release as admin-ui-nightly-*.tar.gz.
+# lands on the rolling `nightly` release as admin-ui-nightly-*.tar.gz. Each version maps
+# to exactly one release, so a missing asset fails the build (no fallback).
 RUN case "${ADMIN_UI_VERSION}" in \
         v*) RELEASE_TAG="${ADMIN_UI_VERSION}"; ASSET_VERSION="${ADMIN_UI_VERSION}" ;; \
         *) RELEASE_TAG="nightly"; ASSET_VERSION="nightly" ;; \
     esac \
-    && { wget -q https://github.com/GluuFederation/flex/releases/download/${RELEASE_TAG}/admin-ui-${ASSET_VERSION}-built.tar.gz -O /tmp/admin-ui.tar.gz \
-         || { echo "Admin UI asset not found for ${RELEASE_TAG}; falling back to nightly"; \
-              wget -q https://github.com/GluuFederation/flex/releases/download/nightly/admin-ui-nightly-built.tar.gz -O /tmp/admin-ui.tar.gz; }; } \
+    && wget -q https://github.com/GluuFederation/flex/releases/download/${RELEASE_TAG}/admin-ui-${ASSET_VERSION}-built.tar.gz -O /tmp/admin-ui.tar.gz \
     && mkdir -p /opt/flex/admin-ui \
     && tar xvf /tmp/admin-ui.tar.gz -C /opt/flex/admin-ui \
     && rm -rf /tmp/admin-ui.tar.gz

--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -312,27 +312,21 @@ def get_admin_ui_bin_url():
     Assets are published by .github/workflows/build-admin-ui.yml: v* tag builds
     attach admin-ui-<tag>-built.tar.gz to that tag's release; everything else
     (main, nightly, branches) lands on the rolling `nightly` release as
-    admin-ui-nightly-built.tar.gz. Falls back to nightly when the tag asset
-    is missing.
+    admin-ui-nightly-built.tar.gz. Each version maps to exactly one release: a
+    missing v* asset is surfaced as an error (never silently downgraded to
+    nightly).
     """
     version = app_versions['NODE_MODULES_BRANCH'].replace('/', '-')
 
     if version.startswith('v'):
-        release_tag = version
-    else:
-        release_tag = 'nightly'
-        version = 'nightly'
-
-    url = '{0}/{1}/admin-ui-{2}-built.tar.gz'.format(admin_ui_releases_base_url, release_tag, version)
-
-    try:
-        request.urlopen(request.Request(url, method='HEAD'), timeout=30)
+        url = '{0}/{1}/admin-ui-{1}-built.tar.gz'.format(admin_ui_releases_base_url, version)
+        try:
+            request.urlopen(request.Request(url, method='HEAD'), timeout=30)
+        except Exception as e:
+            raise RuntimeError("Admin UI release asset not found at {}: {}".format(url, e))
         return url
-    except Exception:
-        fallback_url = '{0}/nightly/admin-ui-nightly-built.tar.gz'.format(admin_ui_releases_base_url)
-        if url != fallback_url:
-            print("Admin UI asset was not found at {}, falling back to {}".format(url, fallback_url))
-        return fallback_url
+
+    return '{0}/nightly/admin-ui-nightly-built.tar.gz'.format(admin_ui_releases_base_url)
 
 
 class flex_installer(JettyInstaller):

--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -309,18 +309,19 @@ admin_ui_releases_base_url = 'https://github.com/GluuFederation/flex/releases/do
 def get_admin_ui_bin_url():
     """Resolves the Admin UI built asset URL on GitHub Releases.
 
-    Assets are published by .github/workflows/build-admin-ui.yml as
-    admin-ui-<version>-built.tar.gz where <version> is either a flex tag
-    (attached to that tag's release) or a branch name (attached to the
-    admin-ui-<branch> release). Falls back to the main branch build when
-    no release asset exists for the requested branch.
+    Assets are published by .github/workflows/build-admin-ui.yml: v* tag builds
+    attach admin-ui-<tag>-built.tar.gz to that tag's release; everything else
+    (main, nightly, branches) lands on the rolling `nightly` release as
+    admin-ui-nightly-built.tar.gz. Falls back to nightly when the tag asset
+    is missing.
     """
     version = app_versions['NODE_MODULES_BRANCH'].replace('/', '-')
 
-    if version.startswith('v') or version == 'nightly':
+    if version.startswith('v'):
         release_tag = version
     else:
-        release_tag = 'admin-ui-' + version
+        release_tag = 'nightly'
+        version = 'nightly'
 
     url = '{0}/{1}/admin-ui-{2}-built.tar.gz'.format(admin_ui_releases_base_url, release_tag, version)
 
@@ -328,7 +329,7 @@ def get_admin_ui_bin_url():
         request.urlopen(request.Request(url, method='HEAD'), timeout=30)
         return url
     except Exception:
-        fallback_url = '{0}/admin-ui-main/admin-ui-main-built.tar.gz'.format(admin_ui_releases_base_url)
+        fallback_url = '{0}/nightly/admin-ui-nightly-built.tar.gz'.format(admin_ui_releases_base_url)
         if url != fallback_url:
             print("Admin UI asset was not found at {}, falling back to {}".format(url, fallback_url))
         return fallback_url


### PR DESCRIPTION
## Summary

Follow-up to #2944. Last night's run exposed two breaks:

1. **docker-admin-ui image build + packages workflow broken** — both consumers still resolved `main`/branch builds to the `admin-ui-<branch>` release, which no longer receives assets (main publishes to the rolling `nightly` release since #2944), and the old `admin-ui-main` fallback never existed. The 23:19 UTC nightly recreation (old inline step) also wiped the freshly uploaded admin-ui assets, so `build-packages` failed on the dead URL.
   - `docker-admin-ui/Dockerfile` and `flex_setup.py get_admin_ui_bin_url()` now resolve `v*` tags to the tag release and **everything else to `nightly`** (`admin-ui-nightly-built.tar.gz`), with a nightly fallback.
2. **Deploy false-green** — the VM readiness poll was `continue-on-error`, so the deploy job reported success after 60+ min of `jans-config-api=inactive`. Now it polls **10 minutes** (a healthy install signal should appear well within that; the previous run proved waiting longer is pointless), dumps diagnostics (`cloud-init status`, failed units, jans unit status, install log tails) and **fails the job**.

With #2944's orchestration now on main, tonight's nightly recreates the release via the admin-ui workflow first, so assets exist before packages/docker fan out — merging this completes the consumer side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Management**
  - Clarified accepted release tag formats and requirements.
  - Prevented overlapping publication runs from modifying the same release simultaneously.

- **Deployment**
  - Improved installation readiness checks with faster failure detection for unsupported legacy environments.
  - Added diagnostic details when deployments time out, including service status and recent logs.

- **Admin UI**
  - Standardized versioned and nightly asset downloads.
  - Removed outdated fallback behavior for unavailable version-specific assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->