### PR TITLE
feat(flex-linux-setup): policy-store set-up changes

### DIFF
--- a/flex-linux-setup/flex_linux_setup/flex_schema.json
+++ b/flex-linux-setup/flex_linux_setup/flex_schema.json
@@ -127,6 +127,30 @@
         "top"
       ],
       "x_origin": "Gluu Flex created objectclass"
+    },
+    {
+      "kind": "STRUCTURAL",
+      "may": [
+        "inum",
+        "displayname",
+        "description",
+        "document",
+        "jansUsrDN",
+        "creationDate",
+        "jansLastUpd",
+        "jansStatus"
+      ],
+      "must": [
+        "objectclass"
+      ],
+      "names": [
+        "adminUIPolicyStore"
+      ],
+      "oid": "jansObjClass",
+      "sup": [
+        "top"
+      ],
+      "x_origin": "Gluu Flex created objectclass"
     }
   ],
   "oidMacros": {

--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -26,6 +26,8 @@ install_py_path = os.path.join(cur_dir, 'jans_install.py')
 installed_components = {'admin_ui': False, 'casa': False}
 jans_config_properties = '/etc/jans/conf/jans.properties'
 
+ADMIN_UI_POLICY_STORE_INUM = '86007dee-fc3f-4668-8323-c4d2836748da'
+
 app_versions = {
     "JANS_APP_VERSION": "0.0.0",
     "JANS_BUILD": "-nightly",
@@ -640,7 +642,7 @@ class flex_installer(JettyInstaller):
 
             shutil.move(tmp_cjar, self.policy_store_cjar_path)
 
-        Config.templateRenderingDict['admin_ui_policy_store_inum'] = str(uuid.uuid4())
+        Config.templateRenderingDict['admin_ui_policy_store_inum'] = ADMIN_UI_POLICY_STORE_INUM
         Config.templateRenderingDict['admin_ui_policy_store_base64'] = self.generate_base64_file(self.policy_store_cjar_path, 1)
         Config.templateRenderingDict['admin_ui_policy_store_creation_date'] = self.get_ldap_time()
 

--- a/flex-linux-setup/flex_linux_setup/flex_setup.py
+++ b/flex-linux-setup/flex_linux_setup/flex_setup.py
@@ -29,7 +29,8 @@ jans_config_properties = '/etc/jans/conf/jans.properties'
 app_versions = {
     "JANS_APP_VERSION": "0.0.0",
     "JANS_BUILD": "-nightly",
-    "NODE_VERSION": "v18.16.0"
+    "NODE_VERSION": "v18.16.0",
+    "GLUU_FLEX_POLICY_STORE": 'v2.0.0',
 }
 
 os.environ["FLEX_PRE_JANS"] = "True"
@@ -347,7 +348,7 @@ class flex_installer(JettyInstaller):
         self.admin_ui_config_properties_path = os.path.join(self.templates_dir, 'auiConfiguration.json')
         # resolved lazily (network request) only when Admin UI assets are needed
         self.adimin_ui_bin_url = ''
-        self.policy_store_cjar_url = 'https://github.com/GluuFederation/GluuFlexAdminUIPolicyStore/releases/download/v0.0.0/admin_ui_2_0.cjar'
+        self.policy_store_cjar_url = 'https://github.com/GluuFederation/GluuFlexAdminUIPolicyStore/releases/download/{}/admin_ui_2_0.cjar'.format(app_versions['GLUU_FLEX_POLICY_STORE'])
         self.policy_store_cjar_path = os.path.join(self.templates_dir, 'policy-store.cjar')
         self.schema_file = os.path.join(self.flex_setup_dir, 'flex_schema.json')
         self.java_security_fn = os.path.join(self.templates_dir, 'java.security')
@@ -363,6 +364,8 @@ class flex_installer(JettyInstaller):
         self.admin_ui_plugin_path = os.path.join(config_api_installer.libDir,
                                                  os.path.basename(self.admin_ui_plugin_source_path))
         self.admin_ui_web_hook_ldif_fn = os.path.join(self.templates_dir, 'aui_webhook.ldif')
+
+        self.admin_ui_policy_store_ldif_fn = os.path.join(self.source_dir, 'adminUIPolicyStore.ldif')
 
         if not flex_installer_downloaded and os.path.exists(self.source_dir):
             os.rename(self.source_dir, self.source_dir + '-' + time.ctime().replace(' ', '_'))
@@ -636,9 +639,13 @@ class flex_installer(JettyInstaller):
                         zout.writestr(item, data)  # preserves ZipInfo metadata + data
 
             shutil.move(tmp_cjar, self.policy_store_cjar_path)
-            config_api_installer.copyFile(self.policy_store_cjar_path, admin_ui_config_dir, backup=False)
 
-        config_api_installer.chown(admin_ui_config_dir, Config.jetty_user, Config.jetty_group, recursive=True)
+        Config.templateRenderingDict['admin_ui_policy_store_inum'] = str(uuid.uuid4())
+        Config.templateRenderingDict['admin_ui_policy_store_base64'] = self.generate_base64_file(self.policy_store_cjar_path, 1)
+        Config.templateRenderingDict['admin_ui_policy_store_creation_date'] = self.get_ldap_time()
+
+        config_api_installer.renderTemplateInOut(self.admin_ui_policy_store_ldif_fn, self.templates_dir, self.source_dir)
+        self.dbUtils.import_ldif([self.admin_ui_policy_store_ldif_fn])
 
         resource_scopes_mapping_lidf_fn = os.path.join(self.templates_dir, 'adminUIResourceScopesMapping.ldif')
 

--- a/flex-linux-setup/flex_linux_setup/templates/adminUIPolicyStore.ldif
+++ b/flex-linux-setup/flex_linux_setup/templates/adminUIPolicyStore.ldif
@@ -1,0 +1,10 @@
+dn: inum=%(admin_ui_policy_store_inum)s,ou=adminUIPolicyStore,ou=admin-ui,o=jans
+objectClass: top
+objectClass: adminUIPolicyStore
+inum: %(admin_ui_policy_store_inum)s
+displayname: Default_Policy_store
+description: Default Admin UI Policy Store
+document: %(admin_ui_policy_store_base64)s
+creationDate: %(admin_ui_policy_store_creation_date)s
+jansStatus: active
+jansUsrDN: inum=%(admin_inum)s,ou=people,o=jans

--- a/flex-linux-setup/flex_linux_setup/templates/adminUIResourceScopesMapping.ldif
+++ b/flex-linux-setup/flex_linux_setup/templates/adminUIResourceScopesMapping.ldif
@@ -576,6 +576,7 @@ dn: inum=adbbcf8f-6c5f-4d1b-90f6-985dd694d20a,ou=adminUIResourceScopesMapping,ou
 inum: adbbcf8f-6c5f-4d1b-90f6-985dd694d20a
 jansAccessType: DELETE
 jansResource: security
+jansScope: https://jans.io/oauth/jans-auth-server/config/adminui/security.delete
 jansScope: https://jans.io/oauth/jans-auth-server/config/adminui/user/role.delete
 jansScope: https://jans.io/oauth/jans-auth-server/config/adminui/user/permission.delete
 jansScope: https://jans.io/oauth/jans-auth-server/config/adminui/user/rolePermissionMapping.delete

--- a/flex-linux-setup/flex_linux_setup/templates/aui_webhook.ldif
+++ b/flex-linux-setup/flex_linux_setup/templates/aui_webhook.ldif
@@ -138,3 +138,17 @@ objectClass: top
 auiFeatureId: jans_keycloak_link_write
 displayName: Jans Keycloak Link - Edit
 jansScope: https://jans.io/oauth/config/jans-keycloak-link.write
+
+dn: auiFeatureId=policy_store_edit,ou=auiFeatures,ou=admin-ui,o=jans
+objectClass: auiFeatures
+objectClass: top
+auiFeatureId: policy_store_edit
+displayName: Policy Store - Add/Edit
+jansScope: https://jans.io/oauth/jans-auth-server/config/adminui/security.write
+
+dn: auiFeatureId=policy_store_delete,ou=auiFeatures,ou=admin-ui,o=jans
+objectClass: auiFeatures
+objectClass: top
+auiFeatureId: policy_store_delete
+displayName: Policy Store - Delete
+jansScope: https://jans.io/oauth/jans-auth-server/config/adminui/security.delete


### PR DESCRIPTION
Closes #2926

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Admin UI support for managing the policy store, including policy metadata, documents, lifecycle details, and status.
  - Added Policy Store Add/Edit and Delete actions with associated security permissions.
  - Policy store configuration is now automatically initialized during installation.

- **Bug Fixes**
  - Enabled the `security.delete` permission for deleting security resources through the Admin UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->