### PR TITLE
fix(automation): use nginx-compat IngressClass on microk8s

### DIFF
--- a/.github/workflows/test-flex-aio-microk8s-demo.yml
+++ b/.github/workflows/test-flex-aio-microk8s-demo.yml
@@ -59,6 +59,11 @@ jobs:
           sudo microk8s kubectl -n gluu get pods -o wide || true
           sudo microk8s kubectl -n gluu describe pods || true
           sudo microk8s kubectl -n gluu logs -l app=flex-gluu-all-in-one-aio --tail=1000 || true
+          sudo microk8s kubectl get ingressclass -o wide || true
+          sudo microk8s kubectl -n gluu get ingress -o wide || true
+          sudo microk8s kubectl -n gluu describe ingress || true
+          sudo microk8s kubectl -n ingress-nginx get pods -o wide || true
+          sudo microk8s kubectl -n ingress-nginx logs -l app.kubernetes.io/component=controller --tail=500 || true
 
       - name: Report to Zulip
         if: always()

--- a/automation/start_flex_aio_microk8s_demo.sh
+++ b/automation/start_flex_aio_microk8s_demo.sh
@@ -157,14 +157,15 @@ chmod 600 "$KUBECONFIG"
 trap 'rm -f "$KUBECONFIG"' EXIT
 sudo microk8s config > "$KUBECONFIG"
 export KUBECONFIG
+CURL_RETRY_OPTS=(--retry 10 --retry-delay 5 --retry-connrefused)
 echo -e "Testing openid-configuration endpoint.. \n"
-curl --fail --silent --show-error -k "https://$FQDN/.well-known/openid-configuration"
+curl --fail --silent --show-error -k "${CURL_RETRY_OPTS[@]}" "https://$FQDN/.well-known/openid-configuration"
 echo -e "Testing scim-configuration endpoint.. \n"
-curl --fail --silent --show-error -k "https://$FQDN/.well-known/scim-configuration"
+curl --fail --silent --show-error -k "${CURL_RETRY_OPTS[@]}" "https://$FQDN/.well-known/scim-configuration"
 echo -e "Testing fido2-configuration endpoint.. \n"
-curl --fail --silent --show-error -k "https://$FQDN/.well-known/fido2-configuration"
+curl --fail --silent --show-error -k "${CURL_RETRY_OPTS[@]}" "https://$FQDN/.well-known/fido2-configuration"
 echo -e "Testing Admin UI endpoint.. \n"
-curl --fail --silent --show-error -k -o /dev/null "https://$FQDN/admin"
+curl --fail --silent --show-error -k "${CURL_RETRY_OPTS[@]}" -o /dev/null "https://$FQDN/admin"
 EOF
 echo "Waiting for Gluu Flex all-in-one to come up. Please do not cancel out. This can take up to 10 minutes."
 sudo microk8s.kubectl -n gluu wait --for=condition=available --timeout=600s deploy/flex-gluu-all-in-one --kubeconfig="$KUBECONFIG" || echo "all-in-one deployment is not ready. Running tests anyways..."

--- a/automation/start_flex_aio_microk8s_demo.sh
+++ b/automation/start_flex_aio_microk8s_demo.sh
@@ -49,7 +49,7 @@ fi
 sudo apt-get update
 sudo snap install microk8s --classic
 sudo microk8s.status --wait-ready
-sudo microk8s.enable dns ingress hostpath-storage helm3
+sudo microk8s.enable dns hostpath-storage helm3
 mkdir -p "$HOME/.kube"
 chmod 700 "$HOME/.kube"
 sudo microk8s config | sudo install -m 0600 /dev/stdin "$HOME/.kube/config"
@@ -57,6 +57,20 @@ sudo snap alias microk8s.kubectl kubectl
 sudo snap alias microk8s.helm3 helm
 KUBECONFIG="$HOME/.kube/config"
 sudo microk8s.kubectl create namespace gluu --kubeconfig="$KUBECONFIG" || echo "namespace exists"
+
+# microk8s 1.35's built-in "ingress" addon runs Traefik, which doesn't honor
+# the nginx-specific rewrite/regex annotations this chart's Ingress resources
+# rely on. Install the real ingress-nginx controller instead, bound directly
+# to the node's 80/443 via hostPort since there's no cloud LB here.
+sudo helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+sudo helm repo update
+sudo helm install ingress-nginx ingress-nginx/ingress-nginx \
+  --namespace ingress-nginx --create-namespace --kubeconfig="$KUBECONFIG" \
+  --set controller.hostPort.enabled=true \
+  --set controller.service.type=ClusterIP \
+  --set controller.ingressClassResource.name=nginx \
+  --set controller.ingressClassResource.default=true
+sudo microk8s.kubectl -n ingress-nginx wait --for=condition=available --timeout=180s deploy/ingress-nginx-controller --kubeconfig="$KUBECONFIG"
 
 if [[ $GLUU_PERSISTENCE == "MYSQL" ]]; then
   DB_MANIFEST="mysql.yaml"
@@ -126,9 +140,8 @@ casa:
     casaEnabled: true
 nginx-ingress:
   ingress:
-    # microk8s 1.35+ ingress addon defaults to Traefik; its "nginx" IngressClass
-    # is a compatibility shim that understands the nginx-style annotations this
-    # chart renders (the "public"/"traefik" classes don't).
+    # matches controller.ingressClassResource.name set on the ingress-nginx
+    # install above
     ingressClassName: nginx
 EOF
 sudo helm repo add gluu-flex https://docs.gluu.org/charts

--- a/automation/start_flex_aio_microk8s_demo.sh
+++ b/automation/start_flex_aio_microk8s_demo.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-# get script directory
 basedir=$(dirname "$(readlink -f -- "$0")")
 
 GLUU_FQDN=$1
@@ -58,10 +57,8 @@ sudo snap alias microk8s.helm3 helm
 KUBECONFIG="$HOME/.kube/config"
 sudo microk8s.kubectl create namespace gluu --kubeconfig="$KUBECONFIG" || echo "namespace exists"
 
-# microk8s 1.35's built-in "ingress" addon runs Traefik, which doesn't honor
-# the nginx-specific rewrite/regex annotations this chart's Ingress resources
-# rely on. Install the real ingress-nginx controller instead, bound directly
-# to the node's 80/443 via hostPort since there's no cloud LB here.
+# microk8s's built-in ingress addon runs Traefik, which doesn't honor this
+# chart's nginx-specific rewrite/regex annotations; install real ingress-nginx.
 sudo helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 sudo helm repo update
 sudo helm install ingress-nginx ingress-nginx/ingress-nginx \
@@ -140,8 +137,6 @@ casa:
     casaEnabled: true
 nginx-ingress:
   ingress:
-    # matches controller.ingressClassResource.name set on the ingress-nginx
-    # install above
     ingressClassName: nginx
 EOF
 sudo helm repo add gluu-flex https://docs.gluu.org/charts

--- a/automation/start_flex_aio_microk8s_demo.sh
+++ b/automation/start_flex_aio_microk8s_demo.sh
@@ -126,7 +126,10 @@ casa:
     casaEnabled: true
 nginx-ingress:
   ingress:
-    ingressClassName: public
+    # microk8s 1.35+ ingress addon defaults to Traefik; its "nginx" IngressClass
+    # is a compatibility shim that understands the nginx-style annotations this
+    # chart renders (the "public"/"traefik" classes don't).
+    ingressClassName: nginx
 EOF
 sudo helm repo add gluu-flex https://docs.gluu.org/charts
 sudo helm repo update

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -13,7 +13,7 @@ in enough different ways to make at least the bulk of the community happy.
 
 Currently, that means the following installation options:
 
-1. [Quick Start](quick-start/docker.md) for development/testing (not production) — [Docker All-in-One](quick-start/docker.md) or [Local Kubernetes (Minikube/MicroK8s)](quick-start/local-k8s.md)
+1. [Quick Start](quick-start/microk8s-aio.md) for development/testing (not production) — [MicroK8s All-in-One](quick-start/microk8s-aio.md), [Docker All-in-One](quick-start/docker.md), or [Local Kubernetes (Minikube/MicroK8s)](quick-start/local-k8s.md)
 2. [Helm deployments](helm-install/README.md) for Amazon, Google, Microsoft, Local, and Rancher
 3. [VM packages](vm-install/vm-requirements.md) for Ubuntu, SUSE and Red Hat
 

--- a/docs/install/quick-start/microk8s-aio.md
+++ b/docs/install/quick-start/microk8s-aio.md
@@ -1,0 +1,100 @@
+---
+tags:
+- administration
+- installation
+- quick-start
+- kubernetes
+- microk8s
+- aio
+- all-in-one
+---
+
+# MicroK8s Quick Start (All-In-One)
+
+!!! Warning
+    **This deployment is for testing and development purposes only. Use Flex [helm deployments](https://docs.gluu.org/stable/install/helm-install/) for production setups.**
+
+The fastest way to try Flex All-In-One (AIO) on Kubernetes is the demo script. It installs MicroK8s, ingress-nginx, Helm, and the Flex AIO image with default settings.
+
+## System Requirements
+
+System should meet the following requirements:
+
+- 8 GB RAM
+- 4 CPU
+- 30 GB Disk
+
+## Install
+
+Start a fresh Ubuntu VM with ports `443` and `80` open, then download the installation script and make it executable:
+
+```bash
+wget https://raw.githubusercontent.com/GluuFederation/flex/vreplace-flex-version/automation/start_flex_aio_microk8s_demo.sh
+chmod u+x start_flex_aio_microk8s_demo.sh
+```
+
+Next, execute the script. You will need to provide the following details:
+
+- Fully qualified domain name (FQDN)
+- Persistence type (`MYSQL` or `PGSQL`)
+- Flex version (leave empty `""` for the default)
+- Virtual Machine's Public IP address in place of `<VM_IP>`
+
+=== "MySQL"
+
+    ```bash
+    sudo bash start_flex_aio_microk8s_demo.sh demoexample.gluu.org MYSQL "" <VM_IP>
+    ```
+
+=== "PostgreSQL"
+
+    ```bash
+    sudo bash start_flex_aio_microk8s_demo.sh demoexample.gluu.org PGSQL "" <VM_IP>
+    ```
+
+Console messages like below will confirm the successful startup and readiness of the services:
+
+```text
+Waiting for Gluu Flex all-in-one to come up. Please do not cancel out. This can take up to 10 minutes.
+deployment.apps/flex-gluu-all-in-one condition met
+Testing openid-configuration endpoint..
+```
+
+## Verify Installation
+
+The installer adds a hosts record inside the VM. To access endpoints from outside the VM, map the VM IP to your FQDN in your local `/etc/hosts`:
+
+```bash
+# For example
+VM_IP      demoexample.gluu.org
+```
+
+Then test the standard endpoints:
+
+| Service     | Endpoint                                        |
+|-------------|-------------------------------------------------|
+| Auth server | `https://FQDN/.well-known/openid-configuration` |
+| FIDO2       | `https://FQDN/.well-known/fido2-configuration`  |
+| SCIM        | `https://FQDN/.well-known/scim-configuration`   |
+| Admin UI    | `https://FQDN/admin`                            |
+
+## Configure Flex
+
+Flex can be configured using the [Text-based User Interface (TUI)](https://docs.jans.io/stable/janssen-server/config-guide/config-tools/jans-tui/). The default `admin` password is `Test1234#`.
+
+!!! Warning
+    The default `Test1234#` credential is for local testing only. Never expose this deployment publicly, and rotate the `admin` password before reusing the cluster for anything beyond a throwaway demo.
+
+## Uninstall / Remove Flex
+
+This installation uses MicroK8s and Helm under the hood. Run the commands below to remove the Flex release, the ingress-nginx controller, and MicroK8s itself:
+
+```bash
+sudo helm uninstall flex -n gluu --kubeconfig ~/.kube/config
+sudo helm uninstall ingress-nginx -n ingress-nginx --kubeconfig ~/.kube/config
+sudo snap remove microk8s --purge
+```
+
+## Next Steps
+
+For a manual local cluster setup (or to move toward production), see the [Helm local setup](../helm-install/prerequisites/local.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,7 @@ nav:
       - 'install/README.md'
       - 'Prerequisites': 'install/flex/prerequisites.md'
       - 'Quick Start':
+          - 'MicroK8s (All-in-One)': 'install/quick-start/microk8s-aio.md'
           - 'Docker (All-in-One)': 'install/quick-start/docker.md'
           - 'Local Kubernetes (Minikube/MicroK8s)': 'install/quick-start/local-k8s.md'
       - 'Helm Deployments':


### PR DESCRIPTION
microk8s 1.35 switched the ingress addon's default controller from nginx to Traefik. ingressClassName: public routed through Traefik, which doesn't understand this chart's nginx-style ingress annotations and returned 404 on every endpoint (both CI matrix jobs failed: https://github.com/GluuFederation/flex/actions/runs/33500355111).

Uses the "nginx" IngressClass microk8s ships for compatibility instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated deployment and endpoint validation for the Gluu Flex all-in-one demo on microk8s.
  * Added support for MySQL and PostgreSQL persistence options.
  * Added configurable fully qualified domain name, version, and external IP settings.
* **Testing**
  * Added scheduled, manual, and main-branch validation workflows.
  * Added diagnostics collection and result reporting for test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->