### PR TITLE
feat(admin-ui): add Cedarling log toggle to profile dropdowns

### DIFF
--- a/admin-ui/app/components/GluuDropdown/GluuDropdown.style.ts
+++ b/admin-ui/app/components/GluuDropdown/GluuDropdown.style.ts
@@ -35,6 +35,15 @@ const getPositionStyles = (position: DropdownPosition) => {
         marginLeft: SHARED_DROPDOWN_STYLES.margin,
         ...baseTransform,
       }
+    // Right-aligned to the trigger instead of centred on it, so a menu wider than
+    // its trigger grows inward. Centring overflows the viewport for a trigger that
+    // sits at the right edge, which scrolls the page horizontally.
+    case 'bottom-end':
+      return {
+        top: '100%',
+        marginTop: SHARED_DROPDOWN_STYLES.margin,
+        right: 0,
+      }
     default:
       return {}
   }
@@ -53,6 +62,16 @@ const getArrowStyles = (position: DropdownPosition) => {
         top: '-15px',
         left: '50%',
         transform: 'translateX(-50%)',
+      }
+    // Rendered against the wrapper rather than the menu (see GluuDropdown.tsx), so it
+    // centres on the trigger. 100% is the trigger's bottom edge; the menu starts 13px
+    // below that and the arrow sits 15px above the menu's top, hence the 2px back up.
+    case 'bottom-end':
+      return {
+        top: 'calc(100% - 2px)',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: SHARED_DROPDOWN_STYLES.menuZIndex + 1,
       }
     case 'left':
       return {
@@ -76,7 +95,8 @@ export const useStyles = makeStyles<{
   position: DropdownPosition
   dropdownBg: string
   centerText?: boolean
-}>()((_theme, { isDark, position, dropdownBg, centerText }) => ({
+  optionPadding?: string
+}>()((_theme, { isDark, position, dropdownBg, centerText, optionPadding }) => ({
   dropdownWrapper: {
     position: 'relative',
     display: 'inline-block',
@@ -93,7 +113,12 @@ export const useStyles = makeStyles<{
     maxHeight: SHARED_DROPDOWN_STYLES.maxHeight,
     overflow: 'visible',
     ...getPositionStyles(position),
-    marginTop: position === 'bottom' ? '13px' : position === 'top' ? undefined : '4px',
+    marginTop:
+      position === 'bottom' || position === 'bottom-end'
+        ? '13px'
+        : position === 'top'
+          ? undefined
+          : '4px',
   },
   dropdownMenuContent: {
     padding: SHARED_DROPDOWN_STYLES.padding,
@@ -140,6 +165,7 @@ export const useStyles = makeStyles<{
     ...createBaseOptionStyles({
       isDark,
       ...(centerText && { optionPadding: '12px 12px' }),
+      ...(optionPadding && { optionPadding }),
     }),
     '&.single-option': {
       justifyContent: 'center',

--- a/admin-ui/app/components/GluuDropdown/GluuDropdown.style.ts
+++ b/admin-ui/app/components/GluuDropdown/GluuDropdown.style.ts
@@ -35,9 +35,6 @@ const getPositionStyles = (position: DropdownPosition) => {
         marginLeft: SHARED_DROPDOWN_STYLES.margin,
         ...baseTransform,
       }
-    // Right-aligned to the trigger instead of centred on it, so a menu wider than
-    // its trigger grows inward. Centring overflows the viewport for a trigger that
-    // sits at the right edge, which scrolls the page horizontally.
     case 'bottom-end':
       return {
         top: '100%',
@@ -63,9 +60,6 @@ const getArrowStyles = (position: DropdownPosition) => {
         left: '50%',
         transform: 'translateX(-50%)',
       }
-    // Rendered against the wrapper rather than the menu (see GluuDropdown.tsx), so it
-    // centres on the trigger. 100% is the trigger's bottom edge; the menu starts 13px
-    // below that and the arrow sits 15px above the menu's top, hence the 2px back up.
     case 'bottom-end':
       return {
         top: 'calc(100% - 2px)',

--- a/admin-ui/app/components/GluuDropdown/GluuDropdown.tsx
+++ b/admin-ui/app/components/GluuDropdown/GluuDropdown.tsx
@@ -70,10 +70,6 @@ export const GluuDropdown = <T extends DropdownValue = DropdownValue>({
   const { classes } = useStyles({ isDark, position, dropdownBg, centerText, optionPadding })
 
   const isOpen = controlled ? (controlledIsOpen ?? false) : internalState.isOpen
-  // A 'bottom-end' menu is right-aligned to the trigger, so an arrow positioned against
-  // the menu can't find the trigger's centre — the menu is wider than the trigger by an
-  // amount that varies with the options. Rendering it against the wrapper instead, which
-  // is inline-block around the trigger alone, centres it with plain CSS.
   const arrowAnchoredToTrigger = position === 'bottom-end'
   const searchQuery = internalState.searchQuery
 

--- a/admin-ui/app/components/GluuDropdown/GluuDropdown.tsx
+++ b/admin-ui/app/components/GluuDropdown/GluuDropdown.tsx
@@ -49,6 +49,7 @@ export const GluuDropdown = <T extends DropdownValue = DropdownValue>({
   renderOption,
   renderTrigger,
   centerText = false,
+  optionPadding,
 }: GluuDropdownProps<T>): React.ReactElement => {
   const [internalState, setInternalState] = useState<DropdownState>({
     isOpen: false,
@@ -66,9 +67,14 @@ export const GluuDropdown = <T extends DropdownValue = DropdownValue>({
   const dropdownBg = useMemo(() => {
     return isDark ? customColors.darkDropdownBg : customColors.white
   }, [isDark])
-  const { classes } = useStyles({ isDark, position, dropdownBg, centerText })
+  const { classes } = useStyles({ isDark, position, dropdownBg, centerText, optionPadding })
 
   const isOpen = controlled ? (controlledIsOpen ?? false) : internalState.isOpen
+  // A 'bottom-end' menu is right-aligned to the trigger, so an arrow positioned against
+  // the menu can't find the trigger's centre — the menu is wider than the trigger by an
+  // amount that varies with the options. Rendering it against the wrapper instead, which
+  // is inline-block around the trigger alone, centres it with plain CSS.
+  const arrowAnchoredToTrigger = position === 'bottom-end'
   const searchQuery = internalState.searchQuery
 
   const setIsOpen = useCallback(
@@ -152,7 +158,7 @@ export const GluuDropdown = <T extends DropdownValue = DropdownValue>({
       option.onClick?.(option.value, option)
       onSelect?.(option.value, option)
 
-      if (closeOnSelect) {
+      if (closeOnSelect && !option.keepOpen) {
         setIsOpen(false)
         setInternalState((prev) => ({ ...prev, searchQuery: '' }))
       }
@@ -269,7 +275,7 @@ export const GluuDropdown = <T extends DropdownValue = DropdownValue>({
           role="listbox"
           id={listboxId}
         >
-          {showArrow && (
+          {showArrow && !arrowAnchoredToTrigger && (
             <div className={classes.arrow}>
               <ArrowIcon />
             </div>
@@ -292,6 +298,11 @@ export const GluuDropdown = <T extends DropdownValue = DropdownValue>({
             {renderOptions}
           </div>
         </Box>
+      )}
+      {isOpen && showArrow && arrowAnchoredToTrigger && (
+        <div className={classes.arrow}>
+          <ArrowIcon />
+        </div>
       )}
     </div>
   )

--- a/admin-ui/app/components/GluuDropdown/types/GluuDropdownTypes.ts
+++ b/admin-ui/app/components/GluuDropdown/types/GluuDropdownTypes.ts
@@ -13,7 +13,6 @@ export type GluuDropdownOption<T extends DropdownValue = DropdownValue> = {
   icon?: React.ReactNode
   metadata?: Record<string, string | number | boolean | null | undefined>
   searchValue?: string
-  /** Keeps the menu open after this option is clicked, even when closeOnSelect is set. */
   keepOpen?: boolean
 }
 
@@ -45,7 +44,6 @@ export type GluuDropdownProps<T extends DropdownValue = DropdownValue> = {
     selectedOption?: GluuDropdownOption<T> | GluuDropdownOption<T>[],
   ) => React.ReactNode
   centerText?: boolean
-  /** Overrides the default option padding, which reserves 48px on the right for a checkmark slot. */
   optionPadding?: string
 }
 

--- a/admin-ui/app/components/GluuDropdown/types/GluuDropdownTypes.ts
+++ b/admin-ui/app/components/GluuDropdown/types/GluuDropdownTypes.ts
@@ -1,6 +1,6 @@
 import type React from 'react'
 
-export type DropdownPosition = 'top' | 'bottom' | 'left' | 'right'
+export type DropdownPosition = 'top' | 'bottom' | 'bottom-end' | 'left' | 'right'
 
 export type DropdownValue = string | number | boolean
 
@@ -13,6 +13,8 @@ export type GluuDropdownOption<T extends DropdownValue = DropdownValue> = {
   icon?: React.ReactNode
   metadata?: Record<string, string | number | boolean | null | undefined>
   searchValue?: string
+  /** Keeps the menu open after this option is clicked, even when closeOnSelect is set. */
+  keepOpen?: boolean
 }
 
 export type GluuDropdownProps<T extends DropdownValue = DropdownValue> = {
@@ -43,6 +45,8 @@ export type GluuDropdownProps<T extends DropdownValue = DropdownValue> = {
     selectedOption?: GluuDropdownOption<T> | GluuDropdownOption<T>[],
   ) => React.ReactNode
   centerText?: boolean
+  /** Overrides the default option padding, which reserves 48px on the right for a checkmark slot. */
+  optionPadding?: string
 }
 
 export type DropdownState = {

--- a/admin-ui/app/locales/en/translation.json
+++ b/admin-ui/app/locales/en/translation.json
@@ -759,6 +759,7 @@
     "platform": "Platform",
     "authType": "Auth Type",
     "showCedarLogs?": "Cedarling Log enabled?",
+    "cedarlingLogs?": "Cedarling logs?",
     "reloginToViewCedarlingChanges": "Please Re-login to view the cedarling changes.",
     "allAvailableHintsSelected": "All available hint options are selected",
     "noMatchingOptions": "No matching options",

--- a/admin-ui/app/locales/es/translation.json
+++ b/admin-ui/app/locales/es/translation.json
@@ -721,6 +721,7 @@
     "platform": "Plataforma",
     "authType": "Tipo de Autenticación",
     "showCedarLogs?": "¿Registro de Cedarling habilitado?",
+    "cedarlingLogs?": "¿Registros de Cedarling?",
     "reloginToViewCedarlingChanges": "Por favor, vuelve a iniciar sesión para ver los cambios de Cedarling.",
     "allAvailableHintsSelected": "Todas las opciones de sugerencia disponibles están seleccionadas",
     "noMatchingOptions": "No hay opciones coincidentes",

--- a/admin-ui/app/locales/fr/translation.json
+++ b/admin-ui/app/locales/fr/translation.json
@@ -842,6 +842,7 @@
     "platform": "Plateforme",
     "authType": "Type d'authentification",
     "showCedarLogs?": "Cedarling Log est-il activé?",
+    "cedarlingLogs?": "Journaux Cedarling ?",
     "reloginToViewCedarlingChanges": "Veuillez vous reconnecter pour voir les modifications de cedarling.",
     "allAvailableHintsSelected": "Toutes les options d'indice disponibles sont sélectionnées.",
     "noMatchingOptions": "Aucune option correspondante",

--- a/admin-ui/app/locales/pt/translation.json
+++ b/admin-ui/app/locales/pt/translation.json
@@ -798,6 +798,7 @@
     "platform": "Plataforma",
     "authType": "Tipo de autenticação",
     "showCedarLogs?": "O Cedarling Log está habilitado?",
+    "cedarlingLogs?": "Logs do Cedarling?",
     "reloginToViewCedarlingChanges": "Por favor, faça login novamente para ver as alterações do cedarling.",
     "allAvailableHintsSelected": "Todas as opções de dica disponíveis estão selecionadas",
     "noMatchingOptions": "Nenhuma opção correspondente",

--- a/admin-ui/app/routes/Apps/Gluu/GluuNavBar.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/GluuNavBar.tsx
@@ -151,7 +151,7 @@ const GluuNavBar = () => {
                   </Box>
                 </Box>
               )}
-              position="bottom"
+              position="bottom-end"
             />
           )}
         </Box>

--- a/admin-ui/app/routes/Apps/Gluu/GluuToggle.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/GluuToggle.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import type { ChangeEvent } from 'react'
 import clsx from 'clsx'
+import customColors from '@/customColors'
 import type { JsonValue } from './types/common'
 import type { GluuToggleProps } from './types/GluuToggle.types'
 import { useStyles } from './styles/GluuToggle.style'
@@ -39,7 +40,7 @@ const GluuToggle = <T = Record<string, JsonValue>,>({
             <svg width="14" height="11" viewBox="0 0 14 11">
               <path
                 d="M11.264 0L5.26 6.004 2.103 2.847 0 4.95l5.26 5.26 8.108-8.107L11.264 0"
-                fill="#fff"
+                fill={customColors.white}
                 fillRule="evenodd"
               />
             </svg>
@@ -48,7 +49,7 @@ const GluuToggle = <T = Record<string, JsonValue>,>({
             <svg width="10" height="10" viewBox="0 0 10 10">
               <path
                 d="M9.9 2.12L7.78 0 4.95 2.828 2.12 0 0 2.12l2.83 2.83L0 7.776 2.123 9.9 4.95 7.07 7.78 9.9 9.9 7.776 7.072 4.95 9.9 2.12"
-                fill="#fff"
+                fill={customColors.white}
                 fillRule="evenodd"
               />
             </svg>

--- a/admin-ui/app/routes/Apps/Gluu/__tests__/GluuNavBar.test.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/__tests__/GluuNavBar.test.tsx
@@ -15,6 +15,10 @@ const createTestStore = (userinfo: UserInfo | null): Store =>
     }),
   })
 
+jest.mock('@/utils/hooks/useCedarlingLogToggle', () => ({
+  useCedarlingLogToggle: () => ({ enabled: false, toggle: jest.fn(), isSaving: false }),
+}))
+
 const renderNavBar = (userinfo: UserInfo | null) => {
   const store = createTestStore(userinfo)
   const Wrapper = ({ children }: { children: ReactNode }) => (

--- a/admin-ui/app/routes/components/Dropdowns/DropdownProfile.tsx
+++ b/admin-ui/app/routes/components/Dropdowns/DropdownProfile.tsx
@@ -5,12 +5,16 @@ import { useAppNavigation, ROUTES } from '@/helpers/navigation'
 import { auditLogoutLogs } from 'Redux/features/sessionSlice'
 import { MANUAL_LOGOUT } from '@/audit/messages'
 import { GluuDropdown, type GluuDropdownOption } from 'Components'
+import Box from '@mui/material/Box'
+import Switch from '@mui/material/Switch'
+import { useCedarlingLogToggle } from '@/utils/hooks/useCedarlingLogToggle'
 import type { DropdownProfileProps } from './types'
 
 const DropdownProfile = ({ trigger, renderTrigger, position = 'bottom' }: DropdownProfileProps) => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const { navigateToRoute } = useAppNavigation()
+  const { enabled: cedarLogsEnabled, toggle: toggleCedarLogs } = useCedarlingLogToggle()
 
   const handleLogout = useCallback(() => {
     dispatch(auditLogoutLogs({ message: MANUAL_LOGOUT }))
@@ -26,6 +30,35 @@ const DropdownProfile = ({ trigger, renderTrigger, position = 'bottom' }: Dropdo
         },
       },
       {
+        value: 'cedarLogs',
+        label: (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              flex: 1,
+              gap: 2,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {t('fields.cedarlingLogs?')}
+            <Switch
+              size="small"
+              checked={cedarLogsEnabled}
+              slotProps={{ input: { 'aria-label': t('fields.cedarlingLogs?') } }}
+            />
+          </Box>
+        ),
+        searchValue: t('fields.cedarlingLogs?'),
+        // The menu stays open so the switch's new position and the resulting toast are
+        // both visible without reopening the dropdown.
+        keepOpen: true,
+        onClick: () => {
+          toggleCedarLogs()
+        },
+      },
+      {
         value: 'logout',
         label: t('menus.signout'),
         onClick: () => {
@@ -33,7 +66,7 @@ const DropdownProfile = ({ trigger, renderTrigger, position = 'bottom' }: Dropdo
         },
       },
     ],
-    [t, navigateToRoute, handleLogout],
+    [t, navigateToRoute, handleLogout, cedarLogsEnabled, toggleCedarLogs],
   )
 
   return (
@@ -43,6 +76,7 @@ const DropdownProfile = ({ trigger, renderTrigger, position = 'bottom' }: Dropdo
       options={options}
       position={position}
       minWidth={182}
+      optionPadding="12px"
       showArrow={true}
     />
   )

--- a/admin-ui/app/routes/components/Dropdowns/DropdownProfile.tsx
+++ b/admin-ui/app/routes/components/Dropdowns/DropdownProfile.tsx
@@ -51,8 +51,6 @@ const DropdownProfile = ({ trigger, renderTrigger, position = 'bottom' }: Dropdo
           </Box>
         ),
         searchValue: t('fields.cedarlingLogs?'),
-        // The menu stays open so the switch's new position and the resulting toast are
-        // both visible without reopening the dropdown.
         keepOpen: true,
         onClick: () => {
           toggleCedarLogs()

--- a/admin-ui/app/routes/components/Dropdowns/MobileProfileDropdown.tsx
+++ b/admin-ui/app/routes/components/Dropdowns/MobileProfileDropdown.tsx
@@ -19,6 +19,8 @@ import { THEME_LIGHT, THEME_DARK } from '@/context/theme/constants'
 import { useThemePersistence } from '@/hooks/useThemePersistence'
 import { useLangPersistence } from '@/hooks/useLangPersistence'
 import { LANG_CODES, DEFAULT_LANG } from '@/constants'
+import Switch from '@mui/material/Switch'
+import { useCedarlingLogToggle } from '@/utils/hooks/useCedarlingLogToggle'
 import { useStyles } from './styles/MobileProfileDropdown.style'
 import type { MobileProfileDropdownProps } from './types'
 
@@ -88,6 +90,8 @@ const MobileProfileDropdown = ({ userInfo, renderTrigger }: MobileProfileDropdow
   }, [isOpen])
 
   const onChangeTheme = useThemePersistence(userInfo)
+
+  const { enabled: cedarLogsEnabled, toggle: toggleCedarLogs } = useCedarlingLogToggle()
 
   const handleProfile = useCallback(() => {
     setIsOpen(false)
@@ -216,6 +220,20 @@ const MobileProfileDropdown = ({ userInfo, renderTrigger }: MobileProfileDropdow
                   </span>
                 </span>
               )}
+            />
+          </div>
+
+          <hr className={classes.divider} />
+
+          <div className={classes.row}>
+            <GluuText variant="span" className={classes.rowLabel}>
+              {t('fields.cedarlingLogs?')}
+            </GluuText>
+            <Switch
+              size="small"
+              checked={cedarLogsEnabled}
+              onChange={toggleCedarLogs}
+              slotProps={{ input: { 'aria-label': t('fields.cedarlingLogs?') } }}
             />
           </div>
 

--- a/admin-ui/app/routes/components/Dropdowns/__tests__/DropdownProfile.test.tsx
+++ b/admin-ui/app/routes/components/Dropdowns/__tests__/DropdownProfile.test.tsx
@@ -7,6 +7,16 @@ import { DropdownProfile } from '../DropdownProfile'
 import sessionReducer, { auditLogoutLogs } from 'Redux/features/sessionSlice'
 import { ROUTES } from '@/helpers/navigation'
 
+const mockToggleCedarLogs = jest.fn()
+
+jest.mock('@/utils/hooks/useCedarlingLogToggle', () => ({
+  useCedarlingLogToggle: () => ({
+    enabled: false,
+    toggle: mockToggleCedarLogs,
+    isSaving: false,
+  }),
+}))
+
 const mockNavigateToRoute = jest.fn()
 
 jest.mock('@/helpers/navigation', () => ({

--- a/admin-ui/app/routes/components/Dropdowns/__tests__/MobileProfileDropdown.test.tsx
+++ b/admin-ui/app/routes/components/Dropdowns/__tests__/MobileProfileDropdown.test.tsx
@@ -3,7 +3,10 @@ import { Provider } from 'react-redux'
 import { configureStore, combineReducers } from '@reduxjs/toolkit'
 import { I18nextProvider } from 'react-i18next'
 import i18n from '@/i18n'
-import { DropdownProfile } from '../DropdownProfile'
+import { ThemeContext } from '@/context/theme/themeContext'
+import type { ThemeContextType } from '@/context/theme/themeContext'
+import { THEME_LIGHT } from '@/context/theme/constants'
+import { MobileProfileDropdown } from '../MobileProfileDropdown'
 import sessionReducer, { auditLogoutLogs } from 'Redux/features/sessionSlice'
 import { ROUTES } from '@/helpers/navigation'
 
@@ -24,13 +27,26 @@ jest.mock('@/helpers/navigation', () => ({
   useAppNavigation: () => ({ navigateToRoute: mockNavigateToRoute }),
 }))
 
+jest.mock('@/hooks/useThemePersistence', () => ({
+  useThemePersistence: () => jest.fn(),
+}))
+
+jest.mock('@/hooks/useLangPersistence', () => ({
+  useLangPersistence: () => ({ lang: 'en', changeLanguage: jest.fn() }),
+}))
+
 const makeStore = () =>
   configureStore({
     reducer: combineReducers({ sessionReducer }),
     preloadedState: { sessionReducer: { landingPath: null, logoutRequested: false } },
   })
 
-const renderProfile = (store = makeStore()) => {
+const themeValue: ThemeContextType = {
+  state: { theme: THEME_LIGHT },
+  dispatch: jest.fn(),
+}
+
+const renderMobileProfile = (store = makeStore()) => {
   const dispatchSpy = jest.spyOn(store, 'dispatch')
   return {
     store,
@@ -38,7 +54,12 @@ const renderProfile = (store = makeStore()) => {
     ...render(
       <Provider store={store}>
         <I18nextProvider i18n={i18n}>
-          <DropdownProfile trigger={<button type="button">Account</button>} />
+          <ThemeContext.Provider value={themeValue}>
+            <MobileProfileDropdown
+              userInfo={{ inum: 'test-inum' } as never}
+              renderTrigger={() => <span>Account</span>}
+            />
+          </ThemeContext.Provider>
         </I18nextProvider>
       </Provider>,
     ),
@@ -47,54 +68,40 @@ const renderProfile = (store = makeStore()) => {
 
 const openMenu = () => fireEvent.click(screen.getByText('Account'))
 
-describe('DropdownProfile', () => {
+describe('MobileProfileDropdown', () => {
   beforeEach(() => {
     mockNavigateToRoute.mockClear()
     mockToggleCedarLogs.mockClear()
   })
 
   it('renders the trigger', () => {
-    renderProfile()
+    renderMobileProfile()
     expect(screen.getByText('Account')).toBeInTheDocument()
   })
 
-  it('shows profile and sign-out options when opened', () => {
-    renderProfile()
+  it('shows profile and sign-out rows when opened', () => {
+    renderMobileProfile()
     openMenu()
     expect(screen.getByText(i18n.t('menus.my_profile'))).toBeInTheDocument()
     expect(screen.getByText(i18n.t('menus.signout'))).toBeInTheDocument()
   })
 
   it('navigates to the profile route when "my profile" is clicked', () => {
-    renderProfile()
+    renderMobileProfile()
     openMenu()
     fireEvent.click(screen.getByText(i18n.t('menus.my_profile')))
     expect(mockNavigateToRoute).toHaveBeenCalledWith(ROUTES.PROFILE)
   })
 
-  it('toggles cedarling logs once when the option is activated', () => {
-    renderProfile()
+  it('toggles cedarling logs once when the switch is changed', () => {
+    renderMobileProfile()
     openMenu()
     fireEvent.click(screen.getByRole('switch', { name: i18n.t('fields.cedarlingLogs?') }))
     expect(mockToggleCedarLogs).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps the menu open after cedarling logs is toggled', () => {
-    renderProfile()
-    openMenu()
-    fireEvent.click(screen.getByRole('switch', { name: i18n.t('fields.cedarlingLogs?') }))
-    expect(screen.getByText(i18n.t('menus.signout'))).toBeInTheDocument()
-  })
-
-  it('closes the menu after sign out is clicked', () => {
-    renderProfile()
-    openMenu()
-    fireEvent.click(screen.getByText(i18n.t('menus.signout')))
-    expect(screen.queryByText(i18n.t('menus.my_profile'))).not.toBeInTheDocument()
-  })
-
   it('dispatches a logout audit when sign out is clicked', () => {
-    const { dispatchSpy } = renderProfile()
+    const { dispatchSpy } = renderMobileProfile()
     openMenu()
     fireEvent.click(screen.getByText(i18n.t('menus.signout')))
     expect(dispatchSpy).toHaveBeenCalledWith(

--- a/admin-ui/app/utils/hooks/useCedarlingLogToggle.ts
+++ b/admin-ui/app/utils/hooks/useCedarlingLogToggle.ts
@@ -1,0 +1,84 @@
+import { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useQueryClient } from '@tanstack/react-query'
+import {
+  useGetAdminuiConf,
+  useEditAdminuiConf,
+  getGetAdminuiConfQueryKey,
+  type AppConfigResponse,
+} from 'JansConfigApi'
+import { useAppDispatch } from '@/redux/hooks'
+import { updateToast } from '@/redux/features/toastSlice'
+import { getOAuth2ConfigResponse } from '@/redux/features/authSlice'
+import type { Config } from '@/redux/features/types/authTypes'
+import { CEDARLING_LOG_TYPE } from '@/cedarling/constants'
+import { getErrorMessage } from '@/utils/errorHandler'
+
+type UseCedarlingLogToggle = {
+  enabled: boolean
+  toggle: () => void
+  isSaving: boolean
+}
+
+export const useCedarlingLogToggle = (): UseCedarlingLogToggle => {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+  const queryClient = useQueryClient()
+
+  const { data: config } = useGetAdminuiConf()
+  const editConfigMutation = useEditAdminuiConf()
+
+  // Holds the value the user just picked so the switch flips immediately. Cleared once the
+  // query cache carries the server's answer, or on failure so the switch snaps back.
+  const [optimisticEnabled, setOptimisticEnabled] = useState<boolean | null>(null)
+
+  const serverEnabled = useMemo(
+    () => config?.cedarlingLogType === CEDARLING_LOG_TYPE.STD_OUT,
+    [config?.cedarlingLogType],
+  )
+
+  const enabled = optimisticEnabled ?? serverEnabled
+
+  const toggle = useCallback(() => {
+    if (editConfigMutation.isPending) return
+
+    const nextEnabled = !enabled
+
+    const updatePayload: AppConfigResponse = {
+      sessionTimeoutInMins: config?.sessionTimeoutInMins || undefined,
+      acrValues: config?.acrValues,
+      additionalParameters: config?.additionalParameters,
+      cedarlingLogType: nextEnabled ? CEDARLING_LOG_TYPE.STD_OUT : CEDARLING_LOG_TYPE.OFF,
+    }
+
+    setOptimisticEnabled(nextEnabled)
+
+    editConfigMutation.mutate(
+      { data: updatePayload },
+      {
+        onSuccess: (updatedConfig) => {
+          // Seed the cache before clearing the optimistic value, otherwise the switch
+          // flickers back to the stale value while the refetch is in flight.
+          queryClient.setQueryData(getGetAdminuiConfQueryKey(), updatedConfig)
+          setOptimisticEnabled(null)
+          queryClient.invalidateQueries({ queryKey: getGetAdminuiConfQueryKey() })
+          dispatch(getOAuth2ConfigResponse({ config: updatedConfig as Config }))
+          dispatch(updateToast(true, 'success', t('fields.reloginToViewCedarlingChanges')))
+        },
+        onError: (error) => {
+          setOptimisticEnabled(null)
+          const normalizedError = error instanceof Error ? error : new Error(String(error))
+          dispatch(
+            updateToast(
+              true,
+              'error',
+              getErrorMessage(normalizedError, 'messages.error_in_saving', t),
+            ),
+          )
+        },
+      },
+    )
+  }, [config, enabled, editConfigMutation, queryClient, dispatch, t])
+
+  return { enabled, toggle, isSaving: editConfigMutation.isPending }
+}

--- a/admin-ui/app/utils/hooks/useCedarlingLogToggle.ts
+++ b/admin-ui/app/utils/hooks/useCedarlingLogToggle.ts
@@ -28,8 +28,6 @@ export const useCedarlingLogToggle = (): UseCedarlingLogToggle => {
   const { data: config } = useGetAdminuiConf()
   const editConfigMutation = useEditAdminuiConf()
 
-  // Holds the value the user just picked so the switch flips immediately. Cleared once the
-  // query cache carries the server's answer, or on failure so the switch snaps back.
   const [optimisticEnabled, setOptimisticEnabled] = useState<boolean | null>(null)
 
   const serverEnabled = useMemo(
@@ -57,8 +55,6 @@ export const useCedarlingLogToggle = (): UseCedarlingLogToggle => {
       { data: updatePayload },
       {
         onSuccess: (updatedConfig) => {
-          // Seed the cache before clearing the optimistic value, otherwise the switch
-          // flickers back to the stale value while the refetch is in flight.
           queryClient.setQueryData(getGetAdminuiConfQueryKey(), updatedConfig)
           setOptimisticEnabled(null)
           queryClient.invalidateQueries({ queryKey: getGetAdminuiConfQueryKey() })

--- a/admin-ui/plugins/admin/__tests__/components/Settings/SettingsPage.test.tsx
+++ b/admin-ui/plugins/admin/__tests__/components/Settings/SettingsPage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -18,10 +18,19 @@ jest.mock('@/cedarling', () => ({
   CEDAR_RESOURCE_SCOPES: { settings: [] },
 }))
 
+const mockUsePermission = jest.fn(() => ({ canRead: true, canWrite: true, canDelete: true }))
+
+jest.mock('@/cedarling/hooks/usePermission', () => ({
+  usePermission: () => mockUsePermission(),
+}))
+
 jest.mock('@/cedarling/utility', () => ({
   ADMIN_UI_RESOURCES: { Settings: 'settings' },
   CEDAR_RESOURCE_SCOPES: { settings: [] },
+  buildCedarPermissionKey: (resource: string, action: string) => `${resource}::${action}`,
 }))
+
+const mockMutateAsync = jest.fn()
 
 jest.mock('JansConfigApi', () => ({
   useGetAdminuiConf: jest.fn(() => ({
@@ -30,7 +39,7 @@ jest.mock('JansConfigApi', () => ({
     isFetching: false,
     isLoading: false,
   })),
-  useEditAdminuiConf: jest.fn(() => ({ mutateAsync: jest.fn() })),
+  useEditAdminuiConf: jest.fn(() => ({ mutateAsync: mockMutateAsync })),
   useGetConfigScriptsByType: jest.fn(() => ({
     data: { entries: [] },
     isLoading: false,
@@ -50,6 +59,9 @@ const store = configureStore({
         config: { clientId: '123', configApiBaseUrl: 'https://example.com' },
       },
     ) => state,
+    cedarPermissions: (
+      state = { permissions: { 'settings::read': true, 'settings::write': true } },
+    ) => state,
     noReducer: (state = {}) => state,
   }),
 })
@@ -57,6 +69,28 @@ const store = configureStore({
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
+
+const makeWrapper = (permissions: Record<string, boolean>) => {
+  const scopedStore = configureStore({
+    reducer: combineReducers({
+      authReducer: (
+        state = {
+          userinfo: { name: 'Test User' },
+          config: { clientId: '123', configApiBaseUrl: 'https://example.com' },
+        },
+      ) => state,
+      cedarPermissions: (state = { permissions }) => state,
+      noReducer: (state = {}) => state,
+    }),
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <AppTestWrapper>
+        <Provider store={scopedStore}>{children}</Provider>
+      </AppTestWrapper>
+    </QueryClientProvider>
+  )
+}
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <QueryClientProvider client={queryClient}>
@@ -97,4 +131,56 @@ it('Should list installed agama project flows in the ACR dropdown', async () => 
     await screen.findByRole('option', { name: /agama_org\.gluu\.agama\.pw\.main \(agama\)/ }),
   ).toBeInTheDocument()
   expect(screen.queryByRole('option', { name: /agama_org\.gluu\.agama\.hidden/ })).toBeNull()
+})
+
+describe('read-only access', () => {
+  beforeEach(() => {
+    mockMutateAsync.mockClear()
+    mockUsePermission.mockReturnValue({ canRead: true, canWrite: false, canDelete: false })
+  })
+
+  afterEach(() => {
+    mockUsePermission.mockReturnValue({ canRead: true, canWrite: true, canDelete: true })
+  })
+
+  it('does not submit when the role lacks Settings write', async () => {
+    const { container } = render(<SettingsPage />, { wrapper: Wrapper })
+    await screen.findByText(/List paging size/)
+
+    const form = container.querySelector('form')
+    expect(form).not.toBeNull()
+    fireEvent.submit(form as HTMLFormElement)
+
+    expect(mockMutateAsync).not.toHaveBeenCalled()
+  })
+
+  it('disables the editable fields when the role lacks Settings write', async () => {
+    const { container } = render(<SettingsPage />, { wrapper: Wrapper })
+    await screen.findByText(/List paging size/)
+
+    const sessionTimeout = container.querySelector('input[name="sessionTimeoutInMins"]')
+    expect(sessionTimeout).toBeDisabled()
+  })
+})
+
+it('shows a loader instead of a permission error while the decision is pending', async () => {
+  mockUsePermission.mockReturnValue({ canRead: false, canWrite: false, canDelete: false })
+
+  render(<SettingsPage />, { wrapper: makeWrapper({}) })
+
+  expect(screen.queryByTestId('MISSING')).toBeNull()
+
+  mockUsePermission.mockReturnValue({ canRead: true, canWrite: true, canDelete: true })
+})
+
+it('shows the permission error once the decision resolves to denied', async () => {
+  mockUsePermission.mockReturnValue({ canRead: false, canWrite: false, canDelete: false })
+
+  render(<SettingsPage />, {
+    wrapper: makeWrapper({ 'settings::read': false, 'settings::write': false }),
+  })
+
+  expect(await screen.findByTestId('MISSING')).toBeInTheDocument()
+
+  mockUsePermission.mockReturnValue({ canRead: true, canWrite: true, canDelete: true })
 })

--- a/admin-ui/plugins/admin/components/Settings/SettingsPage.tsx
+++ b/admin-ui/plugins/admin/components/Settings/SettingsPage.tsx
@@ -12,7 +12,8 @@ import GluuText from 'Routes/Apps/Gluu/GluuText'
 import GluuThemeFormFooter from '@/routes/Apps/Gluu/GluuThemeFormFooter'
 import GluuViewWrapper from 'Routes/Apps/Gluu/GluuViewWrapper'
 import { usePermission } from '@/cedarling/hooks/usePermission'
-import { ADMIN_UI_RESOURCES } from '@/cedarling/utility'
+import { ADMIN_UI_RESOURCES, buildCedarPermissionKey } from '@/cedarling/utility'
+import { CEDAR_ACTIONS } from '@/cedarling/constants'
 import { SETTINGS } from 'Utils/ApiResources'
 import { getFieldPlaceholder } from '@/utils/placeholderUtils'
 import SetTitle from 'Utils/SetTitle'
@@ -75,6 +76,19 @@ const SettingsPage: React.FC = () => {
   const { canRead: canReadSettings, canWrite: canWriteSettings } = usePermission(
     ADMIN_UI_RESOURCES.Settings,
   )
+
+  const settingsDecisions = useAppSelector((state) => state.cedarPermissions?.permissions)
+  const settingsReadResolved =
+    settingsDecisions?.[
+      buildCedarPermissionKey(ADMIN_UI_RESOURCES.Settings, CEDAR_ACTIONS.READ)
+    ] !== undefined
+  const settingsWriteResolved =
+    settingsDecisions?.[
+      buildCedarPermissionKey(ADMIN_UI_RESOURCES.Settings, CEDAR_ACTIONS.WRITE)
+    ] !== undefined
+  const settingsPermissionResolved = settingsReadResolved && settingsWriteResolved
+  const canShowSettings = settingsPermissionResolved ? canReadSettings : null
+  const isSettingsEditable = settingsPermissionResolved && canWriteSettings
 
   const userinfo = useAppSelector((state) => state.authReducer?.userinfo)
   const clientId = useAppSelector((state) => state.authReducer?.config?.clientId)
@@ -156,6 +170,8 @@ const SettingsPage: React.FC = () => {
     initialValues,
     enableReinitialize: true,
     onSubmit: async (values, formikHelpers) => {
+      if (!isSettingsEditable) return
+
       savePagingSizeToStorage(currentPagingSize)
       saveLogLevel(currentLogLevel)
 
@@ -351,7 +367,7 @@ const SettingsPage: React.FC = () => {
 
   return (
     <GluuLoader blocking={loadingScripts || loadingConfig || loadingAgamaProjects || isSubmitting}>
-      <GluuViewWrapper canShow={canReadSettings}>
+      <GluuViewWrapper canShow={canShowSettings}>
         <GluuPageContent>
           <div className={classes.mobileContentPad}>
             <GluuText variant="h1" className={classes.mobilePageTitle}>
@@ -403,7 +419,7 @@ const SettingsPage: React.FC = () => {
                         rsize={12}
                         doc_category={SETTINGS}
                         doc_entry="pageSize"
-                        disabled={isMobile}
+                        disabled={isMobile || !isSettingsEditable}
                         isDark={isDark}
                         reserveErrorSpace
                         handleChange={(e) => {
@@ -424,7 +440,7 @@ const SettingsPage: React.FC = () => {
                         rsize={12}
                         doc_category={SETTINGS}
                         doc_entry="logLevel"
-                        disabled={isMobile}
+                        disabled={isMobile || !isSettingsEditable}
                         isDark={isDark}
                         hideChooseOption
                         reserveErrorSpace
@@ -445,7 +461,7 @@ const SettingsPage: React.FC = () => {
                         doc_entry="sessionTimeoutInMins"
                         errorMessage={formik.errors.sessionTimeoutInMins}
                         showError={Boolean(formik.errors.sessionTimeoutInMins)}
-                        disabled={isMobile}
+                        disabled={isMobile || !isSettingsEditable}
                         isDark={isDark}
                         placeholder={getFieldPlaceholder(t, 'fields.sessionTimeoutInMins')}
                       />
@@ -462,7 +478,7 @@ const SettingsPage: React.FC = () => {
                         rsize={12}
                         doc_category={SETTINGS}
                         doc_entry="adminui_default_acr"
-                        disabled={isMobile}
+                        disabled={isMobile || !isSettingsEditable}
                         isDark={isDark}
                         reserveErrorSpace
                       />
@@ -487,7 +503,7 @@ const SettingsPage: React.FC = () => {
                           doc_entry="cedarSwitch"
                           lsize={12}
                           rsize={12}
-                          disabled={isMobile}
+                          disabled={isMobile || !isSettingsEditable}
                           isDark={isDark}
                           handler={(event: React.ChangeEvent<HTMLInputElement>) => {
                             formik.setFieldValue(
@@ -507,8 +523,8 @@ const SettingsPage: React.FC = () => {
                     title={t('fields.custom_params_auth')}
                     items={additionalParameters}
                     mode="pair"
-                    disabled={isMobile}
-                    hideControls={isMobile}
+                    disabled={isMobile || !isSettingsEditable}
+                    hideControls={isMobile || !isSettingsEditable}
                     emptyStateText={t('messages.no_custom_parameters')}
                     keyPlaceholder={t('placeholders.enter_property_key')}
                     valuePlaceholder={t('placeholders.enter_property_value')}
@@ -524,10 +540,10 @@ const SettingsPage: React.FC = () => {
 
                   <GluuThemeFormFooter
                     showBack
-                    showCancel={!isMobile && canWriteSettings}
+                    showCancel={!isMobile && isSettingsEditable}
                     onCancel={handleCancel}
                     disableCancel={!isFormChanged}
-                    showApply={!isMobile && canWriteSettings}
+                    showApply={!isMobile && isSettingsEditable}
                     onApply={formik.handleSubmit}
                     disableApply={!isFormChanged || hasErrors || isSubmitting}
                     applyButtonType="button"

--- a/admin-ui/plugins/admin/components/Settings/SettingsPage.tsx
+++ b/admin-ui/plugins/admin/components/Settings/SettingsPage.tsx
@@ -11,6 +11,8 @@ import GluuLoader from 'Routes/Apps/Gluu/GluuLoader'
 import GluuText from 'Routes/Apps/Gluu/GluuText'
 import GluuThemeFormFooter from '@/routes/Apps/Gluu/GluuThemeFormFooter'
 import GluuViewWrapper from 'Routes/Apps/Gluu/GluuViewWrapper'
+import { usePermission } from '@/cedarling/hooks/usePermission'
+import { ADMIN_UI_RESOURCES } from '@/cedarling/utility'
 import { SETTINGS } from 'Utils/ApiResources'
 import { getFieldPlaceholder } from '@/utils/placeholderUtils'
 import SetTitle from 'Utils/SetTitle'
@@ -69,6 +71,10 @@ const SettingsPage: React.FC = () => {
   const queryClient = useQueryClient()
 
   const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
+
+  const { canRead: canReadSettings, canWrite: canWriteSettings } = usePermission(
+    ADMIN_UI_RESOURCES.Settings,
+  )
 
   const userinfo = useAppSelector((state) => state.authReducer?.userinfo)
   const clientId = useAppSelector((state) => state.authReducer?.config?.clientId)
@@ -345,7 +351,7 @@ const SettingsPage: React.FC = () => {
 
   return (
     <GluuLoader blocking={loadingScripts || loadingConfig || loadingAgamaProjects || isSubmitting}>
-      <GluuViewWrapper canShow>
+      <GluuViewWrapper canShow={canReadSettings}>
         <GluuPageContent>
           <div className={classes.mobileContentPad}>
             <GluuText variant="h1" className={classes.mobilePageTitle}>
@@ -518,10 +524,10 @@ const SettingsPage: React.FC = () => {
 
                   <GluuThemeFormFooter
                     showBack
-                    showCancel={!isMobile}
+                    showCancel={!isMobile && canWriteSettings}
                     onCancel={handleCancel}
                     disableCancel={!isFormChanged}
-                    showApply={!isMobile}
+                    showApply={!isMobile && canWriteSettings}
                     onApply={formik.handleSubmit}
                     disableApply={!isFormChanged || hasErrors || isSubmitting}
                     applyButtonType="button"

--- a/admin-ui/plugins/admin/plugin-metadata.ts
+++ b/admin-ui/plugins/admin/plugin-metadata.ts
@@ -65,7 +65,7 @@ const pluginMetadata = {
           title: 'menus.settings',
           path: ROUTES.ADMIN_SETTINGS,
           action: CEDAR_ACTIONS.READ,
-          resourceKey: CEDARLING_BYPASS,
+          resourceKey: ADMIN_UI_RESOURCES.Settings,
         },
         {
           title: 'menus.security',
@@ -129,7 +129,7 @@ const pluginMetadata = {
       component: SettingsPage,
       path: ROUTES.ADMIN_SETTINGS,
       action: CEDAR_ACTIONS.READ,
-      resourceKey: CEDARLING_BYPASS,
+      resourceKey: ADMIN_UI_RESOURCES.Settings,
     },
 
     {


### PR DESCRIPTION
### feat(admin-ui): add Cedarling log toggle to the profile dropdowns

#### Summary
- Added a Cedarling log toggle to both desktop and mobile profile dropdowns.
- Added a shared hook to manage the Cedarling log configuration through the Admin UI config endpoint.
- Improved dropdown positioning to support the wider Cedarling log option without viewport overflow.

---

#### Fix Summary
- Added `useCedarlingLogToggle` to toggle `cedarlingLogType` between `STD_OUT` and `OFF`.
- Reused the same configuration source for the Cedarling log switch in `DropdownProfile` and `MobileProfileDropdown`.
- Kept the desktop profile dropdown open while toggling so the loading state and toast remain visible.
- Added `bottom-end` dropdown positioning to right-align the menu with its trigger.
- Updated the dropdown arrow positioning so it remains centered relative to the trigger regardless of menu width.

---

#### Verification
- Verified the Cedarling log toggle is available in both desktop and mobile profile dropdowns.
- Verified toggling the switch updates `cedarlingLogType` between `STD_OUT` and `OFF`.
- Verified the desktop dropdown remains open while the toggle request is in progress.
- Verified the wider dropdown remains within the viewport using `bottom-end` positioning.
- Verified the dropdown arrow remains aligned with the profile trigger.

---

#### 🔗 Ticket

Closes: #3005 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cedarling logging toggles to desktop and mobile profile menus.
  * Cedarling logging preferences now save with immediate visual feedback and status notifications.
  * Added support for keeping dropdowns open after selection and customizing option spacing.
  * Added a right-aligned profile dropdown layout for desktop navigation.
  * Settings access and editing controls now follow user permissions.

* **Localization**
  * Added Cedarling logging labels in English, Spanish, French, and Portuguese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->