### PR TITLE
fix(admin-ui): config forms validate against loaded server data

### DIFF
--- a/admin-ui/app/components/CustomInput/CustomInput.tsx
+++ b/admin-ui/app/components/CustomInput/CustomInput.tsx
@@ -19,6 +19,10 @@ const CustomInput: React.FC<CustomInputProps> = ({
     'is-invalid': invalid,
   })
 
+  // Only associate the control with feedback that is actually rendered, and
+  // only when `name` can supply a stable id.
+  const errorId = error && name ? `${name}-error` : undefined
+
   const control =
     type === 'select' ? (
       <select
@@ -26,6 +30,7 @@ const CustomInput: React.FC<CustomInputProps> = ({
         className={inputClass}
         name={name}
         aria-invalid={invalid || undefined}
+        aria-describedby={errorId}
         onChange={onChange as React.ChangeEventHandler<HTMLSelectElement>}
         onBlur={onBlur as React.FocusEventHandler<HTMLSelectElement>}
         {...(otherProps as React.SelectHTMLAttributes<HTMLSelectElement>)}
@@ -39,6 +44,7 @@ const CustomInput: React.FC<CustomInputProps> = ({
         name={name}
         type={type}
         aria-invalid={invalid || undefined}
+        aria-describedby={errorId}
         onChange={onChange as React.ChangeEventHandler<HTMLInputElement>}
         onBlur={onBlur as React.FocusEventHandler<HTMLInputElement>}
         {...(otherProps as React.InputHTMLAttributes<HTMLInputElement>)}
@@ -52,7 +58,11 @@ const CustomInput: React.FC<CustomInputProps> = ({
   return (
     <>
       {control}
-      <div className="invalid-feedback d-block" data-testid={name ? `${name}-error` : undefined}>
+      <div
+        id={errorId}
+        className="invalid-feedback d-block"
+        data-testid={name ? `${name}-error` : undefined}
+      >
         {error}
       </div>
     </>

--- a/admin-ui/app/components/CustomInput/CustomInput.tsx
+++ b/admin-ui/app/components/CustomInput/CustomInput.tsx
@@ -10,37 +10,52 @@ const CustomInput: React.FC<CustomInputProps> = ({
   children,
   onChange,
   onBlur,
+  invalid,
+  error,
   ...otherProps
 }) => {
   const inputClass = clsx('form-control', className, {
     'custom-control-empty': !label,
+    'is-invalid': invalid,
   })
 
-  if (type === 'select') {
-    return (
+  const control =
+    type === 'select' ? (
       <select
         data-testid={name}
         className={inputClass}
         name={name}
+        aria-invalid={invalid || undefined}
         onChange={onChange as React.ChangeEventHandler<HTMLSelectElement>}
         onBlur={onBlur as React.FocusEventHandler<HTMLSelectElement>}
         {...(otherProps as React.SelectHTMLAttributes<HTMLSelectElement>)}
       >
         {children}
       </select>
+    ) : (
+      <input
+        data-testid={name}
+        className={inputClass}
+        name={name}
+        type={type}
+        aria-invalid={invalid || undefined}
+        onChange={onChange as React.ChangeEventHandler<HTMLInputElement>}
+        onBlur={onBlur as React.FocusEventHandler<HTMLInputElement>}
+        {...(otherProps as React.InputHTMLAttributes<HTMLInputElement>)}
+      />
     )
+
+  if (!error) {
+    return control
   }
 
   return (
-    <input
-      data-testid={name}
-      className={inputClass}
-      name={name}
-      type={type}
-      onChange={onChange as React.ChangeEventHandler<HTMLInputElement>}
-      onBlur={onBlur as React.FocusEventHandler<HTMLInputElement>}
-      {...(otherProps as React.InputHTMLAttributes<HTMLInputElement>)}
-    />
+    <>
+      {control}
+      <div className="invalid-feedback d-block" data-testid={name ? `${name}-error` : undefined}>
+        {error}
+      </div>
+    </>
   )
 }
 

--- a/admin-ui/app/components/CustomInput/types.ts
+++ b/admin-ui/app/components/CustomInput/types.ts
@@ -12,6 +12,8 @@ export type CustomInputProps = {
   'onChange'?: React.ChangeEventHandler<HTMLInputElement | HTMLSelectElement>
   'onBlur'?: React.FocusEventHandler<HTMLInputElement | HTMLSelectElement>
   'children'?: React.ReactNode
+  'invalid'?: boolean
+  'error'?: string
   'data-testid'?: string
   'aria-disabled'?: boolean
   'tabIndex'?: number

--- a/admin-ui/app/locales/en/translation.json
+++ b/admin-ui/app/locales/en/translation.json
@@ -1212,7 +1212,11 @@
     "auth_error_no_code": "Unable to get authorization code",
     "mau_loading": "Loading statistics...",
     "vs_previous_period": "vs previous period",
-    "no_valid_role_logout": "The logged-in user does not have a valid role. You will be logged out in {{seconds}} seconds."
+    "no_valid_role_logout": "The logged-in user does not have a valid role. You will be logged out in {{seconds}} seconds.",
+    "logging_level_required": "Logging level is required",
+    "logging_level_invalid": "Invalid logging level",
+    "logging_layout_required": "Logging layout is required",
+    "logging_layout_invalid": "Invalid logging layout"
   },
   "errors": {
     "attribute_create_failed": "Error creating attribute",
@@ -1291,7 +1295,21 @@
     "field_invalid_url": "{{field}} must be a valid URL",
     "field_invalid_number": "{{field}} must be a valid integer",
     "field_must_be_positive": "{{field}} must be at least 1",
-    "field_invalid_regex": "{{field}} must be a valid regular expression"
+    "field_invalid_regex": "{{field}} must be a valid regular expression",
+    "field_required": "{{field}} is required",
+    "field_must_be_number": "{{field}} must be a number",
+    "field_must_be_integer": "{{field}} must be an integer",
+    "field_min_value": "{{field}} must be at least {{min}}",
+    "field_max_value": "{{field}} must not exceed {{max}}",
+    "field_invalid_value": "Invalid {{field}}",
+    "field_min_items": "At least one {{field}} is required",
+    "must_not_exceed": "Must not exceed {{max}}",
+    "cors_preflight_max_age_max": "Must not exceed 24 hours (86400 seconds)",
+    "min_one_approved_issuer": "At least one approved issuer is required",
+    "min_one_scope": "At least one scope is required",
+    "min_one_asset_type": "At least one type is required",
+    "min_one_service_module": "At least one service module is required",
+    "api_protection_type_invalid": "Invalid API protection type. Supported type is {{type}}"
   },
   "tooltips": {
     "insert_shortcode": "Insert shortcode",
@@ -1639,7 +1657,9 @@
     "log_layout_text": "Text",
     "log_layout_json": "JSON",
     "jwt": "JWT",
-    "reference": "Reference"
+    "reference": "Reference",
+    "expired": "EXPIRED",
+    "register": "REGISTER"
   },
   "documentation": {
     "fido": {

--- a/admin-ui/app/locales/es/translation.json
+++ b/admin-ui/app/locales/es/translation.json
@@ -1212,7 +1212,11 @@
     "fido2_metrics_health_down": "El servicio de métricas no está disponible actualmente.",
     "fido2_metrics_health_status": "Métricas Fido2",
     "fido2_metrics_health_unknown": "No se pudo determinar el estado del servicio de métricas.",
-    "fido2_metrics_health_up": "El servicio de métricas está funcionando con normalidad."
+    "fido2_metrics_health_up": "El servicio de métricas está funcionando con normalidad.",
+    "logging_level_required": "El nivel de registro es obligatorio",
+    "logging_level_invalid": "Nivel de registro no válido",
+    "logging_layout_required": "El formato de registro es obligatorio",
+    "logging_layout_invalid": "Formato de registro no válido"
   },
   "errors": {
     "attribute_create_failed": "Error al crear el atributo",
@@ -1294,7 +1298,21 @@
     "field_invalid_url": "{{field}} debe ser una URL válida",
     "field_invalid_number": "{{field}} debe ser un número entero válido",
     "field_must_be_positive": "{{field}} debe ser al menos 1",
-    "field_invalid_regex": "{{field}} debe ser una expresión regular válida"
+    "field_invalid_regex": "{{field}} debe ser una expresión regular válida",
+    "field_required": "{{field}} es obligatorio",
+    "field_must_be_number": "{{field}} debe ser un número",
+    "field_must_be_integer": "{{field}} debe ser un número entero",
+    "field_min_value": "{{field}} debe ser como mínimo {{min}}",
+    "field_max_value": "{{field}} no debe superar {{max}}",
+    "field_invalid_value": "{{field}} no es válido",
+    "field_min_items": "Se requiere al menos un valor en {{field}}",
+    "must_not_exceed": "No debe superar {{max}}",
+    "cors_preflight_max_age_max": "No debe superar 24 horas (86400 segundos)",
+    "min_one_approved_issuer": "Se requiere al menos un emisor aprobado",
+    "min_one_scope": "Se requiere al menos un alcance",
+    "min_one_asset_type": "Se requiere al menos un tipo",
+    "min_one_service_module": "Se requiere al menos un módulo de servicio",
+    "api_protection_type_invalid": "Tipo de protección de API no válido. El tipo admitido es {{type}}"
   },
   "tooltips": {
     "sort_ascending": "Ordenar ascendente",
@@ -1642,7 +1660,9 @@
     "log_layout_text": "Texto",
     "log_layout_json": "JSON",
     "jwt": "JWT",
-    "reference": "Referencia"
+    "reference": "Referencia",
+    "expired": "CADUCADO",
+    "register": "REGISTRO"
   },
   "documentation": {
     "fido": {

--- a/admin-ui/app/locales/fr/translation.json
+++ b/admin-ui/app/locales/fr/translation.json
@@ -1219,7 +1219,7 @@
     "no_scope_in_spontaneous_client": "Aucune donnée de portée spontanée pour ce client",
     "ssa_entity": "SSA",
     "no_attributes_found": "No attributes found",
-    "all_attributes_added": "All attributes have been added",
+    "all_attributes_added": "Tous les attributs ont été ajoutés",
     "logging_level_required": "Le niveau de journalisation est obligatoire",
     "logging_level_invalid": "Niveau de journalisation non valide",
     "logging_layout_required": "Le format de journalisation est obligatoire",

--- a/admin-ui/app/locales/fr/translation.json
+++ b/admin-ui/app/locales/fr/translation.json
@@ -1219,7 +1219,11 @@
     "no_scope_in_spontaneous_client": "Aucune donnée de portée spontanée pour ce client",
     "ssa_entity": "SSA",
     "no_attributes_found": "No attributes found",
-    "all_attributes_added": "All attributes have been added"
+    "all_attributes_added": "All attributes have been added",
+    "logging_level_required": "Le niveau de journalisation est obligatoire",
+    "logging_level_invalid": "Niveau de journalisation non valide",
+    "logging_layout_required": "Le format de journalisation est obligatoire",
+    "logging_layout_invalid": "Format de journalisation non valide"
   },
   "errors": {
     "attribute_create_failed": "Erreur lors de la création de l'attribut",
@@ -1298,7 +1302,21 @@
     "field_invalid_url": "{{field}} doit être une URL valide",
     "field_invalid_number": "{{field}} doit être un entier valide",
     "field_must_be_positive": "{{field}} doit être au moins 1",
-    "field_invalid_regex": "{{field}} doit être une expression régulière valide"
+    "field_invalid_regex": "{{field}} doit être une expression régulière valide",
+    "field_required": "{{field}} est obligatoire",
+    "field_must_be_number": "{{field}} doit être un nombre",
+    "field_must_be_integer": "{{field}} doit être un nombre entier",
+    "field_min_value": "{{field}} doit être au minimum {{min}}",
+    "field_max_value": "{{field}} ne doit pas dépasser {{max}}",
+    "field_invalid_value": "{{field}} n’est pas valide",
+    "field_min_items": "Au moins une valeur est requise pour {{field}}",
+    "must_not_exceed": "Ne doit pas dépasser {{max}}",
+    "cors_preflight_max_age_max": "Ne doit pas dépasser 24 heures (86400 secondes)",
+    "min_one_approved_issuer": "Au moins un émetteur approuvé est requis",
+    "min_one_scope": "Au moins une portée est requise",
+    "min_one_asset_type": "Au moins un type est requis",
+    "min_one_service_module": "Au moins un module de service est requis",
+    "api_protection_type_invalid": "Type de protection d'API non valide. Le type pris en charge est {{type}}"
   },
   "tooltips": {
     "insert_shortcode": "Insérer un shortcode",
@@ -1647,7 +1665,9 @@
     "log_layout_text": "Texte",
     "log_layout_json": "JSON",
     "jwt": "JWT",
-    "reference": "Référence"
+    "reference": "Référence",
+    "expired": "EXPIRÉ",
+    "register": "INSCRIPTION"
   },
   "documentation": {
     "fido": {

--- a/admin-ui/app/locales/pt/translation.json
+++ b/admin-ui/app/locales/pt/translation.json
@@ -1215,7 +1215,11 @@
     "fido2_metrics_health_down": "O serviço de métricas está indisponível no momento.",
     "fido2_metrics_health_status": "Métricas Fido2",
     "fido2_metrics_health_unknown": "Não foi possível determinar o status do serviço de métricas.",
-    "fido2_metrics_health_up": "O serviço de métricas está funcionando normalmente."
+    "fido2_metrics_health_up": "O serviço de métricas está funcionando normalmente.",
+    "logging_level_required": "O nível de log é obrigatório",
+    "logging_level_invalid": "Nível de log inválido",
+    "logging_layout_required": "O formato de log é obrigatório",
+    "logging_layout_invalid": "Formato de log inválido"
   },
   "errors": {
     "attribute_create_failed": "Erro ao criar atributo",
@@ -1294,7 +1298,21 @@
     "field_invalid_url": "{{field}} deve ser uma URL válida",
     "field_invalid_number": "{{field}} deve ser um número inteiro válido",
     "field_must_be_positive": "{{field}} deve ser pelo menos 1",
-    "field_invalid_regex": "{{field}} deve ser uma expressão regular válida"
+    "field_invalid_regex": "{{field}} deve ser uma expressão regular válida",
+    "field_required": "{{field}} é obrigatório",
+    "field_must_be_number": "{{field}} deve ser um número",
+    "field_must_be_integer": "{{field}} deve ser um número inteiro",
+    "field_min_value": "{{field}} deve ser no mínimo {{min}}",
+    "field_max_value": "{{field}} não deve exceder {{max}}",
+    "field_invalid_value": "{{field}} não é válido",
+    "field_min_items": "É necessário pelo menos um valor em {{field}}",
+    "must_not_exceed": "Não deve exceder {{max}}",
+    "cors_preflight_max_age_max": "Não deve exceder 24 horas (86400 segundos)",
+    "min_one_approved_issuer": "É necessário pelo menos um emissor aprovado",
+    "min_one_scope": "É necessário pelo menos um escopo",
+    "min_one_asset_type": "É necessário pelo menos um tipo",
+    "min_one_service_module": "É necessário pelo menos um módulo de serviço",
+    "api_protection_type_invalid": "Tipo de proteção de API inválido. O tipo suportado é {{type}}"
   },
   "tooltips": {
     "insert_shortcode": "Inserir código de atalho",
@@ -1643,7 +1661,9 @@
     "log_layout_text": "Texto",
     "log_layout_json": "JSON",
     "jwt": "JWT",
-    "reference": "Referência"
+    "reference": "Referência",
+    "expired": "EXPIRADO",
+    "register": "REGISTRO"
   },
   "documentation": {
     "fido": {

--- a/admin-ui/plugins/admin/components/Settings/SettingsPage.tsx
+++ b/admin-ui/plugins/admin/components/Settings/SettingsPage.tsx
@@ -200,6 +200,7 @@ const SettingsPage: React.FC = () => {
       }
     },
     validationSchema,
+    validateOnMount: true,
   })
 
   const { resetForm } = formik
@@ -430,9 +431,7 @@ const SettingsPage: React.FC = () => {
                         doc_category={SETTINGS}
                         doc_entry="sessionTimeoutInMins"
                         errorMessage={formik.errors.sessionTimeoutInMins}
-                        showError={Boolean(
-                          formik.errors.sessionTimeoutInMins && formik.touched.sessionTimeoutInMins,
-                        )}
+                        showError={Boolean(formik.errors.sessionTimeoutInMins)}
                         disabled={!canEditSettings}
                         isDark={isDark}
                         placeholder={getFieldPlaceholder(t, 'fields.sessionTimeoutInMins')}

--- a/admin-ui/plugins/auth-server/components/AuthServerProperties/components/AuthServerPropertiesPage.tsx
+++ b/admin-ui/plugins/auth-server/components/AuthServerProperties/components/AuthServerPropertiesPage.tsx
@@ -129,6 +129,7 @@ const AuthServerPropertiesPage: React.FC = () => {
   const baselineConfigurationRef = useRef<AppConfiguration | null>(null)
   const setFieldValueRef = useRef<FormikProps<AppConfiguration>['setFieldValue'] | null>(null)
   const resetFormRef = useRef<FormikProps<AppConfiguration>['resetForm'] | null>(null)
+  const validateFormRef = useRef<FormikProps<AppConfiguration>['validateForm'] | null>(null)
   const previousConfigurationRef = useRef<AppConfiguration | null>(null)
   const validationSchema = useMemo(() => createAppConfigurationSchema(t), [t])
   const handleAcrUpdateSuccess = useCallback(() => {
@@ -173,13 +174,14 @@ const AuthServerPropertiesPage: React.FC = () => {
     enableReinitialize: true,
     validateOnChange: true,
     validateOnBlur: true,
-    validateOnMount: false,
+    validateOnMount: true,
     onSubmit: () => {},
   })
   useEffect(() => {
     setFieldValueRef.current = formik.setFieldValue
     resetFormRef.current = formik.resetForm
-  }, [formik.setFieldValue, formik.resetForm])
+    validateFormRef.current = formik.validateForm
+  }, [formik.setFieldValue, formik.resetForm, formik.validateForm])
   useEffect(() => {
     const configChanged =
       previousConfigurationRef.current === null ||
@@ -197,6 +199,7 @@ const AuthServerPropertiesPage: React.FC = () => {
           touched: {},
           errors: {},
         })
+        void validateFormRef.current?.(serverConfiguration)
         setResetKey((prev) => prev + 1)
       }
     }
@@ -691,7 +694,6 @@ const AuthServerPropertiesPage: React.FC = () => {
                           lSize={lSize}
                           handler={patchHandler}
                           errors={formik.errors}
-                          touched={formik.touched}
                           formResetKey={resetKey}
                         />
                       </div>

--- a/admin-ui/plugins/auth-server/components/AuthServerProperties/components/JsonPropertyBuilder.tsx
+++ b/admin-ui/plugins/auth-server/components/AuthServerProperties/components/JsonPropertyBuilder.tsx
@@ -175,7 +175,6 @@ const JsonPropertyBuilder = ({
   schema,
   isRenamedKey = false,
   errors,
-  touched,
   formResetKey = 0,
 }: JsonPropertyBuilderProps): JSX.Element => {
   const { t, i18n } = useTranslation()
@@ -218,13 +217,7 @@ const JsonPropertyBuilder = ({
     return getIn(errors, formikPathSegments)
   }, [errors, formikPathSegments])
 
-  const fieldTouched = useMemo(() => {
-    if (!touched) return false
-    return getIn(touched, formikPathSegments) === true
-  }, [touched, formikPathSegments])
-
   const renderError = useCallback(() => {
-    if (!fieldTouched) return null
     if (!fieldError) return null
 
     let errorMessage: string | null
@@ -262,7 +255,7 @@ const JsonPropertyBuilder = ({
         </FormGroup>
       </div>
     )
-  }, [fieldTouched, fieldError, lSize, classes])
+  }, [fieldError, lSize, classes])
 
   const removeHandler = useCallback(() => {
     const patch: JsonPatch = {
@@ -328,7 +321,7 @@ const JsonPropertyBuilder = ({
           rsize={lSize}
           doc_category="json_properties"
           doc_entry={propKey}
-          showError={fieldTouched && typeof fieldError === 'string'}
+          showError={typeof fieldError === 'string'}
           errorMessage={typeof fieldError === 'string' ? fieldError : undefined}
           disabled={isMobile}
         />
@@ -483,7 +476,6 @@ const JsonPropertyBuilder = ({
                 parentIsArray={true}
                 path={path}
                 errors={errors}
-                touched={touched}
                 formResetKey={formResetKey}
               />
             ))
@@ -548,7 +540,6 @@ const JsonPropertyBuilder = ({
                           parentIsArray={false}
                           path={path}
                           errors={errors}
-                          touched={touched}
                           formResetKey={formResetKey}
                         />
                       </div>

--- a/admin-ui/plugins/auth-server/components/AuthServerProperties/types/index.ts
+++ b/admin-ui/plugins/auth-server/components/AuthServerProperties/types/index.ts
@@ -2,7 +2,7 @@ import type { JsonPatch } from 'JansConfigApi'
 import type { Accordion } from 'Components'
 import type React from 'react'
 import type { GenericItem } from '@/redux/types'
-import type { FormikErrors, FormikTouched } from 'formik'
+import type { FormikErrors } from 'formik'
 import type { AutocompleteOption } from '@/routes/Apps/Gluu/types/GluuAutocomplete.types'
 
 export type AppConfiguration = {
@@ -54,7 +54,6 @@ export type JsonPropertyBuilderProps = {
   schema?: SchemaProperty
   isRenamedKey?: boolean
   errors?: FormikErrors<AppConfiguration>
-  touched?: FormikTouched<AppConfiguration>
   formResetKey?: number
 }
 

--- a/admin-ui/plugins/auth-server/components/Authentication/Acrs/AcrsForm.tsx
+++ b/admin-ui/plugins/auth-server/components/Authentication/Acrs/AcrsForm.tsx
@@ -78,7 +78,7 @@ const AcrsForm = ({ item, handleSubmit, isSubmitting = false }: AcrsFormProps): 
     [item, acrs?.defaultAcr],
   )
 
-  const validationSchema = useMemo(() => getAuthNValidationSchema(item), [item])
+  const validationSchema = useMemo(() => getAuthNValidationSchema(item, t), [item, t])
 
   const formik: FormikProps<AcrsFormValues> = useFormik<AcrsFormValues>({
     initialValues,

--- a/admin-ui/plugins/auth-server/components/Authentication/Acrs/helper/__tests__/validations.test.ts
+++ b/admin-ui/plugins/auth-server/components/Authentication/Acrs/helper/__tests__/validations.test.ts
@@ -8,9 +8,13 @@ const baseValid = {
   defaultAuthNMethod: false,
 }
 
+import type { TFunction } from 'i18next'
+
+const t = ((key: string) => key) as TFunction
+
 describe('getAuthNValidationSchema', () => {
   describe('base schema (no item)', () => {
-    const schema = getAuthNValidationSchema(null)
+    const schema = getAuthNValidationSchema(null, t)
 
     it('accepts a valid acr/level/defaultAuthNMethod set', async () => {
       await expect(schema.isValid(baseValid)).resolves.toBe(true)
@@ -18,19 +22,19 @@ describe('getAuthNValidationSchema', () => {
 
     it('requires the acr name', async () => {
       await expect(schema.validate({ ...baseValid, acr: undefined })).rejects.toThrow(
-        'ACR name is required.',
+        'validation_messages.field_required',
       )
     })
 
     it('rejects a non-numeric level', async () => {
       await expect(schema.validate({ ...baseValid, level: 'abc' })).rejects.toThrow(
-        'Level must be a number.',
+        'validation_messages.field_must_be_number',
       )
     })
 
     it('rejects a non-integer level', async () => {
       await expect(schema.validate({ ...baseValid, level: 1.5 })).rejects.toThrow(
-        'Level must be an integer.',
+        'validation_messages.field_must_be_integer',
       )
     })
 
@@ -40,24 +44,24 @@ describe('getAuthNValidationSchema', () => {
 
     it('rejects a level below -1', async () => {
       await expect(schema.validate({ ...baseValid, level: -2 })).rejects.toThrow(
-        'Level must be at least -1.',
+        'validation_messages.field_min_value',
       )
     })
 
     it('requires the default AuthN method', async () => {
       await expect(schema.validate({ acr: 'x', level: 1 })).rejects.toThrow(
-        'Default AuthN Method is required.',
+        'validation_messages.field_required',
       )
     })
   })
 
   describe('script schema', () => {
     const item = { isCustomScript: true } as AuthNItem
-    const schema = getAuthNValidationSchema(item)
+    const schema = getAuthNValidationSchema(item, t)
 
     it('raises the minimum level to 0', async () => {
       await expect(schema.validate({ ...baseValid, level: -1 })).rejects.toThrow(
-        'Level must be at least 0.',
+        'validation_messages.field_min_value',
       )
       await expect(schema.isValid({ ...baseValid, level: 0 })).resolves.toBe(true)
     })
@@ -71,7 +75,7 @@ describe('getAuthNValidationSchema', () => {
 
   describe('ldap schema', () => {
     const item = { name: AUTH_METHOD_NAMES.DEFAULT_LDAP } as AuthNItem
-    const schema = getAuthNValidationSchema(item)
+    const schema = getAuthNValidationSchema(item, t)
 
     const ldapValid = {
       ...baseValid,
@@ -87,32 +91,32 @@ describe('getAuthNValidationSchema', () => {
 
     it('requires bindDN', async () => {
       await expect(schema.validate({ ...ldapValid, bindDN: undefined })).rejects.toThrow(
-        'Bind DN is required.',
+        'validation_messages.field_required',
       )
     })
 
     it('requires at least one server', async () => {
       await expect(schema.validate({ ...ldapValid, servers: [] })).rejects.toThrow(
-        'At least one server is required.',
+        'validation_messages.field_min_items',
       )
     })
 
     it('requires at least one base DN', async () => {
       await expect(schema.validate({ ...ldapValid, baseDNs: [] })).rejects.toThrow(
-        'At least one base DN is required.',
+        'validation_messages.field_min_items',
       )
     })
 
     it('requires maxConnections to be at least 1', async () => {
       await expect(schema.validate({ ...ldapValid, maxConnections: 0 })).rejects.toThrow(
-        'Max connections must be at least 1.',
+        'validation_messages.field_min_value',
       )
     })
   })
 
   describe('built-in schema', () => {
     const item = { name: AUTH_METHOD_NAMES.SIMPLE_PASSWORD } as AuthNItem
-    const schema = getAuthNValidationSchema(item)
+    const schema = getAuthNValidationSchema(item, t)
 
     it('permits optional nullable built-in fields', async () => {
       await expect(

--- a/admin-ui/plugins/auth-server/components/Authentication/Acrs/helper/validations.ts
+++ b/admin-ui/plugins/auth-server/components/Authentication/Acrs/helper/validations.ts
@@ -1,20 +1,34 @@
 import * as Yup from 'yup'
+import type { TFunction } from 'i18next'
 import type { AuthNItem } from '../../types'
 import { AUTH_METHOD_NAMES } from '../../constants'
 
-export const getAuthNValidationSchema = (item: AuthNItem | null): Yup.AnyObjectSchema => {
+export const getAuthNValidationSchema = (
+  item: AuthNItem | null,
+  t: TFunction,
+): Yup.AnyObjectSchema => {
+  const required = (label: string) => t('validation_messages.field_required', { field: t(label) })
+  const numeric = (label: string) =>
+    t('validation_messages.field_must_be_number', { field: t(label) })
+  const integer = (label: string) =>
+    t('validation_messages.field_must_be_integer', { field: t(label) })
+  const minValue = (label: string, min: number) =>
+    t('validation_messages.field_min_value', { field: t(label), min })
+  const minItems = (label: string) => t('validation_messages.field_min_items', { field: t(label) })
   const isBuiltIn = item?.name === AUTH_METHOD_NAMES.SIMPLE_PASSWORD
   const isLdap = item?.name === AUTH_METHOD_NAMES.DEFAULT_LDAP
   const isScript = !!item?.isCustomScript
 
   const baseSchema: Record<string, Yup.AnySchema> = {
-    acr: Yup.string().required('ACR name is required.'),
+    acr: Yup.string().required(required('fields.acr')),
     level: Yup.number()
-      .typeError('Level must be a number.')
-      .required('Level is required.')
-      .integer('Level must be an integer.')
-      .min(-1, 'Level must be at least -1.'),
-    defaultAuthNMethod: Yup.mixed<boolean | string>().required('Default AuthN Method is required.'),
+      .typeError(numeric('fields.level'))
+      .required(required('fields.level'))
+      .integer(integer('fields.level'))
+      .min(-1, minValue('fields.level', -1)),
+    defaultAuthNMethod: Yup.mixed<boolean | string>().required(
+      required('fields.default_authn_method'),
+    ),
   }
 
   if (isBuiltIn) {
@@ -29,37 +43,37 @@ export const getAuthNValidationSchema = (item: AuthNItem | null): Yup.AnyObjectS
     baseSchema.samlACR = Yup.string().optional().nullable()
     baseSchema.description = Yup.string().optional().nullable()
     baseSchema.level = Yup.number()
-      .typeError('Level must be a number.')
-      .required('Level is required.')
-      .integer('Level must be an integer.')
-      .min(0, 'Level must be at least 0.')
+      .typeError(numeric('fields.level'))
+      .required(required('fields.level'))
+      .integer(integer('fields.level'))
+      .min(0, minValue('fields.level', 0))
   }
 
   if (isLdap) {
-    baseSchema.bindDN = Yup.string().required('Bind DN is required.')
+    baseSchema.bindDN = Yup.string().required(required('fields.bind_dn'))
     baseSchema.maxConnections = Yup.number()
-      .typeError('Max connections must be a number.')
-      .required('Max connections is required.')
-      .integer('Max connections must be an integer.')
-      .min(1, 'Max connections must be at least 1.')
+      .typeError(numeric('fields.max_connections'))
+      .required(required('fields.max_connections'))
+      .integer(integer('fields.max_connections'))
+      .min(1, minValue('fields.max_connections', 1))
     baseSchema.remotePrimaryKey = Yup.string().optional().nullable()
     baseSchema.localPrimaryKey = Yup.string().optional().nullable()
     baseSchema.servers = Yup.array()
-      .of(Yup.string().required('Server URL is required.'))
-      .min(1, 'At least one server is required.')
-      .required('Servers are required.')
+      .of(Yup.string().required(required('fields.remote_ldap_server_post')))
+      .min(1, minItems('fields.remote_ldap_server_post'))
+      .required(required('fields.remote_ldap_server_post'))
     baseSchema.baseDNs = Yup.array()
-      .of(Yup.string().required('Base DN is required.'))
-      .min(1, 'At least one base DN is required.')
-      .required('Base DNs are required.')
+      .of(Yup.string().required(required('fields.base_dn')))
+      .min(1, minItems('fields.base_dn'))
+      .required(required('fields.base_dn'))
     baseSchema.bindPassword = Yup.string().optional().nullable()
     baseSchema.useSSL = Yup.boolean().optional().nullable()
     baseSchema.enabled = Yup.boolean().optional().nullable()
     baseSchema.level = Yup.number()
-      .typeError('Level must be a number.')
-      .required('Level is required.')
-      .integer('Level must be an integer.')
-      .min(0, 'Level must be at least 0.')
+      .typeError(numeric('fields.level'))
+      .required(required('fields.level'))
+      .integer(integer('fields.level'))
+      .min(0, minValue('fields.level', 0))
   }
 
   return Yup.object(baseSchema)

--- a/admin-ui/plugins/auth-server/components/ConfigApiProperties/components/ConfigApiPropertiesForm.tsx
+++ b/admin-ui/plugins/auth-server/components/ConfigApiProperties/components/ConfigApiPropertiesForm.tsx
@@ -23,7 +23,7 @@ import {
   READ_ONLY_FIELDS,
   updateValuesAfterRemoval,
   applyRemovePatchToValues,
-  configApiPropertiesSchema,
+  getConfigApiPropertiesSchema,
 } from '../utils'
 import {
   toPairs,
@@ -70,12 +70,15 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
   const previousConfigurationRef = useRef<ApiAppConfiguration | null>(null)
   const processingRemovalsRef = useRef<Set<string>>(new Set())
 
+  const configApiPropertiesSchema = useMemo(() => getConfigApiPropertiesSchema(t), [t])
+
   const formik = useFormik<ApiAppConfiguration>({
     initialValues: configuration,
     validationSchema: configApiPropertiesSchema,
     enableReinitialize: true,
     validateOnChange: true,
     validateOnBlur: true,
+    validateOnMount: true,
     onSubmit: () => {},
   })
 
@@ -405,7 +408,6 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
                     doc_category="config_api_properties"
                     disabled={isFieldDisabled(leftKey)}
                     errors={formik.errors}
-                    touched={formik.touched}
                   />
                 </div>
                 <div className={classes.fieldItem}>
@@ -420,7 +422,6 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
                       doc_category="config_api_properties"
                       disabled={isFieldDisabled(rightKey)}
                       errors={formik.errors}
-                      touched={formik.touched}
                     />
                   )}
                 </div>
@@ -438,7 +439,6 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
                     doc_category="config_api_properties"
                     disabled={isFieldDisabled(leftKey)}
                     errors={formik.errors}
-                    touched={formik.touched}
                   />
                 </div>
                 <div className={classes.fieldItem}>
@@ -453,7 +453,6 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
                       doc_category="config_api_properties"
                       disabled={isFieldDisabled(rightKey)}
                       errors={formik.errors}
-                      touched={formik.touched}
                     />
                   )}
                 </div>
@@ -470,7 +469,6 @@ const ConfigApiPropertiesForm: React.FC<ConfigApiPropertiesFormProps> = ({
                   doc_category="config_api_properties"
                   disabled={isFieldDisabled(propKey)}
                   errors={formik.errors}
-                  touched={formik.touched}
                 />
               </div>
             ))}

--- a/admin-ui/plugins/auth-server/components/ConfigApiProperties/components/JsonPropertyBuilderConfigApi.tsx
+++ b/admin-ui/plugins/auth-server/components/ConfigApiProperties/components/JsonPropertyBuilderConfigApi.tsx
@@ -64,7 +64,6 @@ const JsonPropertyBuilderConfigApi = ({
   parent,
   disabled = false,
   errors,
-  touched,
 }: JsonPropertyBuilderConfigApiProps): JSX.Element => {
   const { t, i18n } = useTranslation()
   const { classes } = useStyles()
@@ -120,11 +119,6 @@ const JsonPropertyBuilderConfigApi = ({
     return getIn(errors, formikPath)
   }, [errors, formikPath])
 
-  const fieldTouched = useMemo(() => {
-    if (!touched) return false
-    return getIn(touched, formikPath) === true
-  }, [touched, formikPath])
-
   const removeHandler = useCallback(() => {
     if (!show) {
       return
@@ -140,7 +134,7 @@ const JsonPropertyBuilderConfigApi = ({
   }, [path, handler, show])
 
   const renderError = useCallback(() => {
-    if (!fieldTouched || !fieldError) return null
+    if (!fieldError) return null
     if (typeof fieldError === 'object' && fieldError !== null) return null
     return (
       <div style={ERROR_CONTAINER_STYLE}>
@@ -158,7 +152,7 @@ const JsonPropertyBuilderConfigApi = ({
         </FormGroup>
       </div>
     )
-  }, [fieldTouched, fieldError, lSize])
+  }, [fieldError, lSize])
 
   const selectFormikAdapter = useMemo(
     () => ({
@@ -242,7 +236,7 @@ const JsonPropertyBuilderConfigApi = ({
           doc_category={doc_category}
           doc_entry={tooltipPropKey || propKey}
           disabled={disabled}
-          showError={fieldTouched && typeof fieldError === 'string'}
+          showError={typeof fieldError === 'string'}
           errorMessage={typeof fieldError === 'string' ? fieldError : undefined}
         />
       )
@@ -371,7 +365,6 @@ const JsonPropertyBuilderConfigApi = ({
                   doc_category={doc_category}
                   disabled={disabled}
                   errors={errors}
-                  touched={touched}
                 />
               )
             })
@@ -458,7 +451,6 @@ const JsonPropertyBuilderConfigApi = ({
                           doc_category={doc_category}
                           disabled={disabled}
                           errors={errors}
-                          touched={touched}
                         />
                       </div>
                     )

--- a/admin-ui/plugins/auth-server/components/ConfigApiProperties/utils/__tests__/validations.test.ts
+++ b/admin-ui/plugins/auth-server/components/ConfigApiProperties/utils/__tests__/validations.test.ts
@@ -1,13 +1,18 @@
-import { configApiPropertiesSchema } from 'Plugins/auth-server/components/ConfigApiProperties/utils/validations'
+import { getConfigApiPropertiesSchema } from 'Plugins/auth-server/components/ConfigApiProperties/utils/validations'
+
+import type { TFunction } from 'i18next'
+
+const t = ((key: string) => key) as TFunction
+const schema = getConfigApiPropertiesSchema(t)
 
 describe('configApiPropertiesSchema', () => {
   it('accepts an empty object (all fields nullable/optional)', async () => {
-    await expect(configApiPropertiesSchema.isValid({})).resolves.toBe(true)
+    await expect(schema.isValid({})).resolves.toBe(true)
   })
 
   it('accepts a populated valid config', async () => {
     await expect(
-      configApiPropertiesSchema.isValid({
+      schema.isValid({
         serviceName: 'jans-config-api',
         configOauthEnabled: true,
         apiProtectionType: 'OAuth2',
@@ -21,38 +26,38 @@ describe('configApiPropertiesSchema', () => {
   })
 
   it('rejects an unsupported api protection type', async () => {
-    await expect(
-      configApiPropertiesSchema.validate({ apiProtectionType: 'Basic' }),
-    ).rejects.toThrow('Invalid API protection type. Supported type is OAuth2')
+    await expect(schema.validate({ apiProtectionType: 'Basic' })).rejects.toThrow(
+      'validation_messages.api_protection_type_invalid',
+    )
   })
 
   it('rejects an empty approved issuer list', async () => {
-    await expect(configApiPropertiesSchema.validate({ apiApprovedIssuer: [] })).rejects.toThrow(
-      'At least one approved issuer is required',
+    await expect(schema.validate({ apiApprovedIssuer: [] })).rejects.toThrow(
+      'validation_messages.min_one_approved_issuer',
     )
   })
 
   it('rejects a malformed issuer url', async () => {
-    await expect(
-      configApiPropertiesSchema.validate({ authIssuerUrl: 'not-a-url' }),
-    ).rejects.toThrow('Invalid URL format')
+    await expect(schema.validate({ authIssuerUrl: 'not-a-url' })).rejects.toThrow(
+      'validation_messages.invalid_url_format',
+    )
   })
 
   it('rejects an unknown logging level', async () => {
-    await expect(configApiPropertiesSchema.validate({ loggingLevel: 'VERBOSE' })).rejects.toThrow(
-      'Invalid logging level',
+    await expect(schema.validate({ loggingLevel: 'VERBOSE' })).rejects.toThrow(
+      'messages.logging_level_invalid',
     )
   })
 
   it('rejects a negative maxCount', async () => {
-    await expect(configApiPropertiesSchema.validate({ maxCount: -1 })).rejects.toThrow(
-      'Must be non-negative',
+    await expect(schema.validate({ maxCount: -1 })).rejects.toThrow(
+      'validation_messages.must_be_non_negative',
     )
   })
 
   it('rejects a maxCount over the ceiling', async () => {
-    await expect(configApiPropertiesSchema.validate({ maxCount: 10001 })).rejects.toThrow(
-      'Must not exceed 10000',
+    await expect(schema.validate({ maxCount: 10001 })).rejects.toThrow(
+      'validation_messages.must_not_exceed',
     )
   })
 
@@ -60,14 +65,14 @@ describe('configApiPropertiesSchema', () => {
     // The number field carries a transform that maps '' -> null; feed the raw
     // form string through a loosely-typed input to exercise it.
     const input: Record<string, string> = { maxCount: '' }
-    await expect(configApiPropertiesSchema.isValid(input)).resolves.toBe(true)
+    await expect(schema.isValid(input)).resolves.toBe(true)
   })
 
   it('rejects a cors preflight max age above 24 hours', async () => {
     await expect(
-      configApiPropertiesSchema.validate({
+      schema.validate({
         corsConfigurationFilters: [{ corsPreflightMaxAge: 90000 }],
       }),
-    ).rejects.toThrow('Must not exceed 24 hours (86400 seconds)')
+    ).rejects.toThrow('validation_messages.cors_preflight_max_age_max')
   })
 })

--- a/admin-ui/plugins/auth-server/components/ConfigApiProperties/utils/validations.ts
+++ b/admin-ui/plugins/auth-server/components/ConfigApiProperties/utils/validations.ts
@@ -1,8 +1,13 @@
 import * as Yup from 'yup'
+import type { TFunction } from 'i18next'
 import type { ApiAppConfiguration } from '../types'
 import { LOG_LEVELS, LOG_LAYOUTS } from '../../Logging/utils'
 
-const configApiPropertiesSchemaShape: Record<keyof ApiAppConfiguration, Yup.AnySchema> = {
+const API_PROTECTION_TYPE = 'OAuth2'
+
+const getConfigApiPropertiesSchemaShape = (
+  t: TFunction,
+): Record<keyof ApiAppConfiguration, Yup.AnySchema> => ({
   serviceName: Yup.string().nullable(),
   configOauthEnabled: Yup.boolean().nullable(),
   disableLoggerTimer: Yup.boolean().nullable(),
@@ -13,22 +18,30 @@ const configApiPropertiesSchemaShape: Record<keyof ApiAppConfiguration, Yup.AnyS
   returnEncryptedClientSecretInResponse: Yup.boolean().nullable(),
   apiApprovedIssuer: Yup.array()
     .of(Yup.string())
-    .min(1, 'At least one approved issuer is required')
+    .min(1, t('validation_messages.min_one_approved_issuer'))
     .nullable(),
   apiProtectionType: Yup.string()
-    .oneOf(['OAuth2'], 'Invalid API protection type. Supported type is OAuth2')
+    .test(
+      'api-protection-type',
+      t('validation_messages.api_protection_type_invalid', { type: API_PROTECTION_TYPE }),
+      (value) => !value || value.toLowerCase() === API_PROTECTION_TYPE.toLowerCase(),
+    )
     .nullable(),
   apiClientId: Yup.string().nullable(),
   apiClientPassword: Yup.string().nullable(),
   endpointInjectionEnabled: Yup.boolean().nullable(),
-  authIssuerUrl: Yup.string().url('Invalid URL format').nullable(),
-  authOpenidConfigurationUrl: Yup.string().url('Invalid URL format').nullable(),
-  authOpenidIntrospectionUrl: Yup.string().url('Invalid URL format').nullable(),
-  authOpenidTokenUrl: Yup.string().url('Invalid URL format').nullable(),
-  authOpenidRevokeUrl: Yup.string().url('Invalid URL format').nullable(),
+  authIssuerUrl: Yup.string().url(t('validation_messages.invalid_url_format')).nullable(),
+  authOpenidConfigurationUrl: Yup.string()
+    .url(t('validation_messages.invalid_url_format'))
+    .nullable(),
+  authOpenidIntrospectionUrl: Yup.string()
+    .url(t('validation_messages.invalid_url_format'))
+    .nullable(),
+  authOpenidTokenUrl: Yup.string().url(t('validation_messages.invalid_url_format')).nullable(),
+  authOpenidRevokeUrl: Yup.string().url(t('validation_messages.invalid_url_format')).nullable(),
   exclusiveAuthScopes: Yup.array()
     .of(Yup.string())
-    .min(1, 'At least one scope is required')
+    .min(1, t('validation_messages.min_one_scope'))
     .nullable(),
   corsConfigurationFilters: Yup.array()
     .of(
@@ -47,18 +60,18 @@ const configApiPropertiesSchemaShape: Record<keyof ApiAppConfiguration, Yup.AnyS
             const num = Number(value)
             return isNaN(num) ? null : num
           })
-          .min(0, 'Must be non-negative')
-          .max(86400, 'Must not exceed 24 hours (86400 seconds)')
+          .min(0, t('validation_messages.must_be_non_negative'))
+          .max(86400, t('validation_messages.cors_preflight_max_age_max'))
           .nullable(),
         corsRequestDecorate: Yup.boolean().nullable(),
       }),
     )
     .nullable(),
   loggingLevel: Yup.string()
-    .oneOf([...LOG_LEVELS], 'Invalid logging level')
+    .oneOf([...LOG_LEVELS], t('messages.logging_level_invalid'))
     .nullable(),
   loggingLayout: Yup.string()
-    .oneOf([...LOG_LAYOUTS], 'Invalid logging layout')
+    .oneOf([...LOG_LAYOUTS], t('messages.logging_layout_invalid'))
     .nullable(),
   disableJdkLogger: Yup.boolean().nullable(),
   disableExternalLoggerConfiguration: Yup.boolean().nullable(),
@@ -70,8 +83,8 @@ const configApiPropertiesSchemaShape: Record<keyof ApiAppConfiguration, Yup.AnyS
       const num = Number(value)
       return isNaN(num) ? null : num
     })
-    .min(0, 'Must be non-negative')
-    .max(10000, 'Must not exceed 10000')
+    .min(0, t('validation_messages.must_be_non_negative'))
+    .max(10000, t('validation_messages.must_not_exceed', { max: 10000 }))
     .nullable(),
   acrExclusionList: Yup.array().of(Yup.string()).nullable(),
   userExclusionAttributes: Yup.array().of(Yup.string()).nullable(),
@@ -120,18 +133,22 @@ const configApiPropertiesSchemaShape: Record<keyof ApiAppConfiguration, Yup.AnyS
       .of(
         Yup.object({
           directory: Yup.string().nullable(),
-          type: Yup.array().of(Yup.string()).min(1, 'At least one type is required').nullable(),
+          type: Yup.array()
+            .of(Yup.string())
+            .min(1, t('validation_messages.min_one_asset_type'))
+            .nullable(),
           description: Yup.string().nullable(),
           jansServiceModule: Yup.array()
             .of(Yup.string())
-            .min(1, 'At least one service module is required')
+            .min(1, t('validation_messages.min_one_service_module'))
             .nullable(),
         }),
       )
       .nullable(),
   }).nullable(),
-}
+})
 
-export const configApiPropertiesSchema = Yup.object().shape(
-  configApiPropertiesSchemaShape,
-) as Yup.ObjectSchema<ApiAppConfiguration>
+const getConfigApiPropertiesSchema = (t: TFunction) =>
+  Yup.object().shape(getConfigApiPropertiesSchemaShape(t)) as Yup.ObjectSchema<ApiAppConfiguration>
+
+export { getConfigApiPropertiesSchema }

--- a/admin-ui/plugins/auth-server/components/Logging/__tests__/validations.test.ts
+++ b/admin-ui/plugins/auth-server/components/Logging/__tests__/validations.test.ts
@@ -1,4 +1,8 @@
-import { loggingValidationSchema } from 'Plugins/auth-server/components/Logging/validations'
+import { getLoggingValidationSchema } from 'Plugins/auth-server/components/Logging/validations'
+import type { TFunction } from 'i18next'
+
+const t = ((key: string) => key) as TFunction
+const loggingValidationSchema = getLoggingValidationSchema(t)
 
 const validValues = {
   loggingLevel: 'INFO',
@@ -32,20 +36,20 @@ describe('loggingValidationSchema', () => {
   it('rejects an unknown logging level', async () => {
     await expect(
       loggingValidationSchema.validate({ ...validValues, loggingLevel: 'VERBOSE' }),
-    ).rejects.toThrow('Invalid logging level')
+    ).rejects.toThrow('messages.logging_level_invalid')
   })
 
   it('rejects an unknown logging layout', async () => {
     await expect(
       loggingValidationSchema.validate({ ...validValues, loggingLayout: 'xml' }),
-    ).rejects.toThrow('Invalid logging layout')
+    ).rejects.toThrow('messages.logging_layout_invalid')
   })
 
   it('requires the logging level', async () => {
     const { loggingLevel, ...rest } = validValues
     void loggingLevel
     await expect(loggingValidationSchema.validate(rest)).rejects.toThrow(
-      'Logging level is required',
+      'messages.logging_level_required',
     )
   })
 
@@ -53,7 +57,7 @@ describe('loggingValidationSchema', () => {
     const { loggingLayout, ...rest } = validValues
     void loggingLayout
     await expect(loggingValidationSchema.validate(rest)).rejects.toThrow(
-      'Logging layout is required',
+      'messages.logging_layout_required',
     )
   })
 

--- a/admin-ui/plugins/auth-server/components/Logging/components/LoggingPage.tsx
+++ b/admin-ui/plugins/auth-server/components/Logging/components/LoggingPage.tsx
@@ -24,7 +24,7 @@ import { usePermission } from '@/cedarling/hooks/usePermission'
 import { ADMIN_UI_RESOURCES } from '@/cedarling/utility'
 import { useTranslation } from 'react-i18next'
 import SetTitle from 'Utils/SetTitle'
-import { loggingValidationSchema } from '../validations'
+import { getLoggingValidationSchema } from '../validations'
 import type { PendingValues } from '../types'
 import { useAppDispatch } from '@/redux/hooks'
 import { updateToast } from 'Redux/features/toastSlice'
@@ -94,6 +94,8 @@ const LoggingPage = (): React.ReactElement => {
     () => getLoggingInitialValues(logging),
     [logging],
   )
+
+  const loggingValidationSchema = useMemo(() => getLoggingValidationSchema(t), [t])
 
   const levelOptions = useMemo(
     () =>
@@ -186,6 +188,7 @@ const LoggingPage = (): React.ReactElement => {
               initialValues={initialValues}
               validationSchema={loggingValidationSchema}
               enableReinitialize
+              validateOnMount
               onSubmit={handleSubmit}
             >
               {(formik) => (
@@ -204,12 +207,8 @@ const LoggingPage = (): React.ReactElement => {
                           doc_category={JSON_CONFIG}
                           doc_entry="loggingLevel"
                           required
-                          showError={!!(formik.errors.loggingLevel && formik.touched.loggingLevel)}
-                          errorMessage={
-                            formik.errors.loggingLevel
-                              ? t(formik.errors.loggingLevel as string)
-                              : undefined
-                          }
+                          showError={!!formik.errors.loggingLevel}
+                          errorMessage={formik.errors.loggingLevel as string | undefined}
                           disabled={isMobile}
                         />
                       </div>
@@ -225,14 +224,8 @@ const LoggingPage = (): React.ReactElement => {
                           doc_category={JSON_CONFIG}
                           doc_entry="loggingLayout"
                           required
-                          showError={
-                            !!(formik.errors.loggingLayout && formik.touched.loggingLayout)
-                          }
-                          errorMessage={
-                            formik.errors.loggingLayout
-                              ? t(formik.errors.loggingLayout as string)
-                              : undefined
-                          }
+                          showError={!!formik.errors.loggingLayout}
+                          errorMessage={formik.errors.loggingLayout as string | undefined}
                           disabled={isMobile}
                         />
                       </div>

--- a/admin-ui/plugins/auth-server/components/Logging/validations.ts
+++ b/admin-ui/plugins/auth-server/components/Logging/validations.ts
@@ -1,14 +1,18 @@
 import * as Yup from 'yup'
+import type { TFunction } from 'i18next'
 import { LOG_LEVELS, LOG_LAYOUTS } from './utils'
 
-export const loggingValidationSchema = Yup.object({
-  loggingLevel: Yup.string()
-    .required('Logging level is required')
-    .oneOf([...LOG_LEVELS], 'Invalid logging level'),
-  loggingLayout: Yup.string()
-    .required('Logging layout is required')
-    .oneOf([...LOG_LAYOUTS], 'Invalid logging layout'),
-  httpLoggingEnabled: Yup.boolean().required(),
-  disableJdkLogger: Yup.boolean().required(),
-  enabledOAuthAuditLogging: Yup.boolean().required(),
-})
+const getLoggingValidationSchema = (t: TFunction) =>
+  Yup.object({
+    loggingLevel: Yup.string()
+      .required(t('messages.logging_level_required'))
+      .oneOf([...LOG_LEVELS], t('messages.logging_level_invalid')),
+    loggingLayout: Yup.string()
+      .required(t('messages.logging_layout_required'))
+      .oneOf([...LOG_LAYOUTS], t('messages.logging_layout_invalid')),
+    httpLoggingEnabled: Yup.boolean().required(),
+    disableJdkLogger: Yup.boolean().required(),
+    enabledOAuthAuditLogging: Yup.boolean().required(),
+  })
+
+export { getLoggingValidationSchema }

--- a/admin-ui/plugins/fido/__tests__/helper/validations.test.ts
+++ b/admin-ui/plugins/fido/__tests__/helper/validations.test.ts
@@ -2,8 +2,13 @@ import {
   isLastKeyValueComplete,
   isLastStringEntryComplete,
   isLastMetadataServerComplete,
-  validationSchema,
+  getFidoValidationSchemas,
 } from 'Plugins/fido/helper/validations'
+
+import type { TFunction } from 'i18next'
+
+const t = ((key: string) => key) as TFunction
+const validationSchema = getFidoValidationSchemas(t)
 
 describe('fido validations', () => {
   describe('isLastKeyValueComplete', () => {

--- a/admin-ui/plugins/fido/components/Configuration/components/DynamicConfiguration.tsx
+++ b/admin-ui/plugins/fido/components/Configuration/components/DynamicConfiguration.tsx
@@ -18,7 +18,7 @@ import { THEME_DARK } from '@/context/theme/constants'
 
 import {
   fidoConstants,
-  validationSchema,
+  getFidoValidationSchemas,
   transformToFormValues,
   buildChangedFieldOperations,
   isLastStringEntryComplete,
@@ -59,10 +59,12 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
     [fidoConfiguration],
   )
 
+  const fidoValidationSchemas = useMemo(() => getFidoValidationSchemas(t), [t])
+
   const formik = useFormik<DynamicConfigFormValues>({
     initialValues,
     onSubmit: readOnly ? () => undefined : toggle,
-    validationSchema: validationSchema[fidoConstants.VALIDATION_SCHEMAS.DYNAMIC_CONFIG],
+    validationSchema: fidoValidationSchemas.dynamicConfigValidationSchema,
     validateOnMount: true,
   })
 
@@ -73,12 +75,12 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
       const snapshot = JSON.stringify(fidoConfiguration)
       if (snapshot !== configSnapshot.current) {
         configSnapshot.current = snapshot
-        formik.resetForm({
-          values: transformToFormValues(
-            fidoConfiguration,
-            fidoConstants.DYNAMIC,
-          ) as DynamicConfigFormValues,
-        })
+        const nextValues = transformToFormValues(
+          fidoConfiguration,
+          fidoConstants.DYNAMIC,
+        ) as DynamicConfigFormValues
+        formik.resetForm({ values: nextValues })
+        void formik.validateForm(nextValues)
       }
     }
   }, [fidoConfiguration])
@@ -411,9 +413,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
                   </GluuButton>
                 </div>
               ))}
-              {showObjectClassError && (
-                <div className={classes.propsError}>{t(objectClassError as string)}</div>
-              )}
+              {showObjectClassError && <div className={classes.propsError}>{objectClassError}</div>}
             </div>
           </div>
         </div>

--- a/admin-ui/plugins/fido/components/Configuration/components/StaticConfiguration.tsx
+++ b/admin-ui/plugins/fido/components/Configuration/components/StaticConfiguration.tsx
@@ -19,7 +19,7 @@ import getThemeColor from '@/context/theme/config'
 import { THEME_DARK } from '@/context/theme/constants'
 
 import {
-  validationSchema,
+  getFidoValidationSchemas,
   transformToFormValues,
   buildChangedFieldOperations,
   fidoConstants,
@@ -65,10 +65,12 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
     fidoConstants.STATIC,
   ) as StaticConfigFormValues
 
+  const fidoValidationSchemas = useMemo(() => getFidoValidationSchemas(t), [t])
+
   const formik = useFormik<StaticConfigFormValues>({
     initialValues,
     onSubmit: readOnly ? () => undefined : toggle,
-    validationSchema: validationSchema[fidoConstants.VALIDATION_SCHEMAS.STATIC_CONFIG],
+    validationSchema: fidoValidationSchemas.staticConfigValidationSchema,
     validateOnMount: true,
   })
 
@@ -79,12 +81,12 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
       const snapshot = JSON.stringify(fidoConfiguration.fido2Configuration)
       if (snapshot !== configSnapshot.current) {
         configSnapshot.current = snapshot
-        formik.resetForm({
-          values: transformToFormValues(
-            fidoConfiguration.fido2Configuration,
-            fidoConstants.STATIC,
-          ) as StaticConfigFormValues,
-        })
+        const nextValues = transformToFormValues(
+          fidoConfiguration.fido2Configuration,
+          fidoConstants.STATIC,
+        ) as StaticConfigFormValues
+        formik.resetForm({ values: nextValues })
+        void formik.validateForm(nextValues)
       }
     }
   }, [fidoConfiguration])
@@ -423,9 +425,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
                   </GluuButton>
                 </div>
               ))}
-              {showPartiesError && (
-                <div className={classes.propsError}>{t(partiesError as string)}</div>
-              )}
+              {showPartiesError && <div className={classes.propsError}>{partiesError}</div>}
             </div>
           </div>
 
@@ -477,9 +477,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
                   </GluuButton>
                 </div>
               ))}
-              {showAlgorithmsError && (
-                <div className={classes.propsError}>{t(algorithmsError as string)}</div>
-              )}
+              {showAlgorithmsError && <div className={classes.propsError}>{algorithmsError}</div>}
             </div>
           </div>
 
@@ -539,9 +537,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
                   </GluuButton>
                 </div>
               ))}
-              {showServersError && (
-                <div className={classes.propsError}>{t(serversError as string)}</div>
-              )}
+              {showServersError && <div className={classes.propsError}>{serversError}</div>}
             </div>
           </div>
 

--- a/admin-ui/plugins/fido/helper/index.ts
+++ b/admin-ui/plugins/fido/helper/index.ts
@@ -1,5 +1,5 @@
 export {
-  validationSchema,
+  getFidoValidationSchemas,
   isLastKeyValueComplete,
   isLastStringEntryComplete,
   isLastMetadataServerComplete,

--- a/admin-ui/plugins/fido/helper/validations.ts
+++ b/admin-ui/plugins/fido/helper/validations.ts
@@ -1,5 +1,8 @@
 import * as Yup from 'yup'
+import type { TFunction } from 'i18next'
 import { PublicKeyCredentialHints, AttestationMode } from '../types'
+import type { FidoValidationSchemas } from '../types'
+import { fidoConstants } from './constants'
 
 export const isLastKeyValueComplete = (items: Array<{ key?: string; value?: string }>): boolean => {
   if (items.length === 0) return true
@@ -25,100 +28,107 @@ const EMPTY_ROW_KEY_VALUE_MSG = 'errors.fido_empty_row_key_value'
 const EMPTY_ROW_VALUE_MSG = 'errors.fido_empty_row_value'
 const EMPTY_ROW_METADATA_SERVER_MSG = 'errors.fido_empty_row_metadata_server'
 
-const dynamicConfigValidationSchema = Yup.object({
-  issuer: Yup.string().required('Issuer is required.'),
-  baseEndpoint: Yup.string().required('Base Endpoint is required.'),
-  cleanServiceInterval: Yup.number()
-    .typeError('Clean Service Interval must be a number.')
-    .required('Clean Service Interval is required.'),
-  cleanServiceBatchChunkSize: Yup.number()
-    .typeError('Clean Service Batch Chunk Size must be a number.')
-    .required('Clean Service Batch Chunk Size is required.'),
-  useLocalCache: Yup.boolean().required('Use Local Cache is required.'),
-  disableJdkLogger: Yup.boolean().required('Disable JDK Logger is required.'),
-  loggingLevel: Yup.string().required('Logging Level is required.'),
-  loggingLayout: Yup.string().required('Logging Layout is required.'),
-  metricReporterEnabled: Yup.boolean().required('Metric Reporter Enabled is required.'),
-  metricReporterInterval: Yup.number()
-    .typeError('Metric Reporter Interval must be a number.')
-    .required('Metric Reporter Interval is required.'),
-  metricReporterKeepDataDays: Yup.number()
-    .typeError('Metric Reporter Keep Data Days must be a number.')
-    .required('Metric Reporter Keep Data Days is required.'),
-  personCustomObjectClassList: Yup.array()
-    .of(Yup.string())
-    .test('no-empty-entries', EMPTY_ROW_VALUE_MSG, (items) => {
-      if (!items || items.length === 0) return true
-      return items.every((item) => Boolean((item ?? '').trim()))
-    }),
-  fido2MetricsEnabled: Yup.boolean().required('FIDO2 Metrics Enabled is required.'),
-  fido2MetricsRetentionDays: Yup.number()
-    .typeError('FIDO2 Metrics Retention Days must be a number.')
-    .required('FIDO2 Metrics Retention Days is required.'),
-  fido2DeviceInfoCollection: Yup.boolean().required('FIDO2 Device Info Collection is required.'),
-  fido2ErrorCategorization: Yup.boolean().required('FIDO2 Error Categorization is required.'),
-  fido2PerformanceMetrics: Yup.boolean().required('FIDO2 Performance Metrics is required.'),
-})
+const L = fidoConstants.LABELS
 
-const staticConfigValidationSchema = Yup.object({
-  authenticatorCertsFolder: Yup.string().required('Authenticator Certificates Folder is required.'),
-  mdsCertsFolder: Yup.string().required('MDS TOC Certificates Folder is required.'),
-  mdsTocsFolder: Yup.string().required('MDS TOC Files Folder is required.'),
-  unfinishedRequestExpiration: Yup.number()
-    .typeError('Unfinished Request Expiration must be a number.')
-    .required('Unfinished Request Expiration is required.'),
-  authenticationHistoryExpiration: Yup.number()
-    .typeError('Authentication History Expiration must be a number.')
-    .required('Authentication History Expiration is required.'),
-  serverMetadataFolder: Yup.string().required('Server Metadata is required.'),
-  userAutoEnrollment: Yup.boolean().required('User Auto Enrollment is required.'),
-  requestedParties: Yup.array()
-    .of(
-      Yup.object().shape({
-        key: Yup.string().nullable(),
-        value: Yup.string().nullable(),
-      }),
-    )
-    .test('no-empty-parties', EMPTY_ROW_KEY_VALUE_MSG, (items) => {
-      if (!items || items.length === 0) return true
-      return items.every(
-        (item) => Boolean((item?.key ?? '').trim()) && Boolean((item?.value ?? '').trim()),
-      )
-    }),
-  enabledFidoAlgorithms: Yup.array()
-    .of(Yup.string())
-    .test('no-empty-algorithms', EMPTY_ROW_VALUE_MSG, (items) => {
-      if (!items || items.length === 0) return true
-      return items.every((item) => Boolean((item ?? '').trim()))
-    }),
-  metadataServers: Yup.array()
-    .of(
-      Yup.object().shape({
-        url: Yup.string().nullable(),
-        rootCert: Yup.string().nullable(),
-      }),
-    )
-    .test('no-empty-servers', EMPTY_ROW_METADATA_SERVER_MSG, (items) => {
-      if (!items || items.length === 0) return true
-      return items.every(
-        (item) => Boolean((item?.url ?? '').trim()) && Boolean((item?.rootCert ?? '').trim()),
-      )
-    }),
-  disableMetadataService: Yup.boolean().required('Disable Metadata Service is required.'),
-  hints: Yup.array()
-    .of(Yup.string().oneOf(Object.values(PublicKeyCredentialHints), 'Invalid hint value.'))
-    .min(1, 'At least one hint is required.')
-    .required('Hints are required.'),
-  enterpriseAttestation: Yup.boolean().required('Enterprise Attestation is required.'),
-  attestationMode: Yup.string()
-    .oneOf(Object.values(AttestationMode), 'Invalid attestation mode.')
-    .required('Attestation Mode is required.'),
-})
+const getFidoValidationSchemas = (t: TFunction): FidoValidationSchemas => {
+  const required = (label: string) => t('validation_messages.field_required', { field: t(label) })
+  const numeric = (label: string) =>
+    t('validation_messages.field_must_be_number', { field: t(label) })
+  const invalid = (label: string) =>
+    t('validation_messages.field_invalid_value', { field: t(label) })
+  const minItems = (label: string) => t('validation_messages.field_min_items', { field: t(label) })
 
-export const validationSchema: {
-  dynamicConfigValidationSchema: typeof dynamicConfigValidationSchema
-  staticConfigValidationSchema: typeof staticConfigValidationSchema
-} = {
-  dynamicConfigValidationSchema,
-  staticConfigValidationSchema,
+  const dynamicConfigValidationSchema = Yup.object({
+    issuer: Yup.string().required(required(L.ISSUER)),
+    baseEndpoint: Yup.string().required(required(L.BASE_ENDPOINT)),
+    cleanServiceInterval: Yup.number()
+      .typeError(numeric(L.CLEAN_SERVICE_INTERVAL))
+      .required(required(L.CLEAN_SERVICE_INTERVAL)),
+    cleanServiceBatchChunkSize: Yup.number()
+      .typeError(numeric(L.CLEAN_SERVICE_BATCH_CHUNK))
+      .required(required(L.CLEAN_SERVICE_BATCH_CHUNK)),
+    useLocalCache: Yup.boolean().required(required(L.USE_LOCAL_CACHE)),
+    disableJdkLogger: Yup.boolean().required(required(L.DISABLE_JDK_LOGGER)),
+    loggingLevel: Yup.string().required(required(L.LOGGING_LEVEL)),
+    loggingLayout: Yup.string().required(required(L.LOGGING_LAYOUT)),
+    metricReporterEnabled: Yup.boolean().required(required(L.METRIC_REPORTER_ENABLED)),
+    metricReporterInterval: Yup.number()
+      .typeError(numeric(L.METRIC_REPORTER_INTERVAL))
+      .required(required(L.METRIC_REPORTER_INTERVAL)),
+    metricReporterKeepDataDays: Yup.number()
+      .typeError(numeric(L.METRIC_REPORTER_KEEP_DATA_DAYS))
+      .required(required(L.METRIC_REPORTER_KEEP_DATA_DAYS)),
+    personCustomObjectClassList: Yup.array()
+      .of(Yup.string())
+      .test('no-empty-entries', t(EMPTY_ROW_VALUE_MSG), (items) => {
+        if (!items || items.length === 0) return true
+        return items.every((item) => Boolean((item ?? '').trim()))
+      }),
+    fido2MetricsEnabled: Yup.boolean().required(required(L.FIDO2_METRICS_ENABLED)),
+    fido2MetricsRetentionDays: Yup.number()
+      .typeError(numeric(L.FIDO2_METRICS_RETENTION_DAYS))
+      .required(required(L.FIDO2_METRICS_RETENTION_DAYS)),
+    fido2DeviceInfoCollection: Yup.boolean().required(required(L.FIDO2_DEVICE_INFO_COLLECTION)),
+    fido2ErrorCategorization: Yup.boolean().required(required(L.FIDO2_ERROR_CATEGORIZATION)),
+    fido2PerformanceMetrics: Yup.boolean().required(required(L.FIDO2_PERFORMANCE_METRICS)),
+  })
+
+  const staticConfigValidationSchema = Yup.object({
+    authenticatorCertsFolder: Yup.string().required(required(L.AUTHENTICATOR_CERTIFICATES_FOLDER)),
+    mdsCertsFolder: Yup.string().required(required(L.MDS_TOC_CERTIFICATES_FOLDER)),
+    mdsTocsFolder: Yup.string().required(required(L.MDS_TOC_FILES_FOLDER)),
+    unfinishedRequestExpiration: Yup.number()
+      .typeError(numeric(L.UNFINISHED_REQUEST_EXPIRATION))
+      .required(required(L.UNFINISHED_REQUEST_EXPIRATION)),
+    authenticationHistoryExpiration: Yup.number()
+      .typeError(numeric(L.AUTHENTICATION_HISTORY_EXPIRATION))
+      .required(required(L.AUTHENTICATION_HISTORY_EXPIRATION)),
+    serverMetadataFolder: Yup.string().required(required(L.SERVER_METADATA_FOLDER)),
+    userAutoEnrollment: Yup.boolean().required(required(L.USER_AUTO_ENROLLMENT)),
+    requestedParties: Yup.array()
+      .of(
+        Yup.object().shape({
+          key: Yup.string().nullable(),
+          value: Yup.string().nullable(),
+        }),
+      )
+      .test('no-empty-parties', t(EMPTY_ROW_KEY_VALUE_MSG), (items) => {
+        if (!items || items.length === 0) return true
+        return items.every(
+          (item) => Boolean((item?.key ?? '').trim()) && Boolean((item?.value ?? '').trim()),
+        )
+      }),
+    enabledFidoAlgorithms: Yup.array()
+      .of(Yup.string())
+      .test('no-empty-algorithms', t(EMPTY_ROW_VALUE_MSG), (items) => {
+        if (!items || items.length === 0) return true
+        return items.every((item) => Boolean((item ?? '').trim()))
+      }),
+    metadataServers: Yup.array()
+      .of(
+        Yup.object().shape({
+          url: Yup.string().nullable(),
+          rootCert: Yup.string().nullable(),
+        }),
+      )
+      .test('no-empty-servers', t(EMPTY_ROW_METADATA_SERVER_MSG), (items) => {
+        if (!items || items.length === 0) return true
+        return items.every(
+          (item) => Boolean((item?.url ?? '').trim()) && Boolean((item?.rootCert ?? '').trim()),
+        )
+      }),
+    disableMetadataService: Yup.boolean().required(required(L.DISABLE_METADATA_SERVICE)),
+    hints: Yup.array()
+      .of(Yup.string().oneOf(Object.values(PublicKeyCredentialHints), invalid(L.HINTS)))
+      .min(1, minItems(L.HINTS))
+      .required(required(L.HINTS)),
+    enterpriseAttestation: Yup.boolean().required(required(L.ENTERPRISE_ATTESTATION)),
+    attestationMode: Yup.string()
+      .oneOf(Object.values(AttestationMode), invalid(L.ATTESTATION_MODE))
+      .required(required(L.ATTESTATION_MODE)),
+  })
+
+  return { dynamicConfigValidationSchema, staticConfigValidationSchema }
 }
+
+export { getFidoValidationSchemas }

--- a/admin-ui/plugins/fido/types/fido.ts
+++ b/admin-ui/plugins/fido/types/fido.ts
@@ -1,3 +1,4 @@
+import type { AnyObject, ObjectSchema } from 'yup'
 import { AppConfiguration1 } from 'JansConfigApi'
 
 // Form values for Dynamic Configuration
@@ -75,3 +76,8 @@ export type FidoFormValuePrimitive =
   | string[]
   | Array<{ key: string; value: string }>
   | Array<{ url: string; rootCert: string }>
+
+export type FidoValidationSchemas = {
+  dynamicConfigValidationSchema: ObjectSchema<AnyObject>
+  staticConfigValidationSchema: ObjectSchema<AnyObject>
+}

--- a/admin-ui/plugins/jans-lock/components/JansLockConfiguration.tsx
+++ b/admin-ui/plugins/jans-lock/components/JansLockConfiguration.tsx
@@ -46,6 +46,7 @@ const JansLockConfiguration: React.FC<JansLockConfigurationProps> = ({
     enableReinitialize: true,
     onSubmit: () => toggle(),
     validationSchema,
+    validateOnMount: true,
   })
 
   const handleCancel = useCallback(() => {

--- a/admin-ui/plugins/jans-lock/components/JansLockFieldRenderer.tsx
+++ b/admin-ui/plugins/jans-lock/components/JansLockFieldRenderer.tsx
@@ -23,14 +23,13 @@ const JansLockFieldRenderer: React.FC<JansLockFieldRendererProps> = ({
 
   const value = formik.values[name]
   const error = formik.errors[name]
-  const touched = formik.touched[name]
 
   const itemClass = useMemo(
     () => (colSize === 12 ? fieldItemFullWidthClass : fieldItemClass),
     [colSize, fieldItemFullWidthClass, fieldItemClass],
   )
   const isDisabled = useMemo(() => disabled || viewOnly, [disabled, viewOnly])
-  const showError = useMemo(() => !!(error && touched), [error, touched])
+  const showError = useMemo(() => !!error, [error])
   const resolvedPlaceholder = useMemo(
     () => (placeholder ? t(placeholder) : undefined),
     [placeholder, t],

--- a/admin-ui/plugins/saml/__tests__/validations.test.ts
+++ b/admin-ui/plugins/saml/__tests__/validations.test.ts
@@ -1,6 +1,6 @@
 import type { TFunction } from 'i18next'
 import {
-  samlConfigurationValidationSchema,
+  getSamlConfigurationValidationSchema,
   websiteSsoIdentityProviderValidationSchema,
   websiteSsoServiceProviderValidationSchema,
 } from 'Plugins/saml/helper/validations'
@@ -8,6 +8,8 @@ import {
 // The factory schemas only use t() to build message strings; echo the key so
 // assertions match on identity. Interpolated fields render as "<key> is Required!".
 const t = ((key: string) => key) as TFunction
+
+const samlConfigurationValidationSchema = getSamlConfigurationValidationSchema(t)
 
 describe('samlConfigurationValidationSchema', () => {
   it('accepts a disabled configuration without a selected IdP', async () => {
@@ -19,7 +21,7 @@ describe('samlConfigurationValidationSchema', () => {
   it('requires a selected IdP when SAML is enabled', async () => {
     await expect(
       samlConfigurationValidationSchema.validate({ enabled: true, selectedIdp: '' }),
-    ).rejects.toThrow('Selected IdP is required when SAML is enabled.')
+    ).rejects.toThrow('validation_messages.field_required')
   })
 
   it('accepts an enabled configuration with a selected IdP', async () => {
@@ -90,7 +92,7 @@ describe('websiteSsoServiceProviderValidationSchema', () => {
 
   it('requires the metadata source type', async () => {
     await expect(schema.validate({ ...validSp, spMetaDataSourceType: '' })).rejects.toThrow(
-      'fields.metadata_location is Required!',
+      'validation_messages.field_required',
     )
   })
 

--- a/admin-ui/plugins/saml/components/SamlConfigurationForm.tsx
+++ b/admin-ui/plugins/saml/components/SamlConfigurationForm.tsx
@@ -12,7 +12,7 @@ import SetTitle from 'Utils/SetTitle'
 import { adminUiFeatures } from '@/constants'
 import { ADMIN_UI_RESOURCES } from '@/cedarling/utility'
 import { useStyles } from './styles/SamlPage.style'
-import { samlConfigurationValidationSchema, transformToFormValues } from '../helper'
+import { getSamlConfigurationValidationSchema, transformToFormValues } from '../helper'
 import { updateToast } from 'Redux/features/toastSlice'
 import { useSamlConfiguration, useUpdateSamlConfiguration } from './hooks'
 import type { SamlConfigurationFormValues } from '../types'
@@ -39,6 +39,11 @@ const SamlConfigurationForm: React.FC = () => {
   }, [])
 
   const initialValues = useMemo(() => transformToFormValues(configuration), [configuration])
+
+  const samlConfigurationValidationSchema = useMemo(
+    () => getSamlConfigurationValidationSchema(t),
+    [t],
+  )
 
   const formik = useFormik<SamlConfigurationFormValues>({
     initialValues,

--- a/admin-ui/plugins/saml/components/SamlConfigurationForm.tsx
+++ b/admin-ui/plugins/saml/components/SamlConfigurationForm.tsx
@@ -146,6 +146,8 @@ const SamlConfigurationForm: React.FC = () => {
                   value={formik.values.selectedIdp}
                   onChange={formik.handleChange}
                   onBlur={formik.handleBlur}
+                  invalid={Boolean(formik.errors.selectedIdp)}
+                  error={formik.errors.selectedIdp}
                 >
                   <option value="">{t('Choose')}...</option>
                   <option value="keycloak">Keycloak</option>

--- a/admin-ui/plugins/saml/helper/index.ts
+++ b/admin-ui/plugins/saml/helper/index.ts
@@ -1,6 +1,6 @@
 export { nameIDPolicyFormat } from './constants'
 export {
-  samlConfigurationValidationSchema,
+  getSamlConfigurationValidationSchema,
   websiteSsoIdentityProviderValidationSchema,
   websiteSsoServiceProviderValidationSchema,
 } from './validations'

--- a/admin-ui/plugins/saml/helper/validations.ts
+++ b/admin-ui/plugins/saml/helper/validations.ts
@@ -8,26 +8,30 @@ import type {
   WebsiteSsoServiceProviderFormValues,
 } from '../types'
 
-export const samlConfigurationValidationSchema: Yup.ObjectSchema<SamlConfigurationFormValues> =
-  Yup.object({
-    enabled: Yup.boolean().required('Enabled field is required.'),
+export const getSamlConfigurationValidationSchema = (
+  t: TFunction,
+): Yup.ObjectSchema<SamlConfigurationFormValues> => {
+  const required = (label: string) => t('validation_messages.field_required', { field: t(label) })
+
+  return Yup.object({
+    enabled: Yup.boolean().required(required('fields.enabled')),
     selectedIdp: Yup.string().when('enabled', {
       is: true,
       then: (schema) =>
-        schema
-          .required('Selected IdP is required when SAML is enabled.')
-          .min(1, 'Selected IdP cannot be empty when SAML is enabled.'),
+        schema.required(required('fields.selected_idp')).min(1, required('fields.selected_idp')),
       otherwise: (schema) => schema,
     }),
     ignoreValidation: Yup.boolean(),
     applicationName: Yup.string(),
   }) as Yup.ObjectSchema<SamlConfigurationFormValues>
+}
 
 // Helper function to create required field when metadata file is not imported
 const requiredWhenMetadataNotImported = (t: TFunction, fieldKey: string) =>
   Yup.string().when('metaDataFileImportedFlag', {
     is: (value: boolean) => value === false,
-    then: () => Yup.string().required(`${t(fieldKey)} is Required!`),
+    then: () =>
+      Yup.string().required(t('validation_messages.field_required', { field: t(fieldKey) })),
     otherwise: () => Yup.string(),
   })
 
@@ -61,9 +65,11 @@ export const websiteSsoIdentityProviderValidationSchema = (
   t: TFunction,
 ): Yup.ObjectSchema<WebsiteSsoIdentityProviderFormValues> =>
   Yup.object().shape({
-    name: noSpacesValidation(t, 'fields.name').required(`${t('fields.name')} is Required!`),
+    name: noSpacesValidation(t, 'fields.name').required(
+      t('validation_messages.field_required', { field: t('fields.name') }),
+    ),
     displayName: noSpacesValidation(t, 'fields.displayName').required(
-      `${t('fields.displayName')} is Required!`,
+      t('validation_messages.field_required', { field: t('fields.displayName') }),
     ),
     description: Yup.string().nullable(),
     enabled: Yup.boolean().required(),
@@ -106,7 +112,9 @@ export const websiteSsoIdentityProviderValidationSchema = (
       .when('metaDataFileImportedFlag', ([value], schema) =>
         value === false
           ? schema
-              .required(`${t('fields.idp_entity_id')} is Required!`)
+              .required(
+                t('validation_messages.field_required', { field: t('fields.idp_entity_id') }),
+              )
               .test(
                 'not-empty',
                 t('errors.cannot_be_empty', { field: t('fields.idp_entity_id') }),
@@ -133,28 +141,36 @@ export const websiteSsoIdentityProviderValidationSchema = (
 const requiredWhenManualTest = (t: TFunction, fieldKey: string) =>
   Yup.string()
     .nullable()
-    .test('required-when-manual', `${t(fieldKey)} is Required!`, function (value) {
-      // Access parent form values through Yup's context
-      const parent = this.from?.[1]?.value as { spMetaDataSourceType?: string } | undefined
-      const isManual = parent?.spMetaDataSourceType?.toLowerCase() === 'manual'
-      if (isManual && (!value || value.trim() === '')) {
-        return false
-      }
-      return true
-    })
+    .test(
+      'required-when-manual',
+      t('validation_messages.field_required', { field: t(fieldKey) }),
+      function (value) {
+        // Access parent form values through Yup's context
+        const parent = this.from?.[1]?.value as { spMetaDataSourceType?: string } | undefined
+        const isManual = parent?.spMetaDataSourceType?.toLowerCase() === 'manual'
+        if (isManual && (!value || value.trim() === '')) {
+          return false
+        }
+        return true
+      },
+    )
 
 export const websiteSsoServiceProviderValidationSchema = (
   t: TFunction,
 ): Yup.ObjectSchema<WebsiteSsoServiceProviderFormValues> =>
   Yup.object().shape({
     displayName: noSpacesValidation(t, 'fields.displayName').required(
-      `${t('fields.displayName')} is Required!`,
+      t('validation_messages.field_required', { field: t('fields.displayName') }),
     ),
-    name: noSpacesValidation(t, 'fields.name').required(`${t('fields.name')} is Required!`),
+    name: noSpacesValidation(t, 'fields.name').required(
+      t('validation_messages.field_required', { field: t('fields.name') }),
+    ),
     spLogoutURL: Yup.string()
       .nullable()
       .concat(urlValidation(t, 'fields.service_provider_logout_url')),
-    spMetaDataSourceType: Yup.string().required(`${t('fields.metadata_location')} is Required!`),
+    spMetaDataSourceType: Yup.string().required(
+      t('validation_messages.field_required', { field: t('fields.metadata_location') }),
+    ),
     metaDataFileImportedFlag: Yup.boolean(),
     metaDataFile: Yup.mixed().when('spMetaDataSourceType', {
       is: (val: string) => val?.toLowerCase() === 'file',

--- a/admin-ui/plugins/scim/components/ScimConfiguration.tsx
+++ b/admin-ui/plugins/scim/components/ScimConfiguration.tsx
@@ -48,6 +48,7 @@ const ScimConfiguration: React.FC<ScimConfigurationProps> = ({
     initialValues: initialFormValues,
     validationSchema,
     onSubmit: toggle,
+    validateOnMount: true,
     enableReinitialize: true,
   })
 

--- a/admin-ui/plugins/scim/components/ScimFieldRenderer.tsx
+++ b/admin-ui/plugins/scim/components/ScimFieldRenderer.tsx
@@ -31,15 +31,13 @@ const ScimFieldRenderer: React.FC<ScimFieldRendererProps> = ({
 
   const value = formik.values[name]
   const error = formik.errors[name]
-  const touched = formik.touched[name]
 
   const fieldPlaceholder = useMemo(() => getFieldPlaceholder(t, label), [t, label])
   const itemClass = useMemo(
     () => (colSize === 12 ? fieldItemFullWidthClass : fieldItemClass),
     [colSize, fieldItemFullWidthClass, fieldItemClass],
   )
-  const showError = useMemo(() => !!(error && touched), [error, touched])
-
+  const showError = useMemo(() => !!error, [error])
   const stableOptions = useMemo(
     () => (selectOptions ? [...selectOptions] : EMPTY_OPTIONS),
     [selectOptions],

--- a/admin-ui/plugins/services/__tests__/components/CachePage.test.tsx
+++ b/admin-ui/plugins/services/__tests__/components/CachePage.test.tsx
@@ -52,6 +52,16 @@ const mockNativeConfig = {
 }
 
 jest.mock('JansConfigApi', () => ({
+  RedisConfigurationRedisProviderType: {
+    STANDALONE: 'STANDALONE',
+    CLUSTER: 'CLUSTER',
+    SHARDED: 'SHARDED',
+    SENTINEL: 'SENTINEL',
+  },
+  MemcachedConfigurationConnectionFactoryType: {
+    DEFAULT: 'DEFAULT',
+    BINARY: 'BINARY',
+  },
   useGetConfigCache: jest.fn(() => ({
     data: { cacheProviderType: 'IN_MEMORY' },
     isLoading: false,

--- a/admin-ui/plugins/services/__tests__/helper/constants.test.ts
+++ b/admin-ui/plugins/services/__tests__/helper/constants.test.ts
@@ -1,66 +1,66 @@
 import {
-  CACHE_PROVIDER_OPTIONS,
-  REDIS_PROVIDER_OPTIONS,
-  CONNECTION_FACTORY_OPTIONS,
+  getCacheProviderOptions,
+  getRedisProviderOptions,
+  getConnectionFactoryOptions,
 } from 'Plugins/services/helper/constants'
 
-describe('CACHE_PROVIDER_OPTIONS', () => {
+describe('getCacheProviderOptions', () => {
   it('has exactly 4 options', () => {
-    expect(CACHE_PROVIDER_OPTIONS).toHaveLength(4)
+    expect(getCacheProviderOptions()).toHaveLength(4)
   })
 
   it('contains IN_MEMORY option', () => {
-    expect(CACHE_PROVIDER_OPTIONS).toContainEqual({ value: 'IN_MEMORY', label: 'In Memory' })
+    expect(getCacheProviderOptions()).toContainEqual({ value: 'IN_MEMORY', label: 'In Memory' })
   })
 
   it('contains MEMCACHED option', () => {
-    expect(CACHE_PROVIDER_OPTIONS).toContainEqual({ value: 'MEMCACHED', label: 'Memcached' })
+    expect(getCacheProviderOptions()).toContainEqual({ value: 'MEMCACHED', label: 'Memcached' })
   })
 
   it('contains REDIS option', () => {
-    expect(CACHE_PROVIDER_OPTIONS).toContainEqual({ value: 'REDIS', label: 'Redis' })
+    expect(getCacheProviderOptions()).toContainEqual({ value: 'REDIS', label: 'Redis' })
   })
 
   it('contains NATIVE_PERSISTENCE option', () => {
-    expect(CACHE_PROVIDER_OPTIONS).toContainEqual({
+    expect(getCacheProviderOptions()).toContainEqual({
       value: 'NATIVE_PERSISTENCE',
       label: 'Native Persistence',
     })
   })
 })
 
-describe('REDIS_PROVIDER_OPTIONS', () => {
+describe('getRedisProviderOptions', () => {
   it('has exactly 4 options', () => {
-    expect(REDIS_PROVIDER_OPTIONS).toHaveLength(4)
+    expect(getRedisProviderOptions()).toHaveLength(4)
   })
 
   it('contains STANDALONE option', () => {
-    expect(REDIS_PROVIDER_OPTIONS).toContainEqual({ value: 'STANDALONE', label: 'Standalone' })
+    expect(getRedisProviderOptions()).toContainEqual({ value: 'STANDALONE', label: 'Standalone' })
   })
 
   it('contains CLUSTER option', () => {
-    expect(REDIS_PROVIDER_OPTIONS).toContainEqual({ value: 'CLUSTER', label: 'Cluster' })
+    expect(getRedisProviderOptions()).toContainEqual({ value: 'CLUSTER', label: 'Cluster' })
   })
 
   it('contains SHARDED option', () => {
-    expect(REDIS_PROVIDER_OPTIONS).toContainEqual({ value: 'SHARDED', label: 'Sharded' })
+    expect(getRedisProviderOptions()).toContainEqual({ value: 'SHARDED', label: 'Sharded' })
   })
 
   it('contains SENTINEL option', () => {
-    expect(REDIS_PROVIDER_OPTIONS).toContainEqual({ value: 'SENTINEL', label: 'Sentinel' })
+    expect(getRedisProviderOptions()).toContainEqual({ value: 'SENTINEL', label: 'Sentinel' })
   })
 })
 
-describe('CONNECTION_FACTORY_OPTIONS', () => {
+describe('getConnectionFactoryOptions', () => {
   it('has exactly 2 options', () => {
-    expect(CONNECTION_FACTORY_OPTIONS).toHaveLength(2)
+    expect(getConnectionFactoryOptions()).toHaveLength(2)
   })
 
   it('contains DEFAULT option', () => {
-    expect(CONNECTION_FACTORY_OPTIONS).toContainEqual({ value: 'DEFAULT', label: 'Default' })
+    expect(getConnectionFactoryOptions()).toContainEqual({ value: 'DEFAULT', label: 'Default' })
   })
 
   it('contains BINARY option', () => {
-    expect(CONNECTION_FACTORY_OPTIONS).toContainEqual({ value: 'BINARY', label: 'Binary' })
+    expect(getConnectionFactoryOptions()).toContainEqual({ value: 'BINARY', label: 'Binary' })
   })
 })

--- a/admin-ui/plugins/services/components/CacheMemcached.tsx
+++ b/admin-ui/plugins/services/components/CacheMemcached.tsx
@@ -1,13 +1,16 @@
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import GluuInputRow from 'Routes/Apps/Gluu/GluuInputRow'
 import GluuSelectRow from 'Routes/Apps/Gluu/GluuSelectRow'
 import { CACHE } from 'Utils/ApiResources'
 import { getFieldPlaceholder } from '@/utils/placeholderUtils'
 import type { CacheMemcachedProps } from './types'
-import { CONNECTION_FACTORY_OPTIONS } from '../helper'
+import { getConnectionFactoryOptions } from '../helper'
 
 const CacheMemcached = ({ formik, classes, isDark, disabled }: CacheMemcachedProps) => {
   const { t } = useTranslation()
+
+  const connectionFactoryOptions = useMemo(() => getConnectionFactoryOptions(), [])
   return (
     <div className={classes.sectionGrid}>
       <div className={classes.fieldItem}>
@@ -31,7 +34,7 @@ const CacheMemcached = ({ formik, classes, isDark, disabled }: CacheMemcachedPro
           name="connectionFactoryType"
           value={formik.values.connectionFactoryType || ''}
           formik={formik}
-          values={CONNECTION_FACTORY_OPTIONS}
+          values={connectionFactoryOptions}
           lsize={12}
           rsize={12}
           doc_category={CACHE}

--- a/admin-ui/plugins/services/components/CachePage.tsx
+++ b/admin-ui/plugins/services/components/CachePage.tsx
@@ -53,7 +53,7 @@ import {
   isRedisCache,
   isNativePersistenceCache,
   buildCacheChangedFieldOperations,
-  CACHE_PROVIDER_OPTIONS,
+  getCacheProviderOptions,
 } from '../helper'
 import { useStyles } from './styles/CachePage.style'
 import { queryDefaults } from '@/utils/queryUtils'
@@ -73,6 +73,8 @@ const PROVIDER_SECTIONS: Record<
 
 const CachePage: React.FC = () => {
   const { t } = useTranslation()
+
+  const cacheProviderOptions = useMemo(() => getCacheProviderOptions(), [])
   const dispatch = useAppDispatch()
   const queryClient = useQueryClient()
   const { logCacheUpdate } = useCacheAudit()
@@ -370,14 +372,11 @@ const CachePage: React.FC = () => {
                       name="cacheProviderType"
                       value={formik.values.cacheProviderType}
                       formik={formik}
-                      values={CACHE_PROVIDER_OPTIONS}
+                      values={cacheProviderOptions}
                       lsize={12}
                       rsize={12}
                       doc_category={CACHE}
                       doc_entry="cacheProviderType"
-                      // Stays interactive on mobile: it only switches which
-                      // provider's settings are shown, and nothing below it can
-                      // be edited or submitted from there anyway.
                       disabled={!canWriteCache}
                       isDark={isDark}
                     />

--- a/admin-ui/plugins/services/components/CacheRedis.tsx
+++ b/admin-ui/plugins/services/components/CacheRedis.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { FormGroup } from 'Components'
 import { useTranslation } from 'react-i18next'
 import GluuInputRow from 'Routes/Apps/Gluu/GluuInputRow'
@@ -7,10 +8,12 @@ import GluuToggleRow from 'Routes/Apps/Gluu/GluuToggleRow'
 import { CACHE } from 'Utils/ApiResources'
 import { getFieldPlaceholder } from '@/utils/placeholderUtils'
 import type { CacheRedisProps } from './types'
-import { REDIS_PROVIDER_OPTIONS } from '../helper'
+import { getRedisProviderOptions } from '../helper'
 
 const CacheRedis = ({ formik, classes, isDark, disabled }: CacheRedisProps) => {
   const { t } = useTranslation()
+
+  const redisProviderOptions = useMemo(() => getRedisProviderOptions(), [])
   return (
     <div className={classes.sectionGrid}>
       <div className={classes.fieldItem}>
@@ -19,7 +22,7 @@ const CacheRedis = ({ formik, classes, isDark, disabled }: CacheRedisProps) => {
           name="redisProviderType"
           value={formik.values.redisProviderType || ''}
           formik={formik}
-          values={REDIS_PROVIDER_OPTIONS}
+          values={redisProviderOptions}
           lsize={12}
           rsize={12}
           doc_category={CACHE}

--- a/admin-ui/plugins/services/components/types.ts
+++ b/admin-ui/plugins/services/components/types.ts
@@ -1,6 +1,7 @@
+import type { CacheConfigurationCacheProviderType } from 'JansConfigApi'
 import type { FormikProps } from 'formik'
 
-export type CacheProviderType = 'IN_MEMORY' | 'MEMCACHED' | 'REDIS' | 'NATIVE_PERSISTENCE'
+export type CacheProviderType = CacheConfigurationCacheProviderType
 
 export type InMemoryCacheFormValues = {
   cacheProviderType: 'IN_MEMORY'

--- a/admin-ui/plugins/services/helper/constants.ts
+++ b/admin-ui/plugins/services/helper/constants.ts
@@ -1,3 +1,8 @@
+import {
+  CacheConfigurationCacheProviderType,
+  RedisConfigurationRedisProviderType,
+  MemcachedConfigurationConnectionFactoryType,
+} from 'JansConfigApi'
 import type { CacheFormValues } from '../components/types'
 
 type CacheFieldLabel = { key: keyof CacheFormValues; label: string }
@@ -45,21 +50,27 @@ export const CACHE_FIELD_LABELS_BY_PROVIDER: Record<string, CacheFieldLabel[]> =
   NATIVE_PERSISTENCE: [...COMMON_FIELDS, ...NATIVE_PERSISTENCE_FIELDS],
 }
 
-export const CACHE_PROVIDER_OPTIONS = [
-  { value: 'IN_MEMORY', label: 'In Memory' },
-  { value: 'MEMCACHED', label: 'Memcached' },
-  { value: 'REDIS', label: 'Redis' },
-  { value: 'NATIVE_PERSISTENCE', label: 'Native Persistence' },
-]
+const titleCase = (value: string) =>
+  value
+    .toLowerCase()
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
 
-export const REDIS_PROVIDER_OPTIONS = [
-  { value: 'STANDALONE', label: 'Standalone' },
-  { value: 'CLUSTER', label: 'Cluster' },
-  { value: 'SHARDED', label: 'Sharded' },
-  { value: 'SENTINEL', label: 'Sentinel' },
-]
+export const getCacheProviderOptions = () =>
+  Object.values(CacheConfigurationCacheProviderType).map((value) => ({
+    value,
+    label: titleCase(value),
+  }))
 
-export const CONNECTION_FACTORY_OPTIONS = [
-  { value: 'DEFAULT', label: 'Default' },
-  { value: 'BINARY', label: 'Binary' },
-]
+export const getRedisProviderOptions = () =>
+  Object.values(RedisConfigurationRedisProviderType).map((value) => ({
+    value,
+    label: titleCase(value),
+  }))
+
+export const getConnectionFactoryOptions = () =>
+  Object.values(MemcachedConfigurationConnectionFactoryType).map((value) => ({
+    value,
+    label: titleCase(value),
+  }))

--- a/admin-ui/plugins/services/helper/index.ts
+++ b/admin-ui/plugins/services/helper/index.ts
@@ -1,6 +1,6 @@
 export {
-  CACHE_PROVIDER_OPTIONS,
-  REDIS_PROVIDER_OPTIONS,
-  CONNECTION_FACTORY_OPTIONS,
+  getCacheProviderOptions,
+  getRedisProviderOptions,
+  getConnectionFactoryOptions,
 } from './constants'
 export * from './utils'

--- a/admin-ui/plugins/smtp/components/SmtpForm.tsx
+++ b/admin-ui/plugins/smtp/components/SmtpForm.tsx
@@ -239,7 +239,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               formik={formik}
               lsize={12}
               rsize={12}
-              showError={formik.touched.host && !!formik.errors.host}
+              showError={!!formik.errors.host}
               errorMessage={formik.errors.host as string}
               required
               disabled={isReadOnly}
@@ -257,7 +257,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               formik={formik}
               lsize={12}
               rsize={12}
-              showError={formik.touched.port && !!formik.errors.port}
+              showError={!!formik.errors.port}
               errorMessage={formik.errors.port as string}
               type="number"
               required
@@ -278,7 +278,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               formik={formik}
               lsize={12}
               rsize={12}
-              showError={formik.touched.connect_protection && !!formik.errors.connect_protection}
+              showError={!!formik.errors.connect_protection}
               errorMessage={formik.errors.connect_protection as string}
               required
               disabled={isReadOnly}
@@ -295,7 +295,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               formik={formik}
               lsize={12}
               rsize={12}
-              showError={formik.touched.from_name && !!formik.errors.from_name}
+              showError={!!formik.errors.from_name}
               errorMessage={formik.errors.from_name as string}
               required
               disabled={isReadOnly}
@@ -314,7 +314,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               formik={formik}
               lsize={12}
               rsize={12}
-              showError={formik.touched.from_email_address && !!formik.errors.from_email_address}
+              showError={!!formik.errors.from_email_address}
               errorMessage={formik.errors.from_email_address as string}
               required
               disabled={isReadOnly}
@@ -332,10 +332,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               formik={formik}
               lsize={12}
               rsize={12}
-              showError={
-                formik.touched.smtp_authentication_account_username &&
-                !!formik.errors.smtp_authentication_account_username
-              }
+              showError={!!formik.errors.smtp_authentication_account_username}
               errorMessage={formik.errors.smtp_authentication_account_username as string}
               required={formik.values.requires_authentication}
               disabled={isReadOnly}
@@ -354,10 +351,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               formik={formik}
               lsize={12}
               rsize={12}
-              showError={
-                formik.touched.smtp_authentication_account_password &&
-                !!formik.errors.smtp_authentication_account_password
-              }
+              showError={!!formik.errors.smtp_authentication_account_password}
               errorMessage={formik.errors.smtp_authentication_account_password as string}
               type="password"
               required={formik.values.requires_authentication}
@@ -376,7 +370,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               formik={formik}
               lsize={12}
               rsize={12}
-              showError={formik.touched.key_store && !!formik.errors.key_store}
+              showError={!!formik.errors.key_store}
               errorMessage={formik.errors.key_store as string}
               disabled={isReadOnly || !optimisticKeystoreEdit}
               isDark={isDark}
@@ -400,7 +394,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               formik={formik}
               lsize={12}
               rsize={12}
-              showError={formik.touched.key_store_password && !!formik.errors.key_store_password}
+              showError={!!formik.errors.key_store_password}
               errorMessage={formik.errors.key_store_password as string}
               type="password"
               disabled={isReadOnly || !optimisticKeystoreEdit}
@@ -424,7 +418,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               formik={formik}
               lsize={12}
               rsize={12}
-              showError={formik.touched.key_store_alias && !!formik.errors.key_store_alias}
+              showError={!!formik.errors.key_store_alias}
               errorMessage={formik.errors.key_store_alias as string}
               disabled={isReadOnly || !optimisticKeystoreEdit}
               isDark={isDark}
@@ -448,7 +442,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               formik={formik}
               lsize={12}
               rsize={12}
-              showError={formik.touched.signing_algorithm && !!formik.errors.signing_algorithm}
+              showError={!!formik.errors.signing_algorithm}
               errorMessage={formik.errors.signing_algorithm as string}
               disabled={isReadOnly || !optimisticKeystoreEdit}
               isDark={isDark}

--- a/admin-ui/plugins/smtp/components/SmtpForm.tsx
+++ b/admin-ui/plugins/smtp/components/SmtpForm.tsx
@@ -324,44 +324,6 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               placeholder={getFieldPlaceholder(t, 'fields.from_email_address')}
             />
           </div>
-          <div className={classes.fieldItem}>
-            <GluuInputRow
-              label="fields.smtp_user_name"
-              name="smtp_authentication_account_username"
-              value={formik.values.smtp_authentication_account_username || ''}
-              formik={formik}
-              lsize={12}
-              rsize={12}
-              showError={!!formik.errors.smtp_authentication_account_username}
-              errorMessage={formik.errors.smtp_authentication_account_username as string}
-              required={formik.values.requires_authentication}
-              disabled={isReadOnly}
-              isDark={isDark}
-              doc_category={smtpConstants.DOC_CATEGORY}
-              doc_entry="smtp_authentication_account_username"
-              placeholder={getFieldPlaceholder(t, 'fields.smtp_user_name')}
-            />
-          </div>
-
-          <div className={classes.fieldItem}>
-            <GluuInputRow
-              label="fields.smtp_user_password"
-              name="smtp_authentication_account_password"
-              value={formik.values.smtp_authentication_account_password || ''}
-              formik={formik}
-              lsize={12}
-              rsize={12}
-              showError={!!formik.errors.smtp_authentication_account_password}
-              errorMessage={formik.errors.smtp_authentication_account_password as string}
-              type="password"
-              required={formik.values.requires_authentication}
-              disabled={isReadOnly}
-              isDark={isDark}
-              doc_category={smtpConstants.DOC_CATEGORY}
-              doc_entry="smtp_authentication_account_password"
-              placeholder={getFieldPlaceholder(t, 'fields.smtp_user_password')}
-            />
-          </div>
           <div className={`${classes.fieldItem} ${classes.fieldItemRelative}`}>
             <GluuInputRow
               label="fields.key_store"
@@ -457,7 +419,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               />
             )}
           </div>
-          <div className={classes.fieldItem}>
+          <div className={`${classes.fieldItem} ${classes.toggleItem}`}>
             <FormGroup>
               <GluuLabel
                 label="fields.trust_host"
@@ -476,7 +438,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
             </FormGroup>
           </div>
 
-          <div className={classes.fieldItem}>
+          <div className={`${classes.fieldItem} ${classes.toggleItem}`}>
             <FormGroup>
               <GluuLabel
                 label="fields.allow_keystore_edit"
@@ -511,7 +473,7 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
               </GluuLoader>
             </FormGroup>
           </div>
-          <div className={classes.fieldItem}>
+          <div className={`${classes.fieldItem} ${classes.toggleItem}`}>
             <FormGroup>
               <GluuLabel
                 label="fields.requires_authentication"
@@ -528,6 +490,44 @@ const SmtpForm = (props: Readonly<SmtpFormProps>) => {
                 disabled={isReadOnly}
               />
             </FormGroup>
+          </div>
+          <div className={classes.fieldItem}>
+            <GluuInputRow
+              label="fields.smtp_user_name"
+              name="smtp_authentication_account_username"
+              value={formik.values.smtp_authentication_account_username || ''}
+              formik={formik}
+              lsize={12}
+              rsize={12}
+              showError={!!formik.errors.smtp_authentication_account_username}
+              errorMessage={formik.errors.smtp_authentication_account_username as string}
+              required={formik.values.requires_authentication}
+              disabled={isReadOnly}
+              isDark={isDark}
+              doc_category={smtpConstants.DOC_CATEGORY}
+              doc_entry="smtp_authentication_account_username"
+              placeholder={getFieldPlaceholder(t, 'fields.smtp_user_name')}
+            />
+          </div>
+
+          <div className={classes.fieldItem}>
+            <GluuInputRow
+              label="fields.smtp_user_password"
+              name="smtp_authentication_account_password"
+              value={formik.values.smtp_authentication_account_password || ''}
+              formik={formik}
+              lsize={12}
+              rsize={12}
+              showError={!!formik.errors.smtp_authentication_account_password}
+              errorMessage={formik.errors.smtp_authentication_account_password as string}
+              type="password"
+              required={formik.values.requires_authentication}
+              disabled={isReadOnly}
+              isDark={isDark}
+              doc_category={smtpConstants.DOC_CATEGORY}
+              doc_entry="smtp_authentication_account_password"
+              placeholder={getFieldPlaceholder(t, 'fields.smtp_user_password')}
+            />
           </div>
 
           {!isReadOnly && (

--- a/admin-ui/plugins/smtp/components/styles/SmtpFormPage.style.ts
+++ b/admin-ui/plugins/smtp/components/styles/SmtpFormPage.style.ts
@@ -147,6 +147,12 @@ export const useStyles = makeStyles<SmtpFormPageStylesParams>()((
     fieldItemRelative: {
       position: 'relative',
     },
+    toggleItem: {
+      paddingBottom: ERROR_SPACE,
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        paddingBottom: 0,
+      },
+    },
     fieldItemFullWidth: {
       width: '100%',
       gridColumn: '1 / -1',

--- a/admin-ui/plugins/user-claims/__tests__/components/UserClaimsForm.test.tsx
+++ b/admin-ui/plugins/user-claims/__tests__/components/UserClaimsForm.test.tsx
@@ -73,6 +73,12 @@ jest.mock('react-router-dom', () => ({
 }))
 
 jest.mock('JansConfigApi', () => ({
+  JansAttributeStatus: {
+    active: 'active',
+    inactive: 'inactive',
+    expired: 'expired',
+    register: 'register',
+  },
   usePostAttributes: jest.fn(() => ({ mutate: jest.fn(), isPending: false })),
   usePutAttributes: jest.fn(() => ({ mutate: jest.fn(), isPending: false })),
   getGetAttributesQueryKey: jest.fn(() => ['attributes']),

--- a/admin-ui/plugins/user-claims/__tests__/components/UserClaimsListPage.test.tsx
+++ b/admin-ui/plugins/user-claims/__tests__/components/UserClaimsListPage.test.tsx
@@ -42,6 +42,12 @@ jest.mock('@/cedarling/utility', () => {
 })
 
 jest.mock('JansConfigApi', () => ({
+  JansAttributeStatus: {
+    active: 'active',
+    inactive: 'inactive',
+    expired: 'expired',
+    register: 'register',
+  },
   getGetAttributesQueryKey: jest.fn(() => ['attributes']),
 }))
 

--- a/admin-ui/plugins/user-claims/__tests__/components/UserClaimsViewPage.test.tsx
+++ b/admin-ui/plugins/user-claims/__tests__/components/UserClaimsViewPage.test.tsx
@@ -74,6 +74,12 @@ jest.mock('@/cedarling/utility', () => {
 })
 
 jest.mock('JansConfigApi', () => ({
+  JansAttributeStatus: {
+    active: 'active',
+    inactive: 'inactive',
+    expired: 'expired',
+    register: 'register',
+  },
   getGetAttributesQueryKey: jest.fn(() => ['attributes']),
   useGetWebhooksByFeatureId: jest.fn(() => ({
     data: [],

--- a/admin-ui/plugins/user-claims/components/UserClaimsForm.tsx
+++ b/admin-ui/plugins/user-claims/components/UserClaimsForm.tsx
@@ -14,6 +14,7 @@ import GluuAutocomplete from 'Routes/Apps/Gluu/GluuAutocomplete'
 import GluuTooltip from 'Routes/Apps/Gluu/GluuTooltip'
 import { HelpOutline } from '@/components/icons'
 import { ATTRIBUTE } from 'Utils/ApiResources'
+import { getAttributeStatusOptions } from '../constants'
 import { useTranslation } from 'react-i18next'
 import GluuCommitDialog from 'Routes/Apps/Gluu/GluuCommitDialog'
 import { adminUiFeatures, MOBILE_MEDIA_QUERY } from '@/constants'
@@ -44,6 +45,11 @@ const USAGE_TYPE_OPTIONS: AutocompleteOption[] = [{ value: 'openid', label: 'Ope
 const UserClaimsForm = memo(function UserClaimsForm(props: AttributeFormProps) {
   const { item, customOnSubmit, hideButtons } = props
   const { t } = useTranslation()
+
+  const statusOptions = useMemo(
+    () => getAttributeStatusOptions().map(({ value, labelKey }) => ({ value, label: t(labelKey) })),
+    [t],
+  )
   const { navigateBack } = useAppNavigation()
   const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
   const [modal, setModal] = useState<boolean>(false)
@@ -251,10 +257,7 @@ const UserClaimsForm = memo(function UserClaimsForm(props: AttributeFormProps) {
                     value={formik.values.status}
                     doc_category={ATTRIBUTE}
                     doc_entry="status"
-                    values={[
-                      { value: 'active', label: t('options.active') },
-                      { value: 'inactive', label: t('options.inactive') },
-                    ]}
+                    values={statusOptions}
                     errorMessage={formik.errors.status ? t(formik.errors.status) : undefined}
                     showError={!!(formik.errors.status && formik.touched.status)}
                     disabled={isViewMode}

--- a/admin-ui/plugins/user-claims/constants/index.ts
+++ b/admin-ui/plugins/user-claims/constants/index.ts
@@ -1,3 +1,4 @@
+import { JansAttributeStatus } from 'JansConfigApi'
 import { DEFAULT_STALE_TIME, DEFAULT_GC_TIME } from '@/utils/queryUtils'
 
 export const API_ATTRIBUTE = 'api-attribute'
@@ -19,3 +20,9 @@ export const ATTRIBUTE_CACHE_CONFIG = {
   GC_TIME: DEFAULT_GC_TIME,
   SINGLE_ATTRIBUTE_STALE_TIME: 2 * 60 * 1000,
 }
+
+export const getAttributeStatusOptions = (): Array<{ value: string; labelKey: string }> =>
+  Object.values(JansAttributeStatus).map((status) => ({
+    value: status,
+    labelKey: `options.${status}`,
+  }))


### PR DESCRIPTION
### fix(admin-ui): config forms validate against loaded server data (#2940)

#### Summary
This PR fixes a validation issue affecting configuration forms across the Admin UI where form validation was performed only against the initial empty state. After server data was loaded, the form values were updated without re-running validation, causing the Apply button state and validation messages to become inconsistent with the displayed values.

The update ensures validation is re-evaluated whenever server configuration is loaded, dependent validation rules change, or array-based fields are modified, resulting in consistent validation behavior across all supported configuration pages.

---

#### Fix Summary
- Revalidated configuration forms after loading server data
- Ensured the Apply button accurately reflects the validity of the current form values
- Updated validation to re-run when conditional field requirements change
- Fixed validation behavior for array and multi-select fields after add or remove operations
- Ensured validation messages are synchronized with the displayed form state on initial page load
- Applied the fix across supported configuration modules, including:
  - FIDO (Static and Dynamic Configuration)
  - SMTP
  - Logging
  - Config API Properties
  - Auth Server Properties
  - SCIM
  - ACRs / Authentication
  - SAML
- Preserved existing validation behavior for entity create and edit forms where validation is intentionally deferred until user interaction
- Improved overall consistency and reliability of configuration form validation

---

#### Verification

```bash
npm run check:all
```

passes successfully.

- Verified configuration forms validate correctly immediately after server data is loaded
- Verified the Apply button is enabled only when the current form state is valid
- Verified conditional required fields are revalidated when their controlling values change
- Verified array and multi-select fields no longer prevent valid submissions
- Verified no regressions in existing configuration workflows
- Verified lint, type-check, and tests pass successfully

---

#### 🔗 Ticket

Closes: #2940

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized validation messages and expanded status options, including expired and register.
  * Added improved accessibility and inline feedback for invalid form fields.

* **Bug Fixes**
  * Forms now validate immediately and when configuration changes.
  * Validation errors display consistently without requiring prior field interaction.
  * Mobile SMTP forms are now correctly read-only.

* **Chores**
  * Cache provider and connection options are generated dynamically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->