### PR TITLE
feat(admin-ui): report VM SSH key to Zulip + bring-your-own deploy target

### DIFF
--- a/.github/workflows/build-admin-ui.yml
+++ b/.github/workflows/build-admin-ui.yml
@@ -67,6 +67,16 @@ on:
         required: false
         type: string
         default: ''
+      target_ip:
+        description: 'Deploy the built assets to this existing VM instead of creating an easycloud VM. Requires the ADMIN_UI_DEPLOY_SSH_KEY secret.'
+        required: false
+        type: string
+        default: ''
+      target_host:
+        description: 'FQDN of the target VM for env-config.js (jans-config-api host). Used with target_ip; falls back to target_ip when empty.'
+        required: false
+        type: string
+        default: ''
       termination_in:
         description: 'Hours before the ephemeral VM is terminated (e.g. 6h)'
         required: false
@@ -129,6 +139,16 @@ on:
         required: false
         type: string
         default: ''
+      target_ip:
+        description: 'Deploy the built assets to this existing VM instead of creating an easycloud VM. Requires the ADMIN_UI_DEPLOY_SSH_KEY secret.'
+        required: false
+        type: string
+        default: ''
+      target_host:
+        description: 'FQDN of the target VM for env-config.js (jans-config-api host). Used with target_ip; falls back to target_ip when empty.'
+        required: false
+        type: string
+        default: ''
       termination_in:
         description: 'Hours before the ephemeral VM is terminated (e.g. 6h)'
         required: false
@@ -142,6 +162,10 @@ on:
       MOAUTO_GPG_PRIVATE_KEY:
         required: false
       MOAUTO_GPG_PRIVATE_KEY_PASSPHRASE:
+        required: false
+      ADMIN_UI_DEPLOY_SSH_KEY:
+        required: false
+      ZULIP_API_KEY:
         required: false
 
 permissions:
@@ -185,6 +209,7 @@ jobs:
           INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
           INPUT_RECREATE: ${{ inputs.recreate_release }}
           INPUT_COMMENT: ${{ inputs.comment_on_pr }}
+          INPUT_TARGET_IP: ${{ inputs.target_ip }}
         run: |
           REF="${BUILD_REF:-$FALLBACK_REF}"
 
@@ -236,6 +261,10 @@ jobs:
             false) DO_DEPLOY=false ;;
             *)     if [ "$IS_RELEASE_REF" = "false" ]; then DO_DEPLOY=true; fi ;;
           esac
+          # an explicit target VM always means "deploy there"
+          if [ -n "$INPUT_TARGET_IP" ] && [ "$INPUT_DEPLOY" != "false" ]; then
+            DO_DEPLOY=true
+          fi
 
           {
             echo "version=$VERSION"
@@ -458,6 +487,7 @@ jobs:
       VERSION_NAME: ${{ needs.build.outputs.version }}
     steps:
       - name: Checkout easycloud
+        if: inputs.target_ip == ''
         uses: actions/checkout@v4
         with:
           repository: GluuFederation/easycloud
@@ -471,6 +501,7 @@ jobs:
           name: admin-ui-built
 
       - name: Install latest GH
+        if: inputs.target_ip == ''
         continue-on-error: true
         run: |
           VERSION=$(curl -s "https://api.github.com/repos/cli/cli/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/' | cut -c2-)
@@ -482,6 +513,7 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
+        if: inputs.target_ip == ''
         uses: crazy-max/ghaction-import-gpg@v5
         with:
           gpg_private_key: ${{ secrets.MOAUTO_GPG_PRIVATE_KEY }}
@@ -490,6 +522,7 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Install terraform
+        if: inputs.target_ip == ''
         run: |
           wget -q https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip
           unzip -q terraform_1.5.7_linux_amd64.zip
@@ -498,6 +531,7 @@ jobs:
           terraform --version
 
       - name: Configure Git
+        if: inputs.target_ip == ''
         run: |
           git config --global user.name "mo-auto"
           git config --global user.email "54212639+mo-auto@users.noreply.github.com"
@@ -509,6 +543,7 @@ jobs:
 
       - name: Create ephemeral DO VM
         id: create_env
+        if: inputs.target_ip == ''
         env:
           GH_TOKEN: ${{ secrets.MOWORKFLOWTOKEN }}
           DO_TOKEN: ${{ secrets.DO_TOKEN }}
@@ -538,20 +573,55 @@ jobs:
           IP=$(terraform output ip | xargs)
           HOST="$ENVNAME.gluu.info"
           {
-            echo "identifier=$IDENTIFIER"
             echo "ip=$IP"
             echo "host=$HOST"
+            echo "pem=$IDENTIFIER/private.pem"
           } >> "$GITHUB_OUTPUT"
           echo "VM created: $HOST ($IP)"
 
+      - name: Report VM access to Zulip
+        if: inputs.target_ip == '' && steps.create_env.outputs.MSG != ''
+        continue-on-error: true
+        uses: zulip/github-actions-zulip/send-message@v1
+        with:
+          api-key: ${{ secrets.ZULIP_API_KEY }}
+          email: "git-gluu@gluu.org"
+          organization-url: "https://chat.gluu.org"
+          to: "bot_reporter"
+          type: "stream"
+          topic: "admin-ui-deployments"
+          content: ${{ steps.create_env.outputs.MSG }}
+
+      - name: Prepare BYO target
+        id: byo
+        if: inputs.target_ip != ''
+        env:
+          TARGET_IP: ${{ inputs.target_ip }}
+          TARGET_HOST: ${{ inputs.target_host }}
+          SSH_KEY: ${{ secrets.ADMIN_UI_DEPLOY_SSH_KEY }}
+        run: |
+          if [ -z "$SSH_KEY" ]; then
+            echo "::error::target_ip is set but the ADMIN_UI_DEPLOY_SSH_KEY secret is empty." >&2
+            exit 1
+          fi
+          mkdir -p byo
+          printf '%s\n' "$SSH_KEY" > byo/private.pem
+          chmod 600 byo/private.pem
+          {
+            echo "ip=$TARGET_IP"
+            echo "host=${TARGET_HOST:-$TARGET_IP}"
+            echo "pem=byo/private.pem"
+          } >> "$GITHUB_OUTPUT"
+          echo "Deploying to existing target $TARGET_IP (host ${TARGET_HOST:-$TARGET_IP})"
+
       - name: Wait for SSH
         env:
-          IDENTIFIER: ${{ steps.create_env.outputs.identifier }}
-          IP: ${{ steps.create_env.outputs.ip }}
+          PEM: ${{ steps.create_env.outputs.pem || steps.byo.outputs.pem }}
+          IP: ${{ steps.create_env.outputs.ip || steps.byo.outputs.ip }}
         run: |
-          chmod 600 "$IDENTIFIER/private.pem"
+          chmod 600 "$PEM"
           for i in $(seq 1 30); do
-            if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -i "$IDENTIFIER/private.pem" "root@$IP" true 2>/dev/null; then
+            if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -i "$PEM" "root@$IP" true 2>/dev/null; then
               echo "SSH is up"
               exit 0
             fi
@@ -562,12 +632,12 @@ jobs:
           exit 1
 
       - name: Wait for Flex install
-        if: inputs.flex_branch != ''
+        if: inputs.flex_branch != '' && inputs.target_ip == ''
         env:
-          IDENTIFIER: ${{ steps.create_env.outputs.identifier }}
+          PEM: ${{ steps.create_env.outputs.pem }}
           IP: ${{ steps.create_env.outputs.ip }}
         run: |
-          SSH="ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -i $IDENTIFIER/private.pem root@$IP"
+          SSH="ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -i $PEM root@$IP"
           for i in $(seq 1 10); do
             CONFIG_API=$($SSH "systemctl is-active jans-config-api" 2>/dev/null || true)
             AUTH=$($SSH "systemctl is-active jans-auth" 2>/dev/null || true)
@@ -600,11 +670,10 @@ jobs:
 
       - name: Deploy admin-ui to VM
         env:
-          IDENTIFIER: ${{ steps.create_env.outputs.identifier }}
-          IP: ${{ steps.create_env.outputs.ip }}
-          HOST: ${{ steps.create_env.outputs.host }}
+          PEM: ${{ steps.create_env.outputs.pem || steps.byo.outputs.pem }}
+          IP: ${{ steps.create_env.outputs.ip || steps.byo.outputs.ip }}
+          HOST: ${{ steps.create_env.outputs.host || steps.byo.outputs.host }}
         run: |
-          PEM="$IDENTIFIER/private.pem"
           SSH_OPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=10 -i $PEM"
 
           tar -xzf "admin-ui-$VERSION_NAME-built.tar.gz"
@@ -626,9 +695,10 @@ jobs:
 
       - name: Summary
         env:
-          HOST: ${{ steps.create_env.outputs.host }}
-          IP: ${{ steps.create_env.outputs.ip }}
+          HOST: ${{ steps.create_env.outputs.host || steps.byo.outputs.host }}
+          IP: ${{ steps.create_env.outputs.ip || steps.byo.outputs.ip }}
           TERMINATION_IN: ${{ inputs.termination_in }}
+          BYO: ${{ inputs.target_ip != '' }}
         run: |
           {
             echo "## Admin UI deployed"
@@ -636,8 +706,13 @@ jobs:
             echo "- **URL:** https://$HOST/admin"
             echo "- **IP:** $IP"
             echo "- **Version:** $VERSION_NAME"
-            echo "- **VM terminates in:** $TERMINATION_IN"
-            echo "- **Admin password:** stored on the VM at /root/flex_admin_password"
-            echo ""
-            echo "Private key: see the easycloud PR / bot_reporter channel (standard easycloud flow)."
+            if [ "$BYO" != "true" ]; then
+              echo "- **VM terminates in:** $TERMINATION_IN"
+              echo "- **Admin password:** stored on the VM at /root/flex_admin_password"
+              echo ""
+              echo "SSH key + connection details were sent to Zulip #bot_reporter (topic admin-ui-deployments) and the easycloud env PR."
+            else
+              echo ""
+              echo "Deployed to the caller-supplied target VM (ADMIN_UI_DEPLOY_SSH_KEY)."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Two deploy-path additions to `build-admin-ui.yml`.

### 1. Report the VM SSH key
The deploy job runs easycloud's `create_ephemerals_envs.sh` directly, so easycloud's *own* Zulip step (which normally shares the VM's private key to `#bot_reporter`) never fires — the user had no way to reach the created VM. Added a `Report VM access to Zulip` step that posts the create script's `MSG` output (base64 PEM + decode instructions + env PR link) to `#bot_reporter`, topic `admin-ui-deployments`. `continue-on-error` so a Zulip hiccup never fails the deploy (the key is also in the easycloud env PR as a fallback).

### 2. Bring-your-own target VM
New `target_ip` + `target_host` inputs deploy the built assets to an **existing** VM instead of creating a fresh easycloud one:
- SSH key comes from the **`ADMIN_UI_DEPLOY_SSH_KEY`** secret (never a plaintext input — GitHub doesn't mask dispatch inputs).
- When `target_ip` is set: easycloud checkout, GPG/terraform/gh setup, VM creation, and the flex-readiness wait are all skipped; `target_ip` forces the deploy job on.
- `env-config.js` points jans-config-api at `target_host` (falls back to `target_ip`).

```bash
# deploy to an existing VM you already own
gh workflow run build-admin-ui.yml --repo GluuFederation/flex \
  -f build_ref=my-branch -f target_ip=203.0.113.10 -f target_host=my.gluu.info
```

### Prerequisites (repo/org secrets)
- `ADMIN_UI_DEPLOY_SSH_KEY` — required only for the BYO path.
- `ZULIP_API_KEY` — for the key-reporting step (already used by easycloud; add to flex if not present, else the step no-ops via continue-on-error).

Follows #2945 (merged). YAML-lint clean; input parity and step gating verified.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deploying the Admin UI to a specified target host or IP address.
  * Added optional SSH key configuration for deployments.
  * Added deployment status reporting through Zulip.
  * Deployment summaries now distinguish between temporary and caller-specified environments.

* **Improvements**
  * Streamlined deployment checks and SSH readiness validation for both temporary and existing targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->