### PR TITLE
fix(admin-ui): validate/repair BYO SSH key rendering + surface ssh errors

### DIFF
--- a/.github/workflows/build-admin-ui.yml
+++ b/.github/workflows/build-admin-ui.yml
@@ -639,6 +639,18 @@ jobs:
           mkdir -p byo
           printf '%s\n' "$SSH_KEY" > byo/private.pem
           chmod 600 byo/private.pem
+          # A key stored with literal "\n" (backslash-n) instead of real newlines is the
+          # most common breakage; repair it, then confirm the key actually parses.
+          if ! ssh-keygen -y -f byo/private.pem >/dev/null 2>&1 && grep -q '\\n' byo/private.pem; then
+            echo "Key contained literal \\n; converting to real newlines"
+            printf '%b' "$SSH_KEY" > byo/private.pem
+            chmod 600 byo/private.pem
+          fi
+          if ! ssh-keygen -y -f byo/private.pem >/dev/null 2>&1; then
+            echo "::error::ADMIN_UI_DEPLOY_SSH_KEY did not parse as a private key (lines=$(wc -l < byo/private.pem)). Store the raw PEM with real newlines — not base64, not backslash-escaped, no passphrase." >&2
+            exit 1
+          fi
+          echo "SSH private key parsed OK"
           {
             echo "ip=$TARGET_IP"
             echo "host=${TARGET_HOST:-$TARGET_IP}"
@@ -662,7 +674,8 @@ jobs:
             echo "Waiting for SSH ($i/30)..."
             sleep 20
           done
-          echo "SSH never came up" >&2
+          echo "SSH never came up; last verbose attempt (handshake only, no key material):" >&2
+          ssh -v -o StrictHostKeyChecking=no -o ConnectTimeout=10 -p "$PORT" -i "$PEM" "root@$IP" true 2>&1 | tail -25 >&2 || true
           exit 1
 
       - name: Wait for Flex install


### PR DESCRIPTION
## Problem

BYO deploys ([run 30822716200](https://github.com/GluuFederation/flex/actions/runs/30822716200)) hang in **Wait for SSH** for 10 min and fail with no reason — `ssh` stderr was `2>/dev/null`. The key works when tested manually, so the file written from the secret isn't a usable private key inside the runner (rendering, not the key itself).

## Root cause

`printf '%s\n' "$SSH_KEY"` is only correct when the secret holds **real newlines**. The most common breakage is a secret stored with literal `\n` (backslash-n) or base64 — the file then isn't a valid PEM and every `ssh` attempt fails silently.

## Fix

- **Validate**: after writing, `ssh-keygen -y -f byo/private.pem` confirms the key parses.
- **Auto-repair**: if it doesn't parse and the file contains literal `\n`, rewrite with `printf '%b'` (real newlines) and re-check.
- **Fail fast**: if it still won't parse, error with exact guidance (store raw PEM, real newlines, not base64/escaped, no passphrase). No key material printed — only line count.
- **Diagnose network/auth**: on SSH-wait timeout, emit one `ssh -v` attempt (handshake only) so `Permission denied (publickey)` vs `Connection timed out` vs bad format is visible.

## Next

Re-run the BYO deploy. Either it now connects (literal-`\n` auto-repaired), or the `Prepare BYO target` / `Wait for SSH` step prints exactly what's wrong.

