### PR TITLE
fix(admin-ui): fix error screen layout on mobile viewports

### DIFF
--- a/admin-ui/app/routes/Apps/Gluu/GluuErrorScreen.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/GluuErrorScreen.tsx
@@ -1,5 +1,6 @@
 import { use, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import clsx from 'clsx'
 import ArrowBack from '@mui/icons-material/ArrowBack'
 import OpenInNew from '@mui/icons-material/OpenInNew'
 import { EmptyLayout } from 'Components'
@@ -26,6 +27,7 @@ const GluuErrorScreen = ({ error, variant = 'crash' }: GluuErrorScreenProps) => 
   const { classes } = useStyles({ themeColors })
 
   const isNotFound = variant === 'not-found'
+  const hasErrorOverlay = isDevelopment && !isNotFound
   const title = isNotFound ? t('messages.resource_not_found_title') : t('messages.crash_title')
   const message = isNotFound
     ? t('messages.resource_not_found_message')
@@ -33,7 +35,7 @@ const GluuErrorScreen = ({ error, variant = 'crash' }: GluuErrorScreenProps) => 
 
   return (
     <EmptyLayout className={classes.screen}>
-      {isDevelopment && !isNotFound && (
+      {hasErrorOverlay && (
         <details className={classes.errorOverlay}>
           <summary className={classes.errorSummary}>{t('actions.show_error')}</summary>
           <pre className={classes.errorStack}>
@@ -42,7 +44,7 @@ const GluuErrorScreen = ({ error, variant = 'crash' }: GluuErrorScreenProps) => 
         </details>
       )}
       <div className={classes.scroller}>
-        <div className={classes.root}>
+        <div className={clsx(classes.root, hasErrorOverlay && classes.rootWithOverlay)}>
           <LogoThemed width={153} height={60} />
           <svg
             className={classes.ghost}

--- a/admin-ui/app/routes/Apps/Gluu/styles/GluuErrorScreen.style.ts
+++ b/admin-ui/app/routes/Apps/Gluu/styles/GluuErrorScreen.style.ts
@@ -1,5 +1,6 @@
 import { makeStyles } from 'tss-react/mui'
 import { fontFamily, fontWeights, fontSizes, letterSpacing, lineHeights } from '@/styles/fonts'
+import { MOBILE_MEDIA_QUERY, SMALL_MAX_MEDIA_QUERY, MOBILE_PAGE_PADDING_X } from '@/constants/ui'
 import type { ThemeConfig } from '@/context/theme/config'
 
 type StyleParams = { themeColors: ThemeConfig }
@@ -26,11 +27,26 @@ export const useStyles = makeStyles<StyleParams>()((theme, { themeColors }) => (
     padding: theme.spacing(12, 8),
     boxSizing: 'border-box',
     fontFamily,
+    [`@media ${MOBILE_MEDIA_QUERY}`]: {
+      paddingBlock: theme.spacing(6),
+      paddingInline: MOBILE_PAGE_PADDING_X.MD,
+    },
+    [`@media ${SMALL_MAX_MEDIA_QUERY}`]: {
+      paddingInline: MOBILE_PAGE_PADDING_X.SM,
+    },
+  },
+  rootWithOverlay: {
+    [`@media ${MOBILE_MEDIA_QUERY}`]: {
+      paddingTop: theme.spacing(10),
+    },
   },
   ghost: {
     width: 89.5,
     height: 105.5,
     marginTop: theme.spacing(5),
+    [`@media ${MOBILE_MEDIA_QUERY}`]: {
+      marginTop: theme.spacing(4),
+    },
   },
   title: {
     margin: 0,
@@ -61,13 +77,19 @@ export const useStyles = makeStyles<StyleParams>()((theme, { themeColors }) => (
   },
   actions: {
     display: 'flex',
+    flexWrap: 'wrap',
     gap: theme.spacing(2),
     alignItems: 'center',
     justifyContent: 'center',
     marginTop: theme.spacing(4),
+    [`@media ${MOBILE_MEDIA_QUERY}`]: {
+      gap: theme.spacing(2.5),
+    },
   },
   actionButton: {
     letterSpacing: letterSpacing.button,
+    whiteSpace: 'nowrap',
+    flexShrink: 0,
   },
   buttonIcon: {
     fontSize: 18,
@@ -86,6 +108,14 @@ export const useStyles = makeStyles<StyleParams>()((theme, { themeColors }) => (
     border: `1px solid ${themeColors.borderColor}`,
     boxShadow: theme.shadows[6],
     textAlign: 'left',
+    [`@media ${MOBILE_MEDIA_QUERY}`]: {
+      left: MOBILE_PAGE_PADDING_X.MD,
+      right: MOBILE_PAGE_PADDING_X.MD,
+    },
+    [`@media ${SMALL_MAX_MEDIA_QUERY}`]: {
+      left: MOBILE_PAGE_PADDING_X.SM,
+      right: MOBILE_PAGE_PADDING_X.SM,
+    },
   },
   errorSummary: {
     cursor: 'pointer',
@@ -112,6 +142,9 @@ export const useStyles = makeStyles<StyleParams>()((theme, { themeColors }) => (
   footer: {
     margin: 0,
     marginTop: theme.spacing(5),
+    [`@media ${MOBILE_MEDIA_QUERY}`]: {
+      marginTop: theme.spacing(6),
+    },
     maxWidth: '100%',
     fontSize: '13px',
     fontWeight: fontWeights.medium,
@@ -120,5 +153,6 @@ export const useStyles = makeStyles<StyleParams>()((theme, { themeColors }) => (
   },
   footerCompany: {
     fontWeight: fontWeights.semiBold,
+    whiteSpace: 'nowrap',
   },
 }))


### PR DESCRIPTION
### fix(admin-ui): fix error screen layout on mobile viewports (#2990)

#### Summary
- Fixed the `GluuErrorScreen` layout for mobile viewports.
- Updated the error screen to follow the shared mobile page padding and responsive layout patterns.
- Improved spacing and action button behavior for both `crash` and `not-found` variants.

---

#### Fix Summary
- Applied `MOBILE_PAGE_PADDING_X` for consistent horizontal spacing on mobile.
- Prevented action button labels from wrapping and stacked the buttons when they no longer fit in a row.
- Prevented "Gluu Inc." from breaking across lines in the footer.
- Updated the dev-only error stack behavior so it does not overlap the Gluu logo or shift the page content when expanded.
- Adjusted mobile vertical spacing between the logo, ghost, actions, and footer.
- Preserved the existing desktop layout.

---

#### Verification
- Verified the error screen at mobile viewports up to 767px.
- Verified both `crash` and `not-found` variants.
- Verified mobile horizontal padding matches the shared `MOBILE_PAGE_PADDING_X` values.
- Verified action button labels remain on a single line and buttons stack when required.
- Verified the footer text remains intact.
- Verified the dev error-stack bar does not overlap the logo or shift the page content.
- Verified the desktop layout remains unchanged.

---

#### 🔗 Ticket

Closes: #2990

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Gluu error screen layout on mobile devices.
  * Error details now display with appropriate spacing and alignment across screen sizes.
  * Action buttons wrap cleanly, remain readable, and avoid unwanted shrinking.
  * Improved footer spacing and preserved the company label on a single line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->