### PR TITLE
feat(admin-ui): implement responsive mobile layout for Jans Lock and FIDO Configuration (#2972)

### DIFF
--- a/admin-ui/plugins/fido/components/Configuration/Fido.tsx
+++ b/admin-ui/plugins/fido/components/Configuration/Fido.tsx
@@ -5,6 +5,7 @@ import GluuLoader from 'Routes/Apps/Gluu/GluuLoader'
 import StaticConfiguration from './components/StaticConfiguration'
 import DynamicConfiguration from './components/DynamicConfiguration'
 import SetTitle from 'Utils/SetTitle'
+import GluuText from 'Routes/Apps/Gluu/GluuText'
 import { GluuPageContent } from '@/components'
 import { fidoConstants } from '../../helper'
 import { useFidoConfig, useUpdateFidoConfig } from '../../hooks'
@@ -89,6 +90,9 @@ const Fido: React.FC = () => {
     <GluuPageContent>
       <GluuViewWrapper canShow={canReadFido}>
         <GluuLoader blocking={isLoading || updateFidoMutation.isPending}>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {t('titles.fido_management')}
+          </GluuText>
           <div className={classes.formCard}>
             <div className={classes.content}>
               <GluuTabs

--- a/admin-ui/plugins/fido/components/Configuration/components/DynamicConfiguration.tsx
+++ b/admin-ui/plugins/fido/components/Configuration/components/DynamicConfiguration.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useFormik } from 'formik'
+import useMediaQuery from '@mui/material/useMediaQuery'
 import { useTranslation } from 'react-i18next'
 import { Add, Delete as DeleteIcon } from '@/components/icons'
 import { Form, Input } from 'Components'
@@ -11,7 +12,7 @@ import GluuThemeFormFooter from 'Routes/Apps/Gluu/GluuThemeFormFooter'
 import GluuText from 'Routes/Apps/Gluu/GluuText'
 import { GluuButton } from '@/components/GluuButton'
 import { getFieldPlaceholder } from '@/utils/placeholderUtils'
-import { adminUiFeatures } from '@/constants'
+import { adminUiFeatures, MOBILE_MEDIA_QUERY } from '@/constants'
 import { useTheme } from '@/context/theme/themeContext'
 import getThemeColor from '@/context/theme/config'
 import { THEME_DARK } from '@/context/theme/constants'
@@ -36,6 +37,8 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
   readOnly,
 }) => {
   const { t } = useTranslation()
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
+  const isReadOnly = readOnly || isMobile
   const { state: themeState } = useTheme()
   const { themeColors, isDark } = useMemo(
     () => ({
@@ -50,8 +53,15 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
   const [commitOperations, setCommitOperations] = useState<GluuCommitDialogOperation[]>([])
 
   const toggle = useCallback(() => {
+    if (isReadOnly) return
     setModal((prev) => !prev)
-  }, [])
+  }, [isReadOnly])
+
+  useEffect(() => {
+    if (isReadOnly) {
+      setModal(false)
+    }
+  }, [isReadOnly])
 
   const initialValues = useMemo<DynamicConfigFormValues>(
     () =>
@@ -63,7 +73,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
 
   const formik = useFormik<DynamicConfigFormValues>({
     initialValues,
-    onSubmit: readOnly ? () => undefined : toggle,
+    onSubmit: isReadOnly ? () => undefined : toggle,
     validationSchema: fidoValidationSchemas.dynamicConfigValidationSchema,
     validateOnMount: true,
   })
@@ -87,12 +97,12 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
 
   const submitForm = useCallback(
     (userMessage: string) => {
-      if (readOnly) {
+      if (isReadOnly) {
         return
       }
       handleSubmit(formik.values, userMessage)
     },
-    [handleSubmit, formik.values, readOnly],
+    [handleSubmit, formik.values, isReadOnly],
   )
 
   const handleCancel = useCallback(() => {
@@ -102,12 +112,12 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
   const handleFormSubmit = useCallback(
     (e: React.SyntheticEvent<HTMLFormElement>) => {
       e.preventDefault()
-      if (readOnly) {
+      if (isReadOnly) {
         return
       }
       formik.handleSubmit()
     },
-    [formik, readOnly],
+    [formik, isReadOnly],
   )
 
   const personCustomObjectClassList = useMemo(
@@ -157,6 +167,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               required
               showError={!!formik.errors.issuer}
               errorMessage={formik.errors.issuer}
@@ -172,6 +183,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               required
               showError={!!formik.errors.baseEndpoint}
               errorMessage={formik.errors.baseEndpoint}
@@ -187,6 +199,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               showError={!!formik.errors.cleanServiceInterval}
               errorMessage={formik.errors.cleanServiceInterval}
               type="number"
@@ -202,6 +215,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               showError={!!formik.errors.cleanServiceBatchChunkSize}
               errorMessage={formik.errors.cleanServiceBatchChunkSize}
               type="number"
@@ -217,6 +231,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               showError={!!formik.errors.loggingLayout}
               errorMessage={formik.errors.loggingLayout}
               placeholder={getFieldPlaceholder(t, fidoConstants.LABELS.LOGGING_LAYOUT)}
@@ -232,6 +247,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               showError={!!formik.errors.metricReporterInterval}
               errorMessage={formik.errors.metricReporterInterval}
               placeholder={getFieldPlaceholder(t, fidoConstants.LABELS.METRIC_REPORTER_INTERVAL)}
@@ -247,6 +263,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               showError={!!formik.errors.metricReporterKeepDataDays}
               errorMessage={formik.errors.metricReporterKeepDataDays}
               placeholder={getFieldPlaceholder(
@@ -265,6 +282,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               showError={!!formik.errors.loggingLevel}
               errorMessage={formik.errors.loggingLevel}
             />
@@ -277,6 +295,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               doc_category={fidoConstants.DOC_CATEGORY}
             />
           </div>
@@ -288,6 +307,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               doc_category={fidoConstants.DOC_CATEGORY}
             />
           </div>
@@ -299,6 +319,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               doc_category={fidoConstants.DOC_CATEGORY}
             />
           </div>
@@ -310,6 +331,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               doc_category={fidoConstants.DOC_CATEGORY}
             />
           </div>
@@ -321,6 +343,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               doc_category={fidoConstants.DOC_CATEGORY}
             />
           </div>
@@ -332,6 +355,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               doc_category={fidoConstants.DOC_CATEGORY}
             />
           </div>
@@ -343,6 +367,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               doc_category={fidoConstants.DOC_CATEGORY}
             />
           </div>
@@ -356,6 +381,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               showError={!!formik.errors.fido2MetricsRetentionDays}
               errorMessage={formik.errors.fido2MetricsRetentionDays}
               placeholder={getFieldPlaceholder(
@@ -376,18 +402,20 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
                   {t(fidoConstants.LABELS.PERSON_CUSTOM_OBJECT_CLASSES)}
                 </span>
               </GluuText>
-              <GluuButton
-                type="button"
-                backgroundColor={themeColors.settings.addPropertyButton.bg}
-                textColor={themeColors.settings.addPropertyButton.text}
-                useOpacityOnHover
-                className={classes.propsActionBtn}
-                onClick={addObjectClass}
-                disabled={!canAddObjectClass}
-              >
-                <Add fontSize="small" />
-                {t(fidoConstants.BUTTON_TEXT.ADD_CLASSES)}
-              </GluuButton>
+              {!isMobile && (
+                <GluuButton
+                  type="button"
+                  backgroundColor={themeColors.settings.addPropertyButton.bg}
+                  textColor={themeColors.settings.addPropertyButton.text}
+                  useOpacityOnHover
+                  className={classes.propsActionBtn}
+                  onClick={addObjectClass}
+                  disabled={!canAddObjectClass}
+                >
+                  <Add fontSize="small" />
+                  {t(fidoConstants.BUTTON_TEXT.ADD_CLASSES)}
+                </GluuButton>
+              )}
             </div>
             <div className={classes.propsBody}>
               {personCustomObjectClassList.map((item, index) => (
@@ -399,18 +427,21 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
                     }
                     placeholder={t('placeholders.value')}
                     className={classes.propsInput}
+                    disabled={isMobile}
                   />
-                  <GluuButton
-                    type="button"
-                    backgroundColor={themeColors.settings.removeButton.bg}
-                    textColor={themeColors.settings.removeButton.text}
-                    useOpacityOnHover
-                    className={classes.propsActionBtn}
-                    onClick={() => removeObjectClass(index)}
-                  >
-                    <DeleteIcon className={classes.propsActionIcon} />
-                    {t('actions.remove')}
-                  </GluuButton>
+                  {!isMobile && (
+                    <GluuButton
+                      type="button"
+                      backgroundColor={themeColors.settings.removeButton.bg}
+                      textColor={themeColors.settings.removeButton.text}
+                      useOpacityOnHover
+                      className={classes.propsActionBtn}
+                      onClick={() => removeObjectClass(index)}
+                    >
+                      <DeleteIcon className={classes.propsActionIcon} />
+                      {t('actions.remove')}
+                    </GluuButton>
+                  )}
                 </div>
               ))}
               {showObjectClassError && <div className={classes.propsError}>{objectClassError}</div>}
@@ -421,8 +452,8 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
 
       <GluuThemeFormFooter
         showBack
-        showCancel
-        showApply={!readOnly}
+        showCancel={!isMobile}
+        showApply={!isReadOnly}
         onApply={() => {
           const ops = buildChangedFieldOperations(
             initialValues,
@@ -440,7 +471,7 @@ const DynamicConfiguration: React.FC<DynamicConfigurationProps> = ({
         isLoading={isSubmitting ?? false}
       />
 
-      {!readOnly && (
+      {!isReadOnly && (
         <GluuWebhookCommitDialog
           handler={toggle}
           modal={modal}

--- a/admin-ui/plugins/fido/components/Configuration/components/StaticConfiguration.tsx
+++ b/admin-ui/plugins/fido/components/Configuration/components/StaticConfiguration.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useFormik } from 'formik'
+import useMediaQuery from '@mui/material/useMediaQuery'
 import { useTranslation } from 'react-i18next'
 import { Add, Delete as DeleteIcon } from '@/components/icons'
 
@@ -13,7 +14,7 @@ import GluuAutocomplete from 'Routes/Apps/Gluu/GluuAutocomplete'
 import GluuText from 'Routes/Apps/Gluu/GluuText'
 import { GluuButton } from '@/components/GluuButton'
 import { getFieldPlaceholder } from '@/utils/placeholderUtils'
-import { adminUiFeatures } from '@/constants'
+import { adminUiFeatures, MOBILE_MEDIA_QUERY } from '@/constants'
 import { useTheme } from '@/context/theme/themeContext'
 import getThemeColor from '@/context/theme/config'
 import { THEME_DARK } from '@/context/theme/constants'
@@ -42,6 +43,8 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
   readOnly,
 }) => {
   const { t } = useTranslation()
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
+  const isReadOnly = readOnly || isMobile
 
   const { state: themeState } = useTheme()
   const { themeColors, isDark } = useMemo(
@@ -57,19 +60,30 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
   const [commitOperations, setCommitOperations] = useState<GluuCommitDialogOperation[]>([])
 
   const toggle = useCallback(() => {
+    if (isReadOnly) return
     setModal((prev) => !prev)
-  }, [])
+  }, [isReadOnly])
 
-  const initialValues: StaticConfigFormValues = transformToFormValues(
-    fidoConfiguration?.fido2Configuration,
-    fidoConstants.STATIC,
-  ) as StaticConfigFormValues
+  useEffect(() => {
+    if (isReadOnly) {
+      setModal(false)
+    }
+  }, [isReadOnly])
+
+  const initialValues = useMemo<StaticConfigFormValues>(
+    () =>
+      transformToFormValues(
+        fidoConfiguration?.fido2Configuration,
+        fidoConstants.STATIC,
+      ) as StaticConfigFormValues,
+    [fidoConfiguration],
+  )
 
   const fidoValidationSchemas = useMemo(() => getFidoValidationSchemas(t), [t])
 
   const formik = useFormik<StaticConfigFormValues>({
     initialValues,
-    onSubmit: readOnly ? () => undefined : toggle,
+    onSubmit: isReadOnly ? () => undefined : toggle,
     validationSchema: fidoValidationSchemas.staticConfigValidationSchema,
     validateOnMount: true,
   })
@@ -93,12 +107,12 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
 
   const submitForm = useCallback(
     (userMessage: string) => {
-      if (readOnly) {
+      if (isReadOnly) {
         return
       }
       handleSubmit(formik.values, userMessage)
     },
-    [handleSubmit, formik.values, readOnly],
+    [handleSubmit, formik.values, isReadOnly],
   )
 
   const handleCancel = useCallback(() => {
@@ -108,12 +122,12 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
   const handleFormSubmit = useCallback(
     (e: React.SyntheticEvent<HTMLFormElement>) => {
       e.preventDefault()
-      if (readOnly) {
+      if (isReadOnly) {
         return
       }
       formik.handleSubmit()
     },
-    [formik, readOnly],
+    [formik, isReadOnly],
   )
 
   const requestedParties = useMemo(
@@ -226,6 +240,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               required
               showError={!!formik.errors.authenticatorCertsFolder}
               errorMessage={formik.errors.authenticatorCertsFolder}
@@ -244,6 +259,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               required
               showError={!!formik.errors.mdsCertsFolder}
               errorMessage={formik.errors.mdsCertsFolder}
@@ -259,6 +275,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               required
               showError={!!formik.errors.mdsTocsFolder}
               errorMessage={formik.errors.mdsTocsFolder}
@@ -274,6 +291,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               required
               showError={!!formik.errors.serverMetadataFolder}
               errorMessage={formik.errors.serverMetadataFolder}
@@ -290,6 +308,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               required
               showError={!!formik.errors.unfinishedRequestExpiration}
               errorMessage={formik.errors.unfinishedRequestExpiration}
@@ -309,6 +328,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               required
               showError={!!formik.errors.authenticationHistoryExpiration}
               errorMessage={formik.errors.authenticationHistoryExpiration}
@@ -328,6 +348,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
               values={ATTESTATION_MODE_OPTIONS}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               required={true}
               showError={!!formik.errors.attestationMode}
               errorMessage={formik.errors.attestationMode}
@@ -344,6 +365,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               doc_category={fidoConstants.DOC_CATEGORY}
             />
           </div>
@@ -355,6 +377,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               doc_category={fidoConstants.DOC_CATEGORY}
             />
           </div>
@@ -366,6 +389,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
               formik={formik}
               lsize={LABEL_SIZE}
               rsize={INPUT_SIZE}
+              disabled={isMobile}
               doc_category={fidoConstants.DOC_CATEGORY}
             />
           </div>
@@ -380,18 +404,20 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
                   {t(fidoConstants.LABELS.REQUESTED_PARTIES_ID)}
                 </span>
               </GluuText>
-              <GluuButton
-                type="button"
-                backgroundColor={themeColors.settings.addPropertyButton.bg}
-                textColor={themeColors.settings.addPropertyButton.text}
-                useOpacityOnHover
-                className={classes.propsActionBtn}
-                onClick={addRequestedParty}
-                disabled={!canAddParty}
-              >
-                <Add fontSize="small" />
-                {t(fidoConstants.BUTTON_TEXT.ADD_PARTY)}
-              </GluuButton>
+              {!isMobile && (
+                <GluuButton
+                  type="button"
+                  backgroundColor={themeColors.settings.addPropertyButton.bg}
+                  textColor={themeColors.settings.addPropertyButton.text}
+                  useOpacityOnHover
+                  className={classes.propsActionBtn}
+                  onClick={addRequestedParty}
+                  disabled={!canAddParty}
+                >
+                  <Add fontSize="small" />
+                  {t(fidoConstants.BUTTON_TEXT.ADD_PARTY)}
+                </GluuButton>
+              )}
             </div>
             <div className={classes.propsBody}>
               {requestedParties.map((item, index) => (
@@ -403,6 +429,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
                     }
                     placeholder={t('placeholders.name')}
                     className={classes.propsInput}
+                    disabled={isMobile}
                   />
                   <Input
                     value={item.value || ''}
@@ -411,18 +438,21 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
                     }
                     placeholder={t('placeholders.value')}
                     className={classes.propsInput}
+                    disabled={isMobile}
                   />
-                  <GluuButton
-                    type="button"
-                    backgroundColor={themeColors.settings.removeButton.bg}
-                    textColor={themeColors.settings.removeButton.text}
-                    useOpacityOnHover
-                    className={classes.propsActionBtn}
-                    onClick={() => removeRequestedParty(index)}
-                  >
-                    <DeleteIcon className={classes.propsActionIcon} />
-                    {t('actions.remove')}
-                  </GluuButton>
+                  {!isMobile && (
+                    <GluuButton
+                      type="button"
+                      backgroundColor={themeColors.settings.removeButton.bg}
+                      textColor={themeColors.settings.removeButton.text}
+                      useOpacityOnHover
+                      className={classes.propsActionBtn}
+                      onClick={() => removeRequestedParty(index)}
+                    >
+                      <DeleteIcon className={classes.propsActionIcon} />
+                      {t('actions.remove')}
+                    </GluuButton>
+                  )}
                 </div>
               ))}
               {showPartiesError && <div className={classes.propsError}>{partiesError}</div>}
@@ -440,18 +470,20 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
                   {t(fidoConstants.LABELS.ENABLED_FIDO_ALGORITHMS)}
                 </span>
               </GluuText>
-              <GluuButton
-                type="button"
-                backgroundColor={themeColors.settings.addPropertyButton.bg}
-                textColor={themeColors.settings.addPropertyButton.text}
-                useOpacityOnHover
-                className={classes.propsActionBtn}
-                onClick={addAlgorithm}
-                disabled={!canAddAlgorithm}
-              >
-                <Add fontSize="small" />
-                {t(fidoConstants.BUTTON_TEXT.ADD_ALGORITHM)}
-              </GluuButton>
+              {!isMobile && (
+                <GluuButton
+                  type="button"
+                  backgroundColor={themeColors.settings.addPropertyButton.bg}
+                  textColor={themeColors.settings.addPropertyButton.text}
+                  useOpacityOnHover
+                  className={classes.propsActionBtn}
+                  onClick={addAlgorithm}
+                  disabled={!canAddAlgorithm}
+                >
+                  <Add fontSize="small" />
+                  {t(fidoConstants.BUTTON_TEXT.ADD_ALGORITHM)}
+                </GluuButton>
+              )}
             </div>
             <div className={classes.propsBody}>
               {enabledFidoAlgorithms.map((item, index) => (
@@ -463,18 +495,21 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
                     }
                     placeholder={t('placeholders.value')}
                     className={classes.propsInput}
+                    disabled={isMobile}
                   />
-                  <GluuButton
-                    type="button"
-                    backgroundColor={themeColors.settings.removeButton.bg}
-                    textColor={themeColors.settings.removeButton.text}
-                    useOpacityOnHover
-                    className={classes.propsActionBtn}
-                    onClick={() => removeAlgorithm(index)}
-                  >
-                    <DeleteIcon className={classes.propsActionIcon} />
-                    {t('actions.remove')}
-                  </GluuButton>
+                  {!isMobile && (
+                    <GluuButton
+                      type="button"
+                      backgroundColor={themeColors.settings.removeButton.bg}
+                      textColor={themeColors.settings.removeButton.text}
+                      useOpacityOnHover
+                      className={classes.propsActionBtn}
+                      onClick={() => removeAlgorithm(index)}
+                    >
+                      <DeleteIcon className={classes.propsActionIcon} />
+                      {t('actions.remove')}
+                    </GluuButton>
+                  )}
                 </div>
               ))}
               {showAlgorithmsError && <div className={classes.propsError}>{algorithmsError}</div>}
@@ -492,18 +527,20 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
                   {t(fidoConstants.LABELS.METADATA_SERVERS)}
                 </span>
               </GluuText>
-              <GluuButton
-                type="button"
-                backgroundColor={themeColors.settings.addPropertyButton.bg}
-                textColor={themeColors.settings.addPropertyButton.text}
-                useOpacityOnHover
-                className={classes.propsActionBtn}
-                onClick={addMetadataServer}
-                disabled={!canAddServer}
-              >
-                <Add fontSize="small" />
-                {t(fidoConstants.BUTTON_TEXT.ADD_METADATA_SERVER)}
-              </GluuButton>
+              {!isMobile && (
+                <GluuButton
+                  type="button"
+                  backgroundColor={themeColors.settings.addPropertyButton.bg}
+                  textColor={themeColors.settings.addPropertyButton.text}
+                  useOpacityOnHover
+                  className={classes.propsActionBtn}
+                  onClick={addMetadataServer}
+                  disabled={!canAddServer}
+                >
+                  <Add fontSize="small" />
+                  {t(fidoConstants.BUTTON_TEXT.ADD_METADATA_SERVER)}
+                </GluuButton>
+              )}
             </div>
             <div className={classes.propsBody}>
               {metadataServers.map((server, index) => (
@@ -515,6 +552,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
                     }
                     placeholder={t('placeholders.enter_url')}
                     className={classes.propsInput}
+                    disabled={isMobile}
                   />
                   <Input
                     value={server.rootCert || ''}
@@ -523,18 +561,21 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
                     }
                     placeholder={t('placeholders.enter_root_certificate')}
                     className={classes.propsInput}
+                    disabled={isMobile}
                   />
-                  <GluuButton
-                    type="button"
-                    backgroundColor={themeColors.settings.removeButton.bg}
-                    textColor={themeColors.settings.removeButton.text}
-                    useOpacityOnHover
-                    className={classes.propsActionBtn}
-                    onClick={() => removeMetadataServer(index)}
-                  >
-                    <DeleteIcon className={classes.propsActionIcon} />
-                    {t('actions.remove')}
-                  </GluuButton>
+                  {!isMobile && (
+                    <GluuButton
+                      type="button"
+                      backgroundColor={themeColors.settings.removeButton.bg}
+                      textColor={themeColors.settings.removeButton.text}
+                      useOpacityOnHover
+                      className={classes.propsActionBtn}
+                      onClick={() => removeMetadataServer(index)}
+                    >
+                      <DeleteIcon className={classes.propsActionIcon} />
+                      {t('actions.remove')}
+                    </GluuButton>
+                  )}
                 </div>
               ))}
               {showServersError && <div className={classes.propsError}>{serversError}</div>}
@@ -551,6 +592,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
               onChange={(vals) => formik.setFieldValue(fidoConstants.FORM_FIELDS.HINTS, vals)}
               onBlur={() => formik.setFieldTouched(fidoConstants.FORM_FIELDS.HINTS, true)}
               options={HINT_OPTIONS}
+              disabled={isMobile}
               required
               showError={!!formik.errors.hints}
               errorMessage={formik.errors.hints as string}
@@ -564,8 +606,8 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
 
       <GluuThemeFormFooter
         showBack
-        showCancel
-        showApply={!readOnly}
+        showCancel={!isMobile}
+        showApply={!isReadOnly}
         onApply={() => {
           const ops = buildChangedFieldOperations(
             initialValues,
@@ -583,7 +625,7 @@ const StaticConfiguration: React.FC<StaticConfigurationProps> = ({
         isLoading={isSubmitting ?? false}
       />
 
-      {!readOnly && (
+      {!isReadOnly && (
         <GluuWebhookCommitDialog
           handler={toggle}
           modal={modal}

--- a/admin-ui/plugins/fido/components/Configuration/styles/FidoConfiguration.style.ts
+++ b/admin-ui/plugins/fido/components/Configuration/styles/FidoConfiguration.style.ts
@@ -1,9 +1,10 @@
 import { makeStyles } from 'tss-react/mui'
 import type { Theme } from '@mui/material/styles'
-import { SPACING, BORDER_RADIUS, OPACITY, ICON_SIZE } from '@/constants'
+import { SPACING, BORDER_RADIUS, OPACITY, ICON_SIZE, MOBILE_MEDIA_QUERY } from '@/constants'
 import { fontFamily, fontWeights, fontSizes, lineHeights } from '@/styles/fonts'
 import { getDynamicListStyles } from '@/styles/dynamicListStyles'
 import { createFormGroupOverrides } from '@/styles/formStyles'
+import { createDisabledInputStyles } from '@/styles/disabledFieldStyles'
 import type { ThemeConfig } from '@/context/theme/config'
 import customColors from '@/customColors'
 
@@ -55,6 +56,11 @@ export const useStyles = makeStyles<FidoConfigStylesParams>()((
       flexDirection: FLEX_DIRECTION_COLUMN,
       gap: SPACING.CARD_CONTENT_GAP,
       width: WIDTH_FULL,
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& input, & select, & textarea, & .custom-select, & .form-control, & .react-toggle': {
+          pointerEvents: 'none' as const,
+        },
+      },
     },
     fieldsGrid: {
       display: 'grid',
@@ -91,6 +97,11 @@ export const useStyles = makeStyles<FidoConfigStylesParams>()((
         },
         '& .input-group': {
           margin: MARGIN_ZERO,
+        },
+        [`@media ${MOBILE_MEDIA_QUERY}`]: {
+          '& .form-group [class*="col"]': {
+            paddingBottom: 0,
+          },
         },
       }
     })(),
@@ -155,6 +166,11 @@ export const useStyles = makeStyles<FidoConfigStylesParams>()((
         color: `${themeColors.fontColor} !important`,
         opacity: OPACITY.DISABLED,
         cursor: 'not-allowed',
+      },
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& input:disabled, & select:disabled, & .custom-select:disabled': createDisabledInputStyles(
+          themeColors.fontColor,
+        ),
       },
       '& input::placeholder': {
         color: `${themeColors.textMuted} !important`,

--- a/admin-ui/plugins/fido/components/Configuration/styles/FidoFormPage.style.ts
+++ b/admin-ui/plugins/fido/components/Configuration/styles/FidoFormPage.style.ts
@@ -1,6 +1,6 @@
 import { makeStyles } from 'tss-react/mui'
 import type { Theme } from '@mui/material/styles'
-import { SPACING, BORDER_RADIUS } from '@/constants'
+import { SPACING, BORDER_RADIUS, createMobilePageTitleStyle } from '@/constants'
 import { getCardBorderStyle } from '@/styles/cardBorderStyles'
 import type { ThemeConfig } from '@/context/theme/config'
 
@@ -22,6 +22,7 @@ export const useStyles = makeStyles<FidoFormPageStylesParams>()((
   const cardBg = themeColors.settings?.cardBackground ?? themeColors.card.background
 
   return {
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     formCard: {
       backgroundColor: cardBg,
       ...cardBorderStyle,

--- a/admin-ui/plugins/jans-lock/components/JansLock.tsx
+++ b/admin-ui/plugins/jans-lock/components/JansLock.tsx
@@ -4,6 +4,8 @@ import { useAppDispatch } from '@/redux/hooks'
 import { useQueryClient } from '@tanstack/react-query'
 import GluuLoader from 'Routes/Apps/Gluu/GluuLoader'
 import GluuViewWrapper from 'Routes/Apps/Gluu/GluuViewWrapper'
+import GluuText from 'Routes/Apps/Gluu/GluuText'
+import { Card, CardBody } from 'Components'
 import { GluuPageContent } from '@/components'
 import type { JsonValue } from 'Routes/Apps/Gluu/types/common'
 import JansLockConfiguration from './JansLockConfiguration'
@@ -92,8 +94,11 @@ const JansLock: React.FC = () => {
     <GluuPageContent>
       <GluuViewWrapper canShow={canReadLock}>
         <GluuLoader blocking={isLoading || patchMutation.isPending}>
-          <div className={classes.formCard}>
-            <div className={classes.content}>
+          <GluuText variant="h1" className={classes.mobilePageTitle}>
+            {t('titles.jans_lock')}
+          </GluuText>
+          <Card className={classes.formCard}>
+            <CardBody className={classes.content}>
               <JansLockConfiguration
                 lockConfig={(lockConfiguration as Record<string, JsonValue>) ?? {}}
                 onUpdate={handleUpdate}
@@ -101,8 +106,8 @@ const JansLock: React.FC = () => {
                 canWriteLock={canWriteLock}
                 classes={classes}
               />
-            </div>
-          </div>
+            </CardBody>
+          </Card>
         </GluuLoader>
       </GluuViewWrapper>
     </GluuPageContent>

--- a/admin-ui/plugins/jans-lock/components/JansLockConfiguration.tsx
+++ b/admin-ui/plugins/jans-lock/components/JansLockConfiguration.tsx
@@ -1,9 +1,10 @@
 import { useFormik, FormikProps } from 'formik'
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import useMediaQuery from '@mui/material/useMediaQuery'
 import { useTranslation } from 'react-i18next'
 import { Form } from 'Components'
 import GluuCommitDialog from 'Routes/Apps/Gluu/GluuCommitDialog'
-import { adminUiFeatures } from '@/constants'
+import { adminUiFeatures, MOBILE_MEDIA_QUERY } from '@/constants'
 import GluuThemeFormFooter from 'Routes/Apps/Gluu/GluuThemeFormFooter'
 import GluuLoader from 'Routes/Apps/Gluu/GluuLoader'
 import {
@@ -30,14 +31,21 @@ const JansLockConfiguration: React.FC<JansLockConfigurationProps> = ({
   classes,
 }) => {
   const { t } = useTranslation()
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
+  const isReadOnly = !canWriteLock || isMobile
   const [modal, setModal] = useState(false)
   const validationSchema = useMemo(() => getLockValidationSchema(t), [t])
 
-  const viewOnly = !canWriteLock
+  useEffect(() => {
+    if (isReadOnly) {
+      setModal(false)
+    }
+  }, [isReadOnly])
 
   const toggle = useCallback((): void => {
+    if (isReadOnly) return
     setModal((prev) => !prev)
-  }, [])
+  }, [isReadOnly])
 
   const initialFormValues = useMemo(() => transformToFormValues(lockConfig), [lockConfig])
 
@@ -97,13 +105,14 @@ const JansLockConfiguration: React.FC<JansLockConfigurationProps> = ({
 
   const submitForm = useCallback(
     (_userMessage: string) => {
+      if (isReadOnly) return
       const { patches: patchOperations } = trimmedValuesAndPatches
 
       if (patchOperations.length > 0) {
         onUpdate(patchOperations)
       }
     },
-    [trimmedValuesAndPatches, onUpdate],
+    [trimmedValuesAndPatches, onUpdate, isReadOnly],
   )
 
   return (
@@ -118,7 +127,7 @@ const JansLockConfiguration: React.FC<JansLockConfigurationProps> = ({
                 formik={formik}
                 fieldItemClass={classes.fieldItem}
                 fieldItemFullWidthClass={classes.fieldItemFullWidth}
-                viewOnly={viewOnly}
+                viewOnly={isReadOnly}
               />
             ))}
           </div>
@@ -126,8 +135,8 @@ const JansLockConfiguration: React.FC<JansLockConfigurationProps> = ({
 
         <GluuThemeFormFooter
           showBack
-          showCancel
-          showApply={canWriteLock}
+          showCancel={!isMobile}
+          showApply={!isReadOnly}
           onApply={toggle}
           onCancel={handleCancel}
           disableCancel={!isFormDirty}

--- a/admin-ui/plugins/jans-lock/components/styles/JansLockFormPage.style.ts
+++ b/admin-ui/plugins/jans-lock/components/styles/JansLockFormPage.style.ts
@@ -1,10 +1,22 @@
 import { makeStyles } from 'tss-react/mui'
-import { alpha } from '@mui/material/styles'
 import type { Theme } from '@mui/material/styles'
-import { SPACING, BORDER_RADIUS, OPACITY } from '@/constants'
-import { fontFamily, fontWeights, fontSizes, lineHeights } from '@/styles/fonts'
-import { getCardBorderStyle } from '@/styles/cardBorderStyles'
+import {
+  SPACING,
+  BORDER_RADIUS,
+  OPACITY,
+  MOBILE_MEDIA_QUERY,
+  createMobilePageTitleStyle,
+} from '@/constants'
 import type { ThemeConfig } from '@/context/theme/config'
+import { getCardBorderStyle } from '@/styles/cardBorderStyles'
+import { createDisabledInputStyles } from '@/styles/disabledFieldStyles'
+import {
+  createFormGroupOverrides,
+  createFormLabelStyles,
+  createFormInputStyles,
+  createFormInputFocusStyles,
+  createFormInputAutofillStyles,
+} from '@/styles/formStyles'
 
 type JansLockFormPageStylesParams = {
   isDark: boolean
@@ -12,76 +24,40 @@ type JansLockFormPageStylesParams = {
 }
 
 const SELECT_ARROW_SPACE = 44
-const INPUT_HEIGHT = 52
-const INPUT_PADDING_VERTICAL = 14
-const INPUT_PADDING_HORIZONTAL = 21
 const ERROR_SPACE = 20
 
-const formGroupOverrides = {
-  '& .form-group': {
-    display: 'flex',
-    flexDirection: 'column' as const,
-    margin: 0,
-    padding: 0,
-  },
-  '& .form-group.row': {
-    marginLeft: 0,
-    marginRight: 0,
-  },
-  '& .form-group > label': {
-    flex: '0 0 auto',
-    width: '100%',
-    maxWidth: '100%',
-    paddingLeft: 0,
-    paddingRight: 0,
-    paddingTop: '0 !important',
-    paddingBottom: '0 !important',
-    marginBottom: '2px !important',
-  },
-  '& .form-group [class*="col"]': {
-    flex: '0 0 100%',
-    width: '100%',
-    maxWidth: '100%',
-    paddingLeft: 0,
-    paddingRight: 0,
-  },
-  '& .input-group': {
-    margin: 0,
-  },
-}
+const formGroupBase = createFormGroupOverrides()
 
 export const useStyles = makeStyles<JansLockFormPageStylesParams>()((
   theme: Theme,
   { isDark, themeColors },
 ) => {
-  const cardBorderStyle = getCardBorderStyle({ isDark })
   const cardBg = themeColors.settings?.cardBackground ?? themeColors.card.background
   const formInputBg = themeColors.settings?.formInputBackground ?? themeColors.inputBackground
   const inputBorderColor = themeColors.settings?.inputBorder ?? themeColors.borderColor
-
-  const fieldItemBase = {
-    ...formGroupOverrides,
-    '& .form-group [class*="col"]': {
-      ...formGroupOverrides['& .form-group [class*="col"]'],
-      position: 'relative' as const,
-      paddingBottom: 0,
-    },
-    '& .form-group [class*="col"]:has([data-field-error])': {
-      paddingBottom: ERROR_SPACE,
-    },
+  const inputColors = {
+    inputBg: formInputBg,
+    inputBorderColor,
+    fontColor: themeColors.fontColor,
+    textMuted: themeColors.textMuted,
   }
 
   return {
+    mobilePageTitle: createMobilePageTitleStyle(themeColors.fontColor),
     formCard: {
-      backgroundColor: cardBg,
-      ...cardBorderStyle,
-      borderRadius: BORDER_RADIUS.DEFAULT,
-      width: '100%',
-      position: 'relative',
-      overflow: 'visible',
-      display: 'flex',
-      flexDirection: 'column',
-      boxSizing: 'border-box',
+      'backgroundColor': `${cardBg} !important`,
+      ...getCardBorderStyle({ isDark }),
+      'borderRadius': BORDER_RADIUS.DEFAULT,
+      'width': '100%',
+      'position': 'relative',
+      'overflow': 'visible',
+      'display': 'flex',
+      'flexDirection': 'column',
+      'boxSizing': 'border-box',
+      '& .card-body': {
+        backgroundColor: `${cardBg} !important`,
+        borderRadius: BORDER_RADIUS.DEFAULT,
+      },
     },
     content: {
       padding: SPACING.CONTENT_PADDING,
@@ -96,124 +72,86 @@ export const useStyles = makeStyles<JansLockFormPageStylesParams>()((
       flexDirection: 'column',
       gap: 0,
       width: '100%',
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& input, & select, & textarea, & .custom-select, & .form-control, & .react-toggle': {
+          pointerEvents: 'none' as const,
+        },
+      },
     },
     fieldsGrid: {
       display: 'grid',
       gridTemplateColumns: '1fr 1fr',
       columnGap: SPACING.SECTION_GAP,
-      rowGap: SPACING.SECTION_GAP,
+      rowGap: SPACING.CARD_CONTENT_GAP,
       width: '100%',
       alignItems: 'start',
       minWidth: 0,
       [theme.breakpoints.down('md')]: {
         gridTemplateColumns: '1fr',
       },
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        rowGap: SPACING.SECTION_GAP,
+      },
     },
     fieldItem: {
       'width': '100%',
       'minWidth': 0,
       'boxSizing': 'border-box',
-      ...fieldItemBase,
-      '& [data-field-error]': {
-        position: 'absolute',
-        fontSize: `${fontSizes.sm} !important`,
+      ...formGroupBase,
+      '& .form-group [class*="col"]': {
+        ...formGroupBase['& .form-group [class*="col"]'],
+        position: 'relative',
+        paddingBottom: ERROR_SPACE,
+      },
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& .form-group [class*="col"]': {
+          paddingBottom: 0,
+        },
       },
     },
     fieldItemFullWidth: {
       'width': '100%',
       'gridColumn': '1 / -1',
       'boxSizing': 'border-box',
-      ...fieldItemBase,
-      // Style the typeahead container and input
-      '& .rbt': {
-        width: '100%',
+      ...formGroupBase,
+      '& .form-group [class*="col"]': {
+        ...formGroupBase['& .form-group [class*="col"]'],
+        position: 'relative',
+        paddingBottom: ERROR_SPACE,
       },
-      '& .rbt .form-control, & .rbt-input-main': {
-        backgroundColor: `${formInputBg} !important`,
-        border: `1px solid ${inputBorderColor} !important`,
-        borderRadius: `${BORDER_RADIUS.SMALL}px !important`,
-        color: `${themeColors.fontColor} !important`,
-        minHeight: INPUT_HEIGHT,
-        height: 'auto',
-        paddingTop: INPUT_PADDING_VERTICAL,
-        paddingBottom: INPUT_PADDING_VERTICAL,
-        paddingLeft: INPUT_PADDING_HORIZONTAL,
-        paddingRight: INPUT_PADDING_HORIZONTAL,
-        outline: 'none !important',
-        boxShadow: 'none !important',
-      },
-      '& .rbt .form-control:focus, & .rbt .form-control:active, & .rbt-input-main:focus, & .rbt-input-main:active':
-        {
-          backgroundColor: `${formInputBg} !important`,
-          color: `${themeColors.fontColor} !important`,
-          border: `1px solid ${inputBorderColor} !important`,
-          outline: 'none !important',
-          boxShadow: 'none !important',
+      [`@media ${MOBILE_MEDIA_QUERY}`]: {
+        '& .form-group [class*="col"]': {
+          paddingBottom: 0,
         },
-      '& .rbt-input-multi': {
-        backgroundColor: `${formInputBg} !important`,
-        border: `1px solid ${inputBorderColor} !important`,
-        borderRadius: `${BORDER_RADIUS.SMALL}px !important`,
-        minHeight: INPUT_HEIGHT,
-        outline: 'none !important',
-        boxShadow: 'none !important',
-      },
-      '& .rbt-input-multi:focus-within': {
-        border: `1px solid ${inputBorderColor} !important`,
-        outline: 'none !important',
-        boxShadow: 'none !important',
       },
     },
-    formLabels: {
-      '& label, & label h5, & label h5 span, & label .MuiSvgIcon-root': {
-        color: `${themeColors.fontColor} !important`,
-        fontFamily: `${fontFamily} !important`,
-        fontSize: `${fontSizes.base} !important`,
-        fontStyle: 'normal',
-        fontWeight: `${fontWeights.semiBold} !important`,
-        lineHeight: `${lineHeights.normal} !important`,
-        margin: '0 !important',
-      },
-    },
+    formLabels: createFormLabelStyles(themeColors.fontColor),
     formWithInputs: {
       '& input, & select, & .custom-select': {
+        ...createFormInputStyles(inputColors),
         backgroundColor: `${formInputBg} !important`,
-        border: `1px solid ${inputBorderColor}`,
         borderRadius: BORDER_RADIUS.SMALL,
-        color: `${themeColors.fontColor} !important`,
-        minHeight: INPUT_HEIGHT,
-        height: 'auto',
-        paddingTop: INPUT_PADDING_VERTICAL,
-        paddingBottom: INPUT_PADDING_VERTICAL,
-        paddingLeft: INPUT_PADDING_HORIZONTAL,
-        paddingRight: INPUT_PADDING_HORIZONTAL,
       },
       '& select, & .custom-select': {
         paddingRight: SELECT_ARROW_SPACE,
       },
-      '& input:focus, & input:active, & select:focus, & select:active': {
-        backgroundColor: `${formInputBg} !important`,
-        color: `${themeColors.fontColor} !important`,
-        border: `1px solid ${inputBorderColor} !important`,
-        outline: 'none',
-        boxShadow: 'none',
-      },
+      '& input:focus, & input:focus-visible, & input:active, & select:focus, & select:focus-visible, & select:active':
+        {
+          ...createFormInputFocusStyles(inputColors),
+          outlineOffset: '0 !important',
+        },
       '& input:disabled, & select:disabled': {
-        backgroundColor: `${alpha(formInputBg, OPACITY.DISABLED)} !important`,
+        backgroundColor: `${formInputBg} !important`,
         border: `1px solid ${inputBorderColor} !important`,
-        color: `${themeColors.fontColor} !important`,
-        opacity: OPACITY.DISABLED,
-        cursor: 'not-allowed',
+        ...createDisabledInputStyles(themeColors.fontColor),
       },
       '& input::placeholder': {
         color: `${themeColors.textMuted} !important`,
         opacity: OPACITY.PLACEHOLDER,
       },
       '& input:-webkit-autofill, & input:-webkit-autofill:hover, & input:-webkit-autofill:focus': {
-        WebkitBoxShadow: `0 0 0 100px ${formInputBg} inset !important`,
-        WebkitTextFillColor: `${themeColors.fontColor} !important`,
+        ...createFormInputAutofillStyles(inputColors),
         backgroundColor: `${formInputBg} !important`,
-        transition: 'background-color 5000s ease-in-out 0s',
       },
     },
   }


### PR DESCRIPTION
### feat(admin-ui): implement responsive mobile layout for Jans Lock and FIDO Configuration (#2972)

#### Summary
Implement the responsive mobile layout for the Jans Lock and FIDO Configuration pages. Both modules are now view-only on mobile, with consistent disabled-field styling, mobile page titles, responsive tab navigation, and shared form styling.

Desktop and tablet behavior remains unchanged.

---

#### Fix Summary
- Added mobile view-only handling for Jans Lock.
- Added mobile view-only handling for FIDO Static and Dynamic Configuration tabs.
- Added Back-only footers on mobile and removed Apply/Cancel actions.
- Disabled all Jans Lock fields on mobile.
- Disabled all FIDO inputs, selects, toggles, and the hints multi-select on mobile.
- Removed Add and Remove controls from FIDO repeatable sections on mobile while keeping existing entries visible.
- Added mobile page titles for both modules.
- Added horizontal scrolling for the FIDO Static/Dynamic tab bar on mobile.
- Added shared `MOBILE_MEDIA_QUERY` handling so CSS and JS use the same breakpoint.
- Ensured resizing into mobile while a commit dialog is open closes the dialog without submitting.
- Standardized disabled-field styling using `createDisabledInputStyles` for full-brightness, readable values.
- Updated Jans Lock to use the shared form-style helpers.
- Removed duplicated Jans Lock form styling.
- Removed unused Jans Lock typeahead CSS rules.
- Preserved existing desktop and tablet styling, field behavior, and permission-based controls.

---

#### Verification

```bash
npm run check:all
```

passes successfully.

- Verified Jans Lock is view-only at ≤767px.
- Verified FIDO Static and Dynamic Configuration are view-only at ≤767px.
- Verified Apply and Cancel are hidden on mobile while Back remains available.
- Verified FIDO repeatable sections do not expose Add/Remove controls on mobile.
- Verified existing FIDO entries remain visible.
- Verified the FIDO hints multi-select is non-interactive on mobile.
- Verified mobile page titles are displayed for both modules.
- Verified the FIDO tab bar scrolls horizontally on narrow screens.
- Verified disabled fields use consistent full-brightness styling.
- Verified an open commit dialog is discarded when resizing below the mobile breakpoint.
- Verified Jans Lock uses the shared form and disabled-field styling helpers.
- Verified desktop and tablet behavior remains unchanged.

---

#### 🔗 Ticket

Closes: #2972


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile-friendly page headings and card layouts for FIDO and Jans Lock configuration screens.
  * Added responsive behavior that makes configuration forms read-only on mobile devices.
  * Mobile views now hide editing actions and disable form controls.

* **Style**
  * Improved responsive spacing, disabled-field appearance, focus states, and form consistency across configuration pages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->