### PR TITLE
feat(flex-linux-setup): use agama-pw in admin-ui for authentication

### DIFF
--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -63,8 +63,8 @@ def get_flex_setup_parser():
     parser.add_argument('--flex-non-interactive', help="Non interactive setup mode", action='store_true')
     parser.add_argument('--install-admin-ui', help="Installs Gluu Flex Admin UI", action='store_true')
     parser.add_argument('--update-admin-ui', help="Updates Gluu Flex Admin UI", action='store_true')
-    parser.add_argument('--adminui_authentication_mode', help="Set authserver.acrValues", default='basic',
-                        choices=['basic', 'agama_io.jans.casa.authn.main'])
+    parser.add_argument('--adminui_authentication_mode', help="Set authserver.acrValues", default='agama_org.gluu.agama.pw.main',
+                        choices=['basic', 'agama_io.jans.casa.authn.main', 'agama_org.gluu.agama.pw.main'])
     parser.add_argument('--install-casa', help="Installs casa", action='store_true')
     parser.add_argument('--remove-flex', help="Removes flex components", action='store_true')
     parser.add_argument('--no-restart-services',

--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -872,6 +872,8 @@ class flex_installer(JettyInstaller):
 
         agama_pw_deployment_ldif_rendered_fn = os.path.join(self.source_dir, os.path.basename(self.agama_pw_deployment_ldif_fn))
         self.dbUtils.import_ldif([agama_pw_deployment_ldif_rendered_fn])
+        print("Enabling Agama Script")
+        installer_obj.dbUtils.enable_script('BADA-BADA')
 
 
 def prompt_for_installation():

--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -873,7 +873,7 @@ class flex_installer(JettyInstaller):
         agama_pw_deployment_ldif_rendered_fn = os.path.join(self.source_dir, os.path.basename(self.agama_pw_deployment_ldif_fn))
         self.dbUtils.import_ldif([agama_pw_deployment_ldif_rendered_fn])
         print("Enabling Agama Script")
-        installer_obj.dbUtils.enable_script('BADA-BADA')
+        self.dbUtils.enable_script('BADA-BADA')
 
 
 def prompt_for_installation():

--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -405,7 +405,9 @@ class flex_installer(JettyInstaller):
                     app_versions['JANS_BRANCH']), self.log4j2_adminui_path),
                 (self.resolve_admin_ui_bin_url(), os.path.join(Config.dist_jans_dir, os.path.basename(self.resolve_admin_ui_bin_url()))),
                 (self.policy_store_cjar_url, self.policy_store_cjar_path),
-                ('https://github.com/GluuFederation/agama-pw/releases/download/v1.0.9/agama-pw.gama', self.agama_pw_fn)
+                (base.determine_jans_artifact_url(
+                         'maven/io/jans/jans-config-api/plugins/admin-ui-plugin/{0}/admin-ui-plugin-{0}-agama-pw.gama'.format(
+                             base.current_app.app_info['jans_version'])), self.agama_pw_fn)
             ]
 
             if argsp.update_admin_ui:

--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -32,7 +32,7 @@ app_versions = {
     "NODE_VERSION": "v18.16.0"
 }
 
-AGAMA_PW_DEPLOYMENT_ID = '48b53270-0ab3-4f34-b3d1-03b179eecbc9'
+AGAMA_PW_DEPLOYMENT_ID = 'ab7aec3d-43f5-3c3f-81de-93a24dfd3f84'
 
 os.environ["FLEX_PRE_JANS"] = "True"
 

--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -367,6 +367,8 @@ class flex_installer(JettyInstaller):
         if not flex_installer_downloaded and os.path.exists(self.source_dir):
             os.rename(self.source_dir, self.source_dir + '-' + time.ctime().replace(' ', '_'))
 
+        self.agama_pw_deployment_ldif_fn = os.path.join(self.templates_dir, 'agama_pw_deployment.ldif')
+        self.agama_pw_fn = os.path.join(Config.dist_jans_dir, 'agama-pw.gama')
         self.source_files = []
 
     def resolve_admin_ui_bin_url(self):
@@ -403,6 +405,7 @@ class flex_installer(JettyInstaller):
                     app_versions['JANS_BRANCH']), self.log4j2_adminui_path),
                 (self.resolve_admin_ui_bin_url(), os.path.join(Config.dist_jans_dir, os.path.basename(self.resolve_admin_ui_bin_url()))),
                 (self.policy_store_cjar_url, self.policy_store_cjar_path),
+                ('https://github.com/GluuFederation/agama-pw/releases/download/v1.0.9/agama-pw.gama', self.agama_pw_fn)
             ]
 
             if argsp.update_admin_ui:
@@ -659,6 +662,8 @@ class flex_installer(JettyInstaller):
 
         self.tls13_settings()
 
+        self.deploy_agama_pw()
+
 
     def install_config_api_plugin(self):
 
@@ -848,6 +853,21 @@ class flex_installer(JettyInstaller):
         jansAuthInstaller.writeFile(keystore_pw_fn, json.dumps(keystore_pw_data))
         jansAuthInstaller.chown(keystore_pw_fn, Config.jetty_user, Config.root_user)
         jansAuthInstaller.run([base.paths.cmd_chmod, '640', keystore_pw_fn])
+
+
+    def deploy_agama_pw(self):
+        print("Deploying Agama-PW Project")
+        Config.templateRenderingDict['agama_pw_deployment_id'] = str(uuid.uuid4())
+        Config.templateRenderingDict['agama_pw_deployment_start_date'] = self.get_ldap_time()
+        Config.templateRenderingDict['agama_pw_assets_base64'] = config_api_installer.generate_base64_file(self.agama_pw_fn, 1)
+        config_api_installer.renderTemplateInOut(
+            self.agama_pw_deployment_ldif_fn,
+            self.templates_dir,
+            self.source_dir
+        )
+
+        agama_pw_deployment_ldif_rendered_fn = os.path.join(self.source_dir, os.path.basename(self.agama_pw_deployment_ldif_fn))
+        self.dbUtils.import_ldif([agama_pw_deployment_ldif_rendered_fn])
 
 
 def prompt_for_installation():

--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -32,6 +32,8 @@ app_versions = {
     "NODE_VERSION": "v18.16.0"
 }
 
+AGAMA_PW_DEPLOYMENT_ID = '48b53270-0ab3-4f34-b3d1-03b179eecbc9'
+
 os.environ["FLEX_PRE_JANS"] = "True"
 
 if '--remove-flex' in sys.argv and '--flex-non-interactive' not in sys.argv:
@@ -859,7 +861,7 @@ class flex_installer(JettyInstaller):
 
     def deploy_agama_pw(self):
         print("Deploying Agama-PW Project")
-        Config.templateRenderingDict['agama_pw_deployment_id'] = str(uuid.uuid4())
+        Config.templateRenderingDict['agama_pw_deployment_id'] = AGAMA_PW_DEPLOYMENT_ID
         Config.templateRenderingDict['agama_pw_deployment_start_date'] = self.get_ldap_time()
         Config.templateRenderingDict['agama_pw_assets_base64'] = config_api_installer.generate_base64_file(self.agama_pw_fn, 1)
         config_api_installer.renderTemplateInOut(

--- a/flex-linux-setup/flex_linux_setup/templates/agama_pw_deployment.ldif
+++ b/flex-linux-setup/flex_linux_setup/templates/agama_pw_deployment.ldif
@@ -2,7 +2,7 @@ dn: jansId=%(agama_pw_deployment_id)s,ou=deployments,ou=agama,o=jans
 objectClass: adsPrjDeployment
 objectClass: top
 jansId: %(agama_pw_deployment_id)s
-adsPrjDeplDetails: {"autoconfigure":true,"projectMetadata":{"projectName":"Agama-PW"}}
+adsPrjDeplDetails: {"autoconfigure":true,"projectMetadata":{"projectName":"agama-pw"}}
 jansActive: false
 jansStartDate: %(agama_pw_deployment_start_date)s
 adsPrjAssets: %(agama_pw_assets_base64)s

--- a/flex-linux-setup/flex_linux_setup/templates/agama_pw_deployment.ldif
+++ b/flex-linux-setup/flex_linux_setup/templates/agama_pw_deployment.ldif
@@ -1,0 +1,8 @@
+dn: jansId=%(agama_pw_deployment_id)s,ou=deployments,ou=agama,o=jans
+objectClass: adsPrjDeployment
+objectClass: top
+jansId: %(agama_pw_deployment_id)s
+adsPrjDeplDetails: {"autoconfigure":true,"projectMetadata":{"projectName":"Agama-PW"}}
+jansActive: false
+jansStartDate: %(agama_pw_deployment_start_date)s
+adsPrjAssets: %(agama_pw_assets_base64)s


### PR DESCRIPTION
Closes #2963 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting Agama Password authentication for the Admin UI.
  * Updated the default Admin UI authentication mode to Agama Password.
  * Continued support for Basic and Casa authentication modes.
  * Automatically downloads and deploys the Agama Password project during Admin UI installation.
  * Includes the required project configuration and assets for a ready-to-use authentication experience.
  * Automatically enables the Agama Password authentication flow after installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->