### PR TITLE
chore: remove unused policy-store attributes from Admin UI configuration

### DIFF
--- a/flex-linux-setup/flex_linux_setup/templates/auiConfiguration.json
+++ b/flex-linux-setup/flex_linux_setup/templates/auiConfiguration.json
@@ -35,9 +35,7 @@
   "uiConfig": {
     "sessionTimeoutInMins": 30,
     "allowSmtpKeystoreEdit": true,
-    "cedarlingLogType":"off",
-    "auiPolicyStoreUrl": "",
-    "auiDefaultPolicyStorePath": "./custom/config/adminUI/policy-store.cjar"
+    "cedarlingLogType":"off"
   },
   "licenseConfig": {
     "ssa": "%(ssa)s",


### PR DESCRIPTION
Closes #3006 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Removed the policy store URL and default policy store path settings from the AUI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->