### PR TITLE
chore(cloud-native): remove unused policy-store attributes from AdminUI configuration

### DIFF
--- a/docker-admin-ui/Dockerfile
+++ b/docker-admin-ui/Dockerfile
@@ -44,7 +44,7 @@ RUN git clone --depth ${GIT_CLONE_DEPTH} --filter blob:none --no-checkout https:
 
 WORKDIR /tmp/flex
 
-ENV FLEX_SOURCE_VERSION=3f30cb6b208433d0ba65e05344980224bd4acfd8
+ENV FLEX_SOURCE_VERSION=f1ca74c77605d943945585124212be92af6f6148
 ARG FLEX_SETUP_DIR=flex-linux-setup/flex_linux_setup
 
 RUN git clone --depth ${GIT_CLONE_DEPTH} --filter blob:none --no-checkout https://github.com/GluuFederation/flex . \

--- a/docker-admin-ui/scripts/bootstrap.py
+++ b/docker-admin-ui/scripts/bootstrap.py
@@ -264,28 +264,25 @@ def resolve_conf_app(old_conf, new_conf):
         # add missing uiConfig
         ui_conf = old_conf.get("uiConfig", {})
 
-        policy_store = "./custom/config/adminUI/policy-store.cjar"
-
         # add top-level config under uiConfig (if missing)
         ui_conf_attrs = {
             "sessionTimeoutInMins": 30,
             "allowSmtpKeystoreEdit": True,
             "cedarlingLogType": "off",
-            "auiPolicyStoreUrl": "",
-            "auiDefaultPolicyStorePath": policy_store,
         }
         for k, v in ui_conf_attrs.items():
             if k not in ui_conf:
                 ui_conf[k] = v
                 should_update = True
 
-        if "cedarlingPolicyStoreRetrievalPoint" in ui_conf:
-            ui_conf.pop("cedarlingPolicyStoreRetrievalPoint", None)
-            should_update = True
-
-        if ui_conf["auiDefaultPolicyStorePath"] != policy_store:
-            ui_conf["auiDefaultPolicyStorePath"] = policy_store
-            should_update = True
+        for del_attr in [
+            "cedarlingPolicyStoreRetrievalPoint",
+            "auiPolicyStoreUrl",
+            "auiDefaultPolicyStorePath",
+        ]:
+            if del_attr in ui_conf:
+                ui_conf.pop(del_attr, None)
+                should_update = True
 
         # update/add uiConfig
         old_conf["uiConfig"] = ui_conf

--- a/docker-admin-ui/templates/admin-ui/auiConfiguration.json
+++ b/docker-admin-ui/templates/admin-ui/auiConfiguration.json
@@ -35,9 +35,7 @@
     "uiConfig": {
       "sessionTimeoutInMins": 30,
       "allowSmtpKeystoreEdit": true,
-      "cedarlingLogType": "off",
-      "auiPolicyStoreUrl": "",
-      "auiDefaultPolicyStorePath": "./custom/config/adminUI/policy-store.cjar"
+      "cedarlingLogType": "off"
     },
     "licenseConfig": {
         "ssa": "%(ssa)s",


### PR DESCRIPTION
Remove unused attributes from admin-ui configuration.

Closes #3008  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Admin UI configuration no longer includes obsolete policy store URL or local policy store path settings.
  - Existing configurations are cleaned up automatically by removing stale policy store entries.
  - Retained configuration defaults continue to be applied consistently, including session timeout, SMTP keystore editing, and Cedarling log settings.

- **Maintenance**
  - Updated the Flex source version used to build the Admin UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->