### PR TITLE
chore(admin-ui): update policy management upload and download rules

### DIFF
--- a/admin-ui/app/locales/en/translation.json
+++ b/admin-ui/app/locales/en/translation.json
@@ -890,7 +890,7 @@
       "adminUiRoles": "Admin UI Roles",
       "capabilities": "Capabilities",
       "mapping": "Roles and Permissions",
-      "policyStoreHistory": "Admin UI Policy Management"
+      "policyStoreHistory": "Policy Management"
     },
     "basic_configuration": "Basic Configuration",
     "inum_configuration": "Inum Configuration",
@@ -966,6 +966,8 @@
     "add_permission": "Add Permission",
     "add_asset": "Add Jans Asset",
     "asset_document_error": "Document is mandatory.",
+    "asset_file_type_invalid": "Only .properties, .css, .js, .jar, .jpeg, .jpg, .png, .gif and .xhtml files can be uploaded.",
+    "metadata_file_type_invalid": "Only .xml and .json metadata files can be uploaded.",
     "service_required": "Related Services are required.",
     "add_configuration": "Add Configuration",
     "credentials": "Credentials",
@@ -1714,7 +1716,7 @@
     "velocity_watch": "Attempts by User",
     "device_fingerprint_shift": "Authenticator Types",
     "threat_origins_ips": "Threat Origins by IP",
-    "policy_store_history": "Admin UI Policy Management",
+    "policy_store_history": "Policy Management",
     "policy_store_contents": "Policy Store Contents"
   },
   "options": {
@@ -2490,6 +2492,7 @@
       "uploadPolicyStore": "Upload",
       "uploadFailed": "Failed to upload policy store",
       "selectFileFirst": "Please select a .cjar file first",
+      "invalidFileType": "Only .cjar policy store files can be uploaded.",
       "auditPolicyStoreUploaded": "Policy store uploaded",
       "auditSyncRoleToScopesMappings": "Sync role to scopes mappings",
       "auditPolicyStoreUrlUpdated": "Policy store URL updated",

--- a/admin-ui/app/locales/es/translation.json
+++ b/admin-ui/app/locales/es/translation.json
@@ -890,7 +890,7 @@
       "adminUiRoles": "Roles de la Interfaz de Administración",
       "capabilities": "Capacidades",
       "mapping": "Roles y permisos",
-      "policyStoreHistory": "Gestión de políticas de Admin UI"
+      "policyStoreHistory": "Gestión de políticas"
     },
     "basic_configuration": "Configuración Básica",
     "inum_configuration": "Configuración Inum",
@@ -966,6 +966,8 @@
     "add_permission": "Agregar Permiso",
     "add_asset": "Agregar Jans Asset",
     "asset_document_error": "El documento es obligatorio.",
+    "asset_file_type_invalid": "Solo se pueden cargar archivos .properties, .css, .js, .jar, .jpeg, .jpg, .png, .gif y .xhtml.",
+    "metadata_file_type_invalid": "Solo se pueden cargar archivos de metadatos .xml y .json.",
     "service_required": "Los servicios relacionados son obligatorios.",
     "add_configuration": "Agregar Configuración",
     "credentials": "Credenciales",
@@ -1717,7 +1719,7 @@
     "velocity_watch": "Intentos por usuario",
     "device_fingerprint_shift": "Tipos de autenticador",
     "threat_origins_ips": "Orígenes de amenazas por IP",
-    "policy_store_history": "Gestión de políticas de Admin UI",
+    "policy_store_history": "Gestión de políticas",
     "policy_store_contents": "Contenido del almacén de políticas"
   },
   "options": {
@@ -2499,6 +2501,7 @@
       "uploadPolicyStore": "Cargar",
       "uploadFailed": "Error al cargar el almacén de políticas",
       "selectFileFirst": "Por favor, seleccione primero un archivo .cjar",
+      "invalidFileType": "Solo se pueden cargar archivos de almacén de políticas .cjar.",
       "auditPolicyStoreUploaded": "Almacén de políticas cargado",
       "defaultPolicyStoreDescription": "Almacén de políticas de la interfaz de administración",
       "uploadSuccess": "Almacén de políticas subido correctamente."

--- a/admin-ui/app/locales/fr/translation.json
+++ b/admin-ui/app/locales/fr/translation.json
@@ -95,7 +95,7 @@
       "adminUiRoles": "Rôles de l'interface utilisateur d'administration",
       "capabilities": "Capacités",
       "mapping": "Rôles et permissions",
-      "policyStoreHistory": "Gestion des politiques Admin UI"
+      "policyStoreHistory": "Gestion des politiques"
     },
     "lock": "Verrouillage",
     "cache": "Cache",
@@ -971,6 +971,8 @@
     "thanks_for_using_admin_ui": "Merci d'avoir utilisé l'interface d'administration.",
     "add_asset": "Ajouter une ressource Jans",
     "asset_document_error": "Le document est obligatoire.",
+    "asset_file_type_invalid": "Seuls les fichiers .properties, .css, .js, .jar, .jpeg, .jpg, .png, .gif et .xhtml peuvent être téléversés.",
+    "metadata_file_type_invalid": "Seuls les fichiers de métadonnées .xml et .json peuvent être téléversés.",
     "service_required": "Les services associés sont obligatoires.",
     "add_configuration": "Ajouter une configuration",
     "error_in_deleting": "Erreur lors de la suppression.",
@@ -1722,7 +1724,7 @@
     "velocity_watch": "Tentatives par utilisateur",
     "device_fingerprint_shift": "Types d'authentificateur",
     "threat_origins_ips": "Origines des menaces par IP",
-    "policy_store_history": "Gestion des politiques Admin UI",
+    "policy_store_history": "Gestion des politiques",
     "policy_store_contents": "Contenu du magasin de politiques"
   },
   "options": {
@@ -2471,6 +2473,7 @@
       "uploadPolicyStore": "Téléverser",
       "uploadFailed": "Échec du téléversement du magasin de politiques",
       "selectFileFirst": "Veuillez d'abord sélectionner un fichier .cjar à téléverser",
+      "invalidFileType": "Seuls les fichiers .cjar de magasin de politiques peuvent être téléversés.",
       "auditPolicyStoreUploaded": "Magasin de politiques téléversé",
       "defaultPolicyStoreDescription": "Magasin de politiques de l’interface d’administration",
       "uploadSuccess": "Magasin de politiques téléversé avec succès."

--- a/admin-ui/app/locales/pt/translation.json
+++ b/admin-ui/app/locales/pt/translation.json
@@ -94,7 +94,7 @@
       "adminUiRoles": "Funções da interface do administrador",
       "capabilities": "Capacidades",
       "mapping": "Funções e permissões",
-      "policyStoreHistory": "Gerenciamento de políticas do Admin UI"
+      "policyStoreHistory": "Gerenciamento de políticas"
     },
     "lock": "Trancar",
     "cache": "Cache",
@@ -967,6 +967,8 @@
     "thanks_for_using_admin_ui": "Obrigado por usar a interface de administração.",
     "add_asset": "Adicionar recurso Jans",
     "asset_document_error": "O documento é obrigatório.",
+    "asset_file_type_invalid": "Somente arquivos .properties, .css, .js, .jar, .jpeg, .jpg, .png, .gif e .xhtml podem ser enviados.",
+    "metadata_file_type_invalid": "Somente arquivos de metadados .xml e .json podem ser enviados.",
     "service_required": "Serviços relacionados são obrigatórios.",
     "add_configuration": "Adicionar configuração",
     "error_in_deleting": "Erro ao excluir.",
@@ -1718,7 +1720,7 @@
     "velocity_watch": "Tentativas por usuário",
     "device_fingerprint_shift": "Tipos de autenticador",
     "threat_origins_ips": "Origens de ameaças por IP",
-    "policy_store_history": "Gerenciamento de políticas do Admin UI",
+    "policy_store_history": "Gerenciamento de políticas",
     "policy_store_contents": "Conteúdo do repositório de políticas"
   },
   "options": {
@@ -2468,6 +2470,7 @@
       "uploadPolicyStore": "Enviar",
       "uploadFailed": "Falha ao enviar o repositório de políticas",
       "selectFileFirst": "Por favor, selecione primeiro um arquivo .cjar",
+      "invalidFileType": "Somente arquivos .cjar de repositório de políticas podem ser enviados.",
       "auditPolicyStoreUploaded": "Repositório de políticas enviado",
       "defaultPolicyStoreDescription": "Repositório de políticas da interface de administração",
       "uploadSuccess": "Repositório de políticas enviado com sucesso."

--- a/admin-ui/app/routes/Apps/Gluu/GluuUploadFile.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/GluuUploadFile.tsx
@@ -18,6 +18,7 @@ const DEFAULT_ACCEPT: Accept = {
 const GluuUploadFile: React.FC<GluuUploadFileProps> = ({
   accept = DEFAULT_ACCEPT,
   onDrop,
+  onDropRejected,
   placeholder,
   onClearFiles,
   disabled = false,
@@ -63,6 +64,7 @@ const GluuUploadFile: React.FC<GluuUploadFileProps> = ({
     isDragActive: isDragActive1,
   } = useFileDrop({
     onDrop: handleDrop,
+    onDropRejected,
     accept,
     disabled,
   })

--- a/admin-ui/app/routes/Apps/Gluu/__tests__/GluuUploadFile.test.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/__tests__/GluuUploadFile.test.tsx
@@ -28,6 +28,47 @@ describe('GluuUploadFile', () => {
     expect(container.querySelector('input[type="file"]')).toBeInTheDocument()
   })
 
+  it('exposes only the accepted extension on the file input', () => {
+    const { container } = renderUploadFile(
+      baseProps({ accept: { 'application/vnd.gluu.cjar': ['.cjar'] } }),
+    )
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    expect(input.accept).toBe('application/vnd.gluu.cjar,.cjar')
+    expect(input.accept).not.toContain('application/zip')
+  })
+
+  it('reports a rejected file instead of selecting it', () => {
+    const onDrop = jest.fn()
+    const onDropRejected = jest.fn()
+    const { container } = renderUploadFile(
+      baseProps({ onDrop, onDropRejected, accept: { 'application/vnd.gluu.cjar': ['.cjar'] } }),
+    )
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(['x'], 'files.zip', { type: 'application/zip' })
+
+    fireEvent.change(input, { target: { files: [file] } })
+
+    expect(onDropRejected).toHaveBeenCalledTimes(1)
+    expect(onDrop).not.toHaveBeenCalled()
+    expect(screen.queryByText('files.zip')).not.toBeInTheDocument()
+  })
+
+  it('selects a file that matches the accepted extension', () => {
+    const onDrop = jest.fn()
+    const onDropRejected = jest.fn()
+    const { container } = renderUploadFile(
+      baseProps({ onDrop, onDropRejected, accept: { 'application/vnd.gluu.cjar': ['.cjar'] } }),
+    )
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(['x'], 'store.cjar', { type: '' })
+
+    fireEvent.change(input, { target: { files: [file] } })
+
+    expect(onDropRejected).not.toHaveBeenCalled()
+    expect(onDrop).toHaveBeenCalledWith([file])
+    expect(screen.getByText('store.cjar')).toBeInTheDocument()
+  })
+
   it('renders the file name and a remove button when fileName is provided', () => {
     renderUploadFile(baseProps({ fileName: 'cert.jwt' }))
     expect(screen.getByText('cert.jwt')).toBeInTheDocument()

--- a/admin-ui/app/routes/Apps/Gluu/types/GluuComponentPropsTypes.ts
+++ b/admin-ui/app/routes/Apps/Gluu/types/GluuComponentPropsTypes.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties, ReactNode, HTMLAttributes, Ref } from 'react'
 import type { AlertProps } from '@mui/material/Alert'
 import type { FormikProps } from 'formik'
-import type { Accept } from '@/hooks/useFileDrop'
+import type { Accept, FileRejection } from '@/hooks/useFileDrop'
 import type { JsonPatch } from 'JansConfigApi'
 import type { JsonValue } from './common'
 
@@ -236,6 +236,7 @@ export type GluuTooltipProps = {
 export type GluuUploadFileProps = {
   accept?: Accept
   onDrop: (files: File[]) => void
+  onDropRejected?: (rejections: FileRejection[]) => void
   placeholder: string
   onClearFiles: () => void
   disabled?: boolean

--- a/admin-ui/app/utils/__tests__/policyStore.test.ts
+++ b/admin-ui/app/utils/__tests__/policyStore.test.ts
@@ -2,6 +2,8 @@ import {
   base64ToUint8Array,
   buildArchiveDownloadName,
   decodedByteLength,
+  ensureCjarExtension,
+  hasCjarExtension,
   isActivePolicyStore,
   selectActivePolicyStore,
   toPolicyStoreEntries,
@@ -106,9 +108,9 @@ describe('decodedByteLength', () => {
 describe('buildArchiveDownloadName', () => {
   const at = new Date(2026, 7, 24, 9, 5)
 
-  it('inserts a short timestamp before the existing extension', () => {
+  it('rewrites a non-cjar extension to cjar', () => {
     expect(buildArchiveDownloadName('default_ps.zip', 'inum-1', at)).toBe(
-      'default_ps-20260824-0905.zip',
+      'default_ps-20260824-0905.cjar',
     )
   })
 
@@ -126,5 +128,36 @@ describe('buildArchiveDownloadName', () => {
 
   it('falls back to the inum when the store has no display name', () => {
     expect(buildArchiveDownloadName(undefined, 'inum-1', at)).toBe('inum-1-20260824-0905.cjar')
+  })
+})
+
+describe('hasCjarExtension', () => {
+  it.each([['store.cjar'], ['STORE.CJAR'], ['  store.cjar  ']])('accepts %p', (name) => {
+    expect(hasCjarExtension(name)).toBe(true)
+  })
+
+  it.each([['store.zip'], ['store'], ['store.cjar.zip'], [''], [undefined]])(
+    'rejects %p',
+    (name) => {
+      expect(hasCjarExtension(name)).toBe(false)
+    },
+  )
+})
+
+describe('ensureCjarExtension', () => {
+  it('leaves a cjar name untouched', () => {
+    expect(ensureCjarExtension('default_ps.cjar')).toBe('default_ps.cjar')
+  })
+
+  it('replaces a non-cjar extension', () => {
+    expect(ensureCjarExtension('default_ps.zip')).toBe('default_ps.cjar')
+  })
+
+  it('appends the extension when there is none', () => {
+    expect(ensureCjarExtension('default_ps')).toBe('default_ps.cjar')
+  })
+
+  it.each([[undefined], [''], ['   ']])('falls back to a default name for %p', (name) => {
+    expect(ensureCjarExtension(name)).toBe('policy-store.cjar')
   })
 })

--- a/admin-ui/app/utils/policyStore.ts
+++ b/admin-ui/app/utils/policyStore.ts
@@ -85,6 +85,21 @@ export const decodedByteLength = (base64: string | undefined): number => {
   return Math.max(0, Math.floor((normalized.length * 3) / 4) - padding)
 }
 
+export const hasCjarExtension = (name: string | undefined): boolean =>
+  Boolean(name?.trim().toLowerCase().endsWith(CJAR_EXTENSION))
+
+export const ensureCjarExtension = (name: string | undefined): string => {
+  const source = name?.trim()
+  if (!source) {
+    return `policy-store${CJAR_EXTENSION}`
+  }
+  if (hasCjarExtension(source)) {
+    return source
+  }
+  const [, base] = REGEX_ARCHIVE_FILE_EXTENSION.exec(source) ?? []
+  return `${base || source}${CJAR_EXTENSION}`
+}
+
 export const buildArchiveDownloadName = (
   displayname: string | undefined,
   inum: string | undefined,
@@ -93,6 +108,6 @@ export const buildArchiveDownloadName = (
   const pad = (value: number) => String(value).padStart(2, '0')
   const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}`
   const source = displayname?.trim() || inum || 'policy-store'
-  const [, base, extension] = REGEX_ARCHIVE_FILE_EXTENSION.exec(source) ?? []
-  return `${base || source}-${stamp}${extension || CJAR_EXTENSION}`
+  const [, base] = REGEX_ARCHIVE_FILE_EXTENSION.exec(source) ?? []
+  return `${base || source}-${stamp}${CJAR_EXTENSION}`
 }

--- a/admin-ui/plugins/admin/__tests__/components/Cedarling/CedarlingConfigPage.test.tsx
+++ b/admin-ui/plugins/admin/__tests__/components/Cedarling/CedarlingConfigPage.test.tsx
@@ -90,6 +90,74 @@ describe('CedarlingConfigPage', () => {
     expect(policyStoreElements.length).toBeGreaterThan(0)
   })
 
+  it('offers only the cjar extension on the file input', () => {
+    render(<CedarlingConfigPage />, { wrapper: Wrapper })
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+
+    expect(input.accept).toContain('.cjar')
+    expect(input.accept).not.toContain('application/zip')
+  })
+
+  it('rejects a dropped file that is not a cjar', async () => {
+    const dispatchSpy = jest.spyOn(store, 'dispatch')
+    render(<CedarlingConfigPage />, { wrapper: Wrapper })
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(['payload'], 'files.zip', { type: 'application/zip' })
+
+    fireEvent.drop(input, {
+      dataTransfer: {
+        files: [file],
+        items: [{ kind: 'file', type: file.type, getAsFile: () => file }],
+        types: ['Files'],
+      },
+    })
+
+    await waitFor(() => {
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'toast/updateToast',
+          payload: expect.objectContaining({
+            type: 'error',
+            message: expect.stringContaining('.cjar'),
+          }),
+        }),
+      )
+    })
+    expect(screen.queryByText('files.zip')).not.toBeInTheDocument()
+    dispatchSpy.mockRestore()
+  })
+
+  it('rejects a file that is not named .cjar even when its mime type matches', async () => {
+    const dispatchSpy = jest.spyOn(store, 'dispatch')
+    render(<CedarlingConfigPage />, { wrapper: Wrapper })
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(['payload'], 'store.zip', { type: 'application/vnd.gluu.cjar' })
+
+    fireEvent.drop(input, {
+      dataTransfer: {
+        files: [file],
+        items: [{ kind: 'file', type: file.type, getAsFile: () => file }],
+        types: ['Files'],
+      },
+    })
+
+    await waitFor(() => {
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'toast/updateToast',
+          payload: expect.objectContaining({
+            type: 'error',
+            message: expect.stringContaining('.cjar'),
+          }),
+        }),
+      )
+    })
+    dispatchSpy.mockRestore()
+  })
+
   it('uploads the .cjar as an inactive policy store without re-syncing the role mappings', async () => {
     render(<CedarlingConfigPage />, { wrapper: Wrapper })
 

--- a/admin-ui/plugins/admin/__tests__/components/Cedarling/PolicyStoreHistoryPage.test.tsx
+++ b/admin-ui/plugins/admin/__tests__/components/Cedarling/PolicyStoreHistoryPage.test.tsx
@@ -177,6 +177,41 @@ describe('PolicyStoreHistoryPage', () => {
     expect(screen.queryByRole('button', { name: 'Set active' })).not.toBeInTheDocument()
   })
 
+  it('names the download after the inum when the display name is only whitespace', async () => {
+    const { useGetAdminuiPolicyStore } = jest.requireMock('JansConfigApi') as {
+      useGetAdminuiPolicyStore: jest.Mock
+    }
+    const defaultImpl = useGetAdminuiPolicyStore.getMockImplementation()
+    useGetAdminuiPolicyStore.mockImplementation(() => ({
+      data: { entries: [{ ...mockBackupStore, displayname: '   ' }], totalEntriesCount: 1 },
+      isLoading: false,
+      isFetching: false,
+      refetch: jest.fn(),
+    }))
+
+    let downloadName: string | undefined
+    const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      downloadName = this.download
+    })
+
+    try {
+      render(<PolicyStoreHistoryPage />, { wrapper: Wrapper })
+
+      const buttons = await screen.findAllByRole('button', { name: 'Download' })
+      fireEvent.click(buttons[0])
+
+      await waitFor(() => {
+        expect(clickSpy).toHaveBeenCalled()
+      })
+      expect(downloadName).toBe('backup-1.cjar')
+    } finally {
+      clickSpy.mockRestore()
+      useGetAdminuiPolicyStore.mockImplementation(defaultImpl)
+    }
+  })
+
   it('activates a backup through the confirm dialog', async () => {
     render(<PolicyStoreHistoryPage />, { wrapper: Wrapper })
     await screen.findByText('previous-policies.cjar')

--- a/admin-ui/plugins/admin/components/Assets/AssetForm.tsx
+++ b/admin-ui/plugins/admin/components/Assets/AssetForm.tsx
@@ -34,6 +34,8 @@ import getThemeColor from '@/context/theme/config'
 import { THEME_DARK } from '@/context/theme/constants'
 import { useStyles } from './JansAssetFormPage.style'
 import { T_KEYS } from './constants'
+import { useAppDispatch } from '@/redux/hooks'
+import { updateToast } from 'Redux/features/toastSlice'
 
 const AssetForm: React.FC<AssetFormProps> = ({ viewOnly = false }) => {
   const { id } = useParams<RouteParams>()
@@ -92,6 +94,8 @@ const AssetForm: React.FC<AssetFormProps> = ({ viewOnly = false }) => {
     validationSchema,
   })
 
+  const dispatch = useAppDispatch()
+
   const handleFileDrop: FileDropHandler = useCallback(
     (files: File[]) => {
       const file = files[0]
@@ -103,6 +107,10 @@ const AssetForm: React.FC<AssetFormProps> = ({ viewOnly = false }) => {
     },
     [formik],
   )
+
+  const handleFileDropRejected = useCallback(() => {
+    dispatch(updateToast(true, 'error', t(T_KEYS.MSG_ASSET_FILE_TYPE_INVALID)))
+  }, [dispatch, t])
 
   const handleClearFiles: FileClearHandler = useCallback(() => {
     formik.setFieldValue('document', null)
@@ -179,6 +187,7 @@ const AssetForm: React.FC<AssetFormProps> = ({ viewOnly = false }) => {
                 accept={buildAcceptFileTypes()}
                 placeholder={t(T_KEYS.PLACEHOLDER_ASSET_UPLOAD)}
                 onDrop={handleFileDrop}
+                onDropRejected={handleFileDropRejected}
                 onClearFiles={handleClearFiles}
                 disabled={viewOnly}
                 showClearButton={!viewOnly}

--- a/admin-ui/plugins/admin/components/Assets/__tests__/AssetForm.test.tsx
+++ b/admin-ui/plugins/admin/components/Assets/__tests__/AssetForm.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -39,9 +39,9 @@ const buildStore = () =>
     }),
   })
 
-const renderForm = () =>
+const renderForm = (store = buildStore()) =>
   render(
-    <Provider store={buildStore()}>
+    <Provider store={store}>
       <QueryClientProvider
         client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
       >
@@ -57,6 +57,38 @@ describe('AssetForm', () => {
     renderForm()
     expect(document.querySelector('input[name="fileName"]')).toBeInTheDocument()
     expect(document.querySelector('select[name="service"], [name="service"]')).toBeInTheDocument()
+  })
+
+  it('reports an unsupported file instead of selecting it', () => {
+    const store = buildStore()
+    const dispatchSpy = jest.spyOn(store, 'dispatch')
+    const { container } = renderForm(store)
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+
+    fireEvent.change(input, {
+      target: { files: [new File(['x'], 'notes.zip', { type: 'application/zip' })] },
+    })
+
+    expect(screen.queryByText('notes.zip')).not.toBeInTheDocument()
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          type: 'error',
+          message: expect.stringContaining('.xhtml'),
+        }),
+      }),
+    )
+  })
+
+  it('selects a supported asset file', () => {
+    const { container } = renderForm()
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+
+    fireEvent.change(input, {
+      target: { files: [new File(['x'], 'logo.png', { type: 'image/png' })] },
+    })
+
+    expect(screen.getByText('logo.png')).toBeInTheDocument()
   })
 
   it('disables the apply action while the form is pristine', () => {

--- a/admin-ui/plugins/admin/components/Assets/constants.ts
+++ b/admin-ui/plugins/admin/components/Assets/constants.ts
@@ -26,6 +26,7 @@ export const T_KEYS = {
   MSG_NO_SPACES: 'messages.no_spaces',
   MSG_SERVICE_REQUIRED: 'messages.service_required',
   MSG_ASSET_DOCUMENT_ERROR: 'messages.asset_document_error',
+  MSG_ASSET_FILE_TYPE_INVALID: 'messages.asset_file_type_invalid',
   ACTION_VIEW: 'actions.view',
   ACTION_EDIT: 'actions.edit',
   ACTION_DELETE: 'actions.delete',

--- a/admin-ui/plugins/admin/components/Cedarling/CedarlingConfigPage.tsx
+++ b/admin-ui/plugins/admin/components/Cedarling/CedarlingConfigPage.tsx
@@ -29,17 +29,18 @@ import { adminUiFeatures } from '@/constants'
 import { usePolicyStoreMutations } from './hooks/usePolicyStoreMutations'
 import { fileToBase64 } from '@/utils/policyStore'
 import { CJAR_EXTENSION } from '@/constants/policyStore'
+import { hasCjarExtension } from '@/utils/policyStore'
 
 const SECURITY_RESOURCE_ID = ADMIN_UI_RESOURCES.Security
 
-const ZIP_MIME_TYPE = 'application/zip'
+const CJAR_MIME_TYPE = 'application/vnd.gluu.cjar'
 
 const POLICY_STORE_REPO_URL =
   'https://github.com/GluuFederation/GluuFlexAdminUIPolicyStore/tree/agama-lab-policy-designer'
 const AGAMA_LAB_URL = 'https://cloud.gluu.org/agama-lab'
 
 const CJAR_ACCEPT = {
-  [ZIP_MIME_TYPE]: [CJAR_EXTENSION],
+  [CJAR_MIME_TYPE]: [CJAR_EXTENSION],
 }
 
 const CedarlingConfigPage: React.FC = () => {
@@ -79,12 +80,26 @@ const CedarlingConfigPage: React.FC = () => {
 
   const dispatch = useAppDispatch()
 
-  const handleFileDrop = useCallback((files: File[]) => {
-    const [file] = files
-    if (file) {
+  const handleFileDrop = useCallback(
+    (files: File[]) => {
+      const [file] = files
+      if (!file) {
+        return
+      }
+      if (!hasCjarExtension(file.name)) {
+        setSelectedFile(null)
+        dispatch(updateToast(true, 'error', t('documentation.cedarlingConfig.invalidFileType')))
+        return
+      }
       setSelectedFile(file)
-    }
-  }, [])
+    },
+    [dispatch, t],
+  )
+
+  const handleDropRejected = useCallback(() => {
+    setSelectedFile(null)
+    dispatch(updateToast(true, 'error', t('documentation.cedarlingConfig.invalidFileType')))
+  }, [dispatch, t])
 
   const handleClearFiles = useCallback(() => {
     setSelectedFile(null)
@@ -213,6 +228,7 @@ const CedarlingConfigPage: React.FC = () => {
                             <GluuUploadFile
                               accept={CJAR_ACCEPT}
                               onDrop={handleFileDrop}
+                              onDropRejected={handleDropRejected}
                               placeholder={t('documentation.cedarlingConfig.selectCjarFile')}
                               onClearFiles={handleClearFiles}
                               disabled={!canWriteSecurity || isLoading}

--- a/admin-ui/plugins/admin/components/Cedarling/PolicyStoreHistoryPage.tsx
+++ b/admin-ui/plugins/admin/components/Cedarling/PolicyStoreHistoryPage.tsx
@@ -172,7 +172,7 @@ const PolicyStoreHistoryPage: React.FC = () => {
         const url = URL.createObjectURL(blob)
         const link = document.createElement('a')
         link.href = url
-        link.download = ensureCjarExtension(store.displayname || store.inum)
+        link.download = ensureCjarExtension(store.displayname?.trim() || store.inum)
         document.body.appendChild(link)
         link.click()
         document.body.removeChild(link)

--- a/admin-ui/plugins/admin/components/Cedarling/PolicyStoreHistoryPage.tsx
+++ b/admin-ui/plugins/admin/components/Cedarling/PolicyStoreHistoryPage.tsx
@@ -35,6 +35,7 @@ import {
   base64ToUint8Array,
 } from '@/utils/policyStore'
 import { formatBytes } from '@/utils/cjarArchive'
+import { ensureCjarExtension } from '@/utils/policyStore'
 import { logger } from '@/utils/logger'
 import { useAppDispatch, useAppSelector } from '@/redux/hooks'
 import { updateToast } from '@/redux/features/toastSlice'
@@ -171,7 +172,7 @@ const PolicyStoreHistoryPage: React.FC = () => {
         const url = URL.createObjectURL(blob)
         const link = document.createElement('a')
         link.href = url
-        link.download = store.displayname || `${store.inum}.cjar`
+        link.download = ensureCjarExtension(store.displayname || store.inum)
         document.body.appendChild(link)
         link.click()
         document.body.removeChild(link)

--- a/admin-ui/plugins/saml/__tests__/components/WebsiteSsoIdentityProviderForm.test.tsx
+++ b/admin-ui/plugins/saml/__tests__/components/WebsiteSsoIdentityProviderForm.test.tsx
@@ -178,4 +178,45 @@ describe('WebsiteSsoIdentityProviderForm', () => {
       expect(displayNameInput).toHaveValue('New Display Name')
     })
   })
+
+  describe('metadata file upload', () => {
+    const openUploadField = () => {
+      const toggle = screen.getByTestId('metaDataFileImportedFlag')
+      fireEvent.click(toggle)
+      return document.querySelector('input[type="file"]') as HTMLInputElement
+    }
+
+    it('reports an unsupported metadata file instead of selecting it', async () => {
+      const dispatchSpy = jest.spyOn(store, 'dispatch')
+      await renderForm()
+
+      const input = openUploadField()
+      const file = new File(['x'], 'logo.png', { type: 'image/png' })
+
+      fireEvent.change(input, { target: { files: [file] } })
+
+      expect(screen.queryByText('logo.png')).not.toBeInTheDocument()
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'toast/updateToast',
+          payload: expect.objectContaining({
+            type: 'error',
+            message: expect.stringContaining('.xml'),
+          }),
+        }),
+      )
+      dispatchSpy.mockRestore()
+    })
+
+    it('selects an xml metadata file', async () => {
+      await renderForm()
+
+      const input = openUploadField()
+      const file = new File(['<xml/>'], 'metadata.xml', { type: 'text/xml' })
+
+      fireEvent.change(input, { target: { files: [file] } })
+
+      expect(await screen.findByText('metadata.xml')).toBeInTheDocument()
+    })
+  })
 })

--- a/admin-ui/plugins/saml/__tests__/components/WebsiteSsoServiceProviderForm.test.tsx
+++ b/admin-ui/plugins/saml/__tests__/components/WebsiteSsoServiceProviderForm.test.tsx
@@ -204,4 +204,45 @@ describe('WebsiteSsoServiceProviderForm', () => {
       expect(screen.getByTestId('samlMetadata.entityId')).toBeInTheDocument()
     })
   })
+
+  describe('metadata file upload', () => {
+    const openUploadField = () => {
+      const sourceType = document.querySelector('[name="spMetaDataSourceType"]') as HTMLElement
+      fireEvent.change(sourceType, { target: { value: 'file' } })
+      return document.querySelector('input[type="file"]') as HTMLInputElement
+    }
+
+    it('reports an unsupported metadata file instead of selecting it', async () => {
+      const dispatchSpy = jest.spyOn(store, 'dispatch')
+      await renderForm()
+
+      const input = openUploadField()
+      const file = new File(['x'], 'logo.png', { type: 'image/png' })
+
+      fireEvent.change(input, { target: { files: [file] } })
+
+      expect(screen.queryByText('logo.png')).not.toBeInTheDocument()
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'toast/updateToast',
+          payload: expect.objectContaining({
+            type: 'error',
+            message: expect.stringContaining('.xml'),
+          }),
+        }),
+      )
+      dispatchSpy.mockRestore()
+    })
+
+    it('selects an xml metadata file', async () => {
+      await renderForm()
+
+      const input = openUploadField()
+      const file = new File(['<xml/>'], 'metadata.xml', { type: 'text/xml' })
+
+      fireEvent.change(input, { target: { files: [file] } })
+
+      expect(await screen.findByText('metadata.xml')).toBeInTheDocument()
+    })
+  })
 })

--- a/admin-ui/plugins/saml/components/WebsiteSsoIdentityProviderForm.tsx
+++ b/admin-ui/plugins/saml/components/WebsiteSsoIdentityProviderForm.tsx
@@ -213,6 +213,10 @@ const WebsiteSsoIdentityProviderForm = ({
     [formik],
   )
 
+  const handleDropRejected = useCallback(() => {
+    dispatch(updateToast(true, 'error', t('messages.metadata_file_type_invalid')))
+  }, [dispatch, t])
+
   const handleDrop = useCallback(
     (files: File[]) => {
       const file = files[0]
@@ -409,6 +413,7 @@ const WebsiteSsoIdentityProviderForm = ({
                         }
                         placeholder={`Drag 'n' drop .xml/.json file here, or click to select file`}
                         onDrop={handleDrop}
+                        onDropRejected={handleDropRejected}
                         onClearFiles={handleClearFiles}
                         disabled={viewOnly}
                         showClearButton={!viewOnly}

--- a/admin-ui/plugins/saml/components/WebsiteSsoServiceProviderForm.tsx
+++ b/admin-ui/plugins/saml/components/WebsiteSsoServiceProviderForm.tsx
@@ -285,6 +285,10 @@ const WebsiteSsoServiceProviderForm = ({
     }
   }, [dispatch])
 
+  const handleDropRejected = useCallback(() => {
+    dispatch(updateToast(true, 'error', t('messages.metadata_file_type_invalid')))
+  }, [dispatch, t])
+
   const handleDrop = useCallback(
     (files: File[]) => {
       if (viewOnly) return
@@ -495,6 +499,7 @@ const WebsiteSsoServiceProviderForm = ({
                         }
                         placeholder={`Drag 'n' drop .xml/.json file here, or click to select file`}
                         onDrop={handleDrop}
+                        onDropRejected={handleDropRejected}
                         onClearFiles={handleClearFiles}
                         disabled={viewOnly}
                         showClearButton={!viewOnly}


### PR DESCRIPTION
### chore(admin-ui): update policy management upload and download rules (#3010)

#### Summary
- Renamed the Policy Store menu to `Policy Management`.
- Restricted policy store upload and download actions to `.cjar` policy stores.

---

#### Fix Summary
- Updated the Policy Store menu label to `Policy Management`.
- Limited upload functionality to policy stores with the `.cjar` extension.
- Limited download functionality to policy stores with the `.cjar` extension.

---

#### Verification
- Verified the menu is displayed as `Policy Management`.
- Verified only `.cjar` policy stores can be uploaded.
- Verified download is available only for `.cjar` policy stores.

---

#### 🔗 Ticket

Closes: #3010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer validation feedback when unsupported asset, metadata, or policy-store files are uploaded.
  - Restricted Cedarling policy-store uploads to `.cjar` files.
  - Ensured downloaded policy-store archives always use the `.cjar` extension.
  - Updated policy-management labels across supported languages.

- **Bug Fixes**
  - Rejected files are no longer displayed as successfully selected.
  - Added consistent error notifications for invalid file drops.

- **Tests**
  - Expanded coverage for file validation, rejected uploads, and `.cjar` filename handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->