### PR TITLE
feat(cloud-native): save admin-ui policy store in persistence

### DIFF
--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -44,7 +44,7 @@ RUN git clone --depth ${GIT_CLONE_DEPTH} --filter blob:none --no-checkout https:
 
 WORKDIR /tmp/flex
 
-ENV FLEX_SOURCE_VERSION=7a45cf2c280330fe62eb31d9b46dfb478ee14e66
+ENV FLEX_SOURCE_VERSION=3f30cb6b208433d0ba65e05344980224bd4acfd8
 ARG FLEX_SETUP_DIR=flex-linux-setup/flex_linux_setup
 
 RUN git clone --depth ${GIT_CLONE_DEPTH} --filter blob:none --no-checkout https://github.com/GluuFederation/flex . \
@@ -76,6 +76,12 @@ RUN case "${ADMIN_UI_VERSION}" in \
     && mkdir -p /opt/flex/admin-ui \
     && tar xvf /tmp/admin-ui.tar.gz -C /opt/flex/admin-ui \
     && rm -rf /tmp/admin-ui.tar.gz
+
+# add default policy store (for admin-ui and cedarling integration) from https://github.com/GluuFederation/GluuFlexAdminUIPolicyStore
+ARG AUI_POLICY_VERSION=v2.0.0
+ARG AUI_POLICY_FILE=admin_ui_2_0.cjar
+
+RUN wget -nv https://github.com/GluuFederation/GluuFlexAdminUIPolicyStore/releases/download/${AUI_POLICY_VERSION}/${AUI_POLICY_FILE} -O /app/templates/admin-ui/policy-store.cjar
 
 # ======
 # Python

--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -81,7 +81,15 @@ RUN case "${ADMIN_UI_VERSION}" in \
 ARG AUI_POLICY_VERSION=v2.0.0
 ARG AUI_POLICY_FILE=admin_ui_2_0.cjar
 
-RUN wget -nv https://github.com/GluuFederation/GluuFlexAdminUIPolicyStore/releases/download/${AUI_POLICY_VERSION}/${AUI_POLICY_FILE} -O /app/templates/admin-ui/policy-store.cjar
+WORKDIR /app/templates/admin-ui
+
+RUN wget -nv "https://github.com/GluuFederation/GluuFlexAdminUIPolicyStore/releases/download/${AUI_POLICY_VERSION}/${AUI_POLICY_FILE}" \
+    && wget -nv "https://github.com/GluuFederation/GluuFlexAdminUIPolicyStore/releases/download/${AUI_POLICY_VERSION}/${AUI_POLICY_FILE}.sha256sum" \
+    && sha256sum -c admin_ui_2_0.cjar.sha256sum \
+    && rm -f admin_ui_2_0.cjar.sha256sum \
+    && mv admin_ui_2_0.cjar policy-store.cjar
+
+WORKDIR /
 
 # ======
 # Python

--- a/docker-admin-ui/scripts/bootstrap.py
+++ b/docker-admin-ui/scripts/bootstrap.py
@@ -3,6 +3,8 @@ import logging.config
 import os
 from uuid import uuid4
 from functools import cached_property
+from tempfile import TemporaryDirectory
+from zipfile import ZipFile
 
 from jans.pycloudlib import get_manager
 from jans.pycloudlib import wait_for_persistence
@@ -11,11 +13,15 @@ from jans.pycloudlib.persistence.sql import SqlClient
 from jans.pycloudlib.persistence.utils import PersistenceMapper
 from jans.pycloudlib.utils import encode_text
 from jans.pycloudlib.utils import get_random_chars
+from jans.pycloudlib.utils import generate_base64_contents
 
 from settings import LOGGING_CONFIG
+from utils import generalized_time_utc
 
 logging.config.dictConfig(LOGGING_CONFIG)
 logger = logging.getLogger("admin-ui")
+
+AUI_POLICY_STORE_INUM = "86007dee-fc3f-4668-8323-c4d2836748da"
 
 
 def main():
@@ -133,12 +139,26 @@ class PersistenceSetup:
             "org_id": "",
         })
 
+        ctx.update({
+            "admin_ui_policy_store_inum": AUI_POLICY_STORE_INUM,
+            # policy store is now saved into persistence
+            # (previously `/opt/jans/jetty/jans-config-api/custom/config/adminUI/policy-store.cjar` file)
+            "admin_ui_policy_store_base64": configure_policy_store(hostname),
+            "admin_ui_policy_store_creation_date": generalized_time_utc(),
+            "admin_inum": self.manager.config.get("admin_inum"),
+        })
+
         # finalized contexts
         return ctx
 
     @cached_property
     def ldif_files(self):
-        filenames = ["clients.ldif", "aui_webhook.ldif", "adminUIResourceScopesMapping.ldif"]
+        filenames = [
+            "clients.ldif",
+            "aui_webhook.ldif",
+            "adminUIResourceScopesMapping.ldif",
+            "adminUIPolicyStore.ldif",
+        ]
         return [f"/app/templates/admin-ui/{filename}" for filename in filenames]
 
     def import_ldif_files(self):
@@ -286,6 +306,35 @@ def render_env_config(manager):
 
     with open("/opt/flex/admin-ui/dist/env-config.js", "w") as fw:
         fw.write(txt)
+
+
+def configure_policy_store(hostname):
+    logger.info("Configuring admin-ui policy store")
+
+    policy_file = "trusted-issuers/GluuFlexAdminUI.json"
+    policy_file_found = False
+
+    with TemporaryDirectory() as tmp_dir:
+        src_archive_path = "/app/templates/admin-ui/policy-store.cjar"
+        tmp_archive_path = os.path.join(tmp_dir, "policy-store.cjar")
+
+        with ZipFile(src_archive_path, "r") as src_archive, ZipFile(tmp_archive_path, "w", compression=src_archive.compression) as tmp_archive:
+            for item in src_archive.infolist():
+                if item.filename == policy_file:
+                    policy_file_found = True
+                    policy = src_archive.read(item.filename).decode()
+                    data = policy.replace("your-openid-provider.server", hostname).encode()
+                else:
+                    data = src_archive.read(item.filename)
+
+                # copy item and preserve the original compression
+                tmp_archive.writestr(item, data, compress_type=item.compress_type)
+
+        if not policy_file_found:
+            raise FileNotFoundError(f"The required policy file {policy_file} is not found in {src_archive_path} archive.")
+
+        with open(tmp_archive_path, "rb") as f:
+            return generate_base64_contents(f.read())
 
 
 if __name__ == "__main__":

--- a/docker-admin-ui/scripts/upgrade.py
+++ b/docker-admin-ui/scripts/upgrade.py
@@ -334,6 +334,10 @@ class Upgrade:
                 "dn": "inum=77aa2e0e-a67d-4f90-a28c-a9b6077c3a7d,ou=adminUIResourceScopesMapping,ou=admin-ui,o=jans",
                 "jansScope": "https://jans.io/oauth/config/uma.admin",
             },
+            {
+                "dn": "inum=adbbcf8f-6c5f-4d1b-90f6-985dd694d20a,ou=adminUIResourceScopesMapping,ou=admin-ui,o=jans",
+                "jansScope": "https://jans.io/oauth/jans-auth-server/config/adminui/security.delete",
+            },
         ]:
             add_scope(scope["dn"], scope["jansScope"])
 

--- a/docker-admin-ui/scripts/utils.py
+++ b/docker-admin-ui/scripts/utils.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from datetime import UTC
+
+
+def utcnow():
+    return datetime.now(UTC)
+
+
+def generalized_time_utc(dtime=None):
+    """Calculate LDAP generalized time."""
+    if not dtime:
+        dtime = utcnow()
+    return dtime.strftime("%Y%m%d%H%M%SZ")

--- a/docker-flex-all-in-one/Dockerfile
+++ b/docker-flex-all-in-one/Dockerfile
@@ -70,7 +70,7 @@ RUN ln -sf /app/flex_aio/admin_ui/entrypoint.sh /app/bin/admin-ui-entrypoint.sh
 # Assets sync
 # ===========
 
-ENV JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ENV JANS_SOURCE_VERSION=0ec865687513582fc63980c40c6cc980295182d3
 
 # note that as we're pulling from a monorepo (with multiple project in it)
 # we are using partial-clone and sparse-checkout to get the assets

--- a/docker-persistence-loader/Dockerfile
+++ b/docker-persistence-loader/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/janssenproject/jans/persistence-loader:0.0.0-nightly
 # Assets sync
 # ===========
 
-ENV FLEX_SOURCE_VERSION=fb97e1d4b6e0bd272fc99996e413bee52c1edc72
+ENV FLEX_SOURCE_VERSION=3f30cb6b208433d0ba65e05344980224bd4acfd8
 
 USER 0
 


### PR DESCRIPTION
Policy store for admin-ui is now saved into persistence.

Closes #3001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the default admin UI policy store during image builds.
  * Automatically configures policy-store data for the deployed hostname.

* **Bug Fixes**
  * Added support for the `adminui/security.delete` permission during upgrades.
  * Improved policy-store archive validation and processing.

* **Chores**
  * Updated bundled Flex, Janssen, and persistence schema source revisions.
  * Added UTC timestamp handling for administrative configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->