### PR TITLE
fix(admin-ui): prevent duplicate Config API requests on login

### DIFF
--- a/admin-ui/app/redux/api/__tests__/apiToken.test.ts
+++ b/admin-ui/app/redux/api/__tests__/apiToken.test.ts
@@ -1,0 +1,116 @@
+jest.mock('Orval', () => ({ setApiToken: jest.fn(), getApiToken: jest.fn(() => null) }))
+jest.mock('../backend-api', () => ({ fetchApiTokenWithDefaultScopes: jest.fn() }))
+jest.mock('../sessionState', () => ({ hasActiveSession: jest.fn(() => false) }))
+jest.mock('@/utils/logger', () => ({ logger: { error: jest.fn(), info: jest.fn() } }))
+
+import { getApiToken, setApiToken } from 'Orval'
+import { fetchApiTokenWithDefaultScopes } from '../backend-api'
+import { hasActiveSession } from '../sessionState'
+import { clearApiToken, ensureApiToken } from '../apiToken'
+import type { AppDispatch } from '../../hooks'
+
+const mockedFetch = fetchApiTokenWithDefaultScopes as jest.MockedFunction<
+  typeof fetchApiTokenWithDefaultScopes
+>
+const mockedGetApiToken = getApiToken as jest.MockedFunction<typeof getApiToken>
+const mockedSetApiToken = setApiToken as jest.MockedFunction<typeof setApiToken>
+const mockedHasActiveSession = hasActiveSession as jest.MockedFunction<typeof hasActiveSession>
+
+const buildJwt = (exp: number) =>
+  `header.${Buffer.from(JSON.stringify({ exp })).toString('base64url')}.signature`
+
+const dispatch: AppDispatch = jest.fn()
+
+describe('ensureApiToken owns the api protection token', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    clearApiToken()
+    mockedGetApiToken.mockReturnValue(null)
+    mockedHasActiveSession.mockReturnValue(false)
+    mockedFetch.mockResolvedValue({ access_token: 'tok' })
+  })
+
+  it('mints once and serves the cached token afterwards', async () => {
+    const first = await ensureApiToken(dispatch)
+    mockedGetApiToken.mockReturnValue('tok')
+    const second = await ensureApiToken(dispatch)
+
+    expect(first?.access_token).toBe('tok')
+    expect(second?.access_token).toBe('tok')
+    expect(mockedFetch).toHaveBeenCalledTimes(1)
+    expect(mockedSetApiToken).toHaveBeenCalledWith('tok')
+  })
+
+  it('collapses concurrent callers onto a single request', async () => {
+    const [a, b, c] = await Promise.all([
+      ensureApiToken(dispatch),
+      ensureApiToken(dispatch),
+      ensureApiToken(dispatch),
+    ])
+
+    expect(mockedFetch).toHaveBeenCalledTimes(1)
+    expect([a?.access_token, b?.access_token, c?.access_token]).toEqual(['tok', 'tok', 'tok'])
+  })
+
+  it('skips the request entirely once a session cookie is live', async () => {
+    mockedHasActiveSession.mockReturnValue(true)
+
+    await expect(ensureApiToken(dispatch)).resolves.toBeNull()
+    expect(mockedFetch).not.toHaveBeenCalled()
+  })
+
+  it('still mints for callers that require a token despite a live session', async () => {
+    mockedHasActiveSession.mockReturnValue(true)
+
+    const token = await ensureApiToken(dispatch, { required: true })
+
+    expect(token?.access_token).toBe('tok')
+    expect(mockedFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('remints when the cached token is close to expiry', async () => {
+    mockedFetch.mockResolvedValue({ access_token: buildJwt(Math.floor(Date.now() / 1000) + 10) })
+
+    const first = await ensureApiToken(dispatch)
+    mockedGetApiToken.mockReturnValue(first?.access_token ?? null)
+    await ensureApiToken(dispatch)
+
+    expect(mockedFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps a cached token that is comfortably inside its expiry', async () => {
+    mockedFetch.mockResolvedValue({ access_token: buildJwt(Math.floor(Date.now() / 1000) + 3600) })
+
+    const first = await ensureApiToken(dispatch)
+    mockedGetApiToken.mockReturnValue(first?.access_token ?? null)
+    await ensureApiToken(dispatch)
+
+    expect(mockedFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('force remints even when a usable token is cached', async () => {
+    await ensureApiToken(dispatch)
+    mockedGetApiToken.mockReturnValue('tok')
+    await ensureApiToken(dispatch, { force: true })
+
+    expect(mockedFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('drops the cache when the interceptor slot was cleared elsewhere', async () => {
+    await ensureApiToken(dispatch)
+    mockedGetApiToken.mockReturnValue(null)
+    await ensureApiToken(dispatch)
+
+    expect(mockedFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears the token and rethrows when the mint fails', async () => {
+    mockedFetch.mockRejectedValue(new Error('token boom'))
+
+    await expect(ensureApiToken(dispatch)).rejects.toThrow('token boom')
+    expect(mockedSetApiToken).toHaveBeenCalledWith(null)
+
+    mockedFetch.mockResolvedValue({ access_token: 'tok' })
+    await expect(ensureApiToken(dispatch)).resolves.toEqual({ access_token: 'tok' })
+  })
+})

--- a/admin-ui/app/redux/api/apiToken.ts
+++ b/admin-ui/app/redux/api/apiToken.ts
@@ -1,0 +1,90 @@
+import { getApiToken, setApiToken } from 'Orval'
+import { fetchApiTokenWithDefaultScopes } from './backend-api'
+import { hasActiveSession } from './sessionState'
+import { setApiDefaultToken, setBackendStatus } from '../features/authSlice'
+import decodeJwt from '@/utils/jwtDecode'
+import { logger } from '@/utils/logger'
+import type { AppDispatch } from '../hooks'
+import type { ApiTokenResponse } from './types/BackendApi'
+import type { ApiErrorLike } from '../types/audit'
+
+type EnsureApiTokenOptions = {
+  force?: boolean
+  required?: boolean
+}
+
+const EXPIRY_SKEW_MS = 30_000
+
+let cachedToken: ApiTokenResponse | null = null
+let cachedExpiryMs: number | null = null
+let mintInFlight: Promise<ApiTokenResponse> | null = null
+
+const readExpiryMs = (accessToken: string): number | null => {
+  try {
+    const { exp } = decodeJwt<{ exp?: number }>(accessToken)
+    return typeof exp === 'number' ? exp * 1000 : null
+  } catch {
+    return null
+  }
+}
+
+const toBackendStatus = (error: Error | ApiErrorLike) => {
+  const err = error as ApiErrorLike
+  const statusCode = typeof err?.response?.status === 'number' ? err.response.status : null
+  const errorMessage =
+    err?.response?.data?.responseMessage ??
+    err?.response?.data?.message ??
+    (error instanceof Error ? error.message : error != null ? String(error) : 'Network error')
+  return { active: false as const, errorMessage, statusCode }
+}
+
+export const clearApiToken = (): void => {
+  cachedToken = null
+  cachedExpiryMs = null
+  setApiToken(null)
+}
+
+const isCachedTokenUsable = (): boolean => {
+  if (!cachedToken || !getApiToken()) return false
+  if (cachedExpiryMs === null) return true
+  return Date.now() + EXPIRY_SKEW_MS < cachedExpiryMs
+}
+
+const mintApiToken = (dispatch: AppDispatch): Promise<ApiTokenResponse> => {
+  mintInFlight ??= (async () => {
+    try {
+      const token = await fetchApiTokenWithDefaultScopes()
+      cachedToken = token
+      cachedExpiryMs = readExpiryMs(token.access_token)
+      setApiToken(token.access_token)
+      dispatch(setApiDefaultToken(token))
+      dispatch(setBackendStatus({ active: true, errorMessage: null, statusCode: null }))
+      return token
+    } catch (error) {
+      clearApiToken()
+      logger.error(
+        'Failed to fetch API token with default scopes',
+        error instanceof Error ? error : String(error),
+      )
+      dispatch(setBackendStatus(toBackendStatus(error as Error | ApiErrorLike)))
+      throw error
+    } finally {
+      mintInFlight = null
+    }
+  })()
+
+  return mintInFlight
+}
+
+export const ensureApiToken = async (
+  dispatch: AppDispatch,
+  { force = false, required = false }: EnsureApiTokenOptions = {},
+): Promise<ApiTokenResponse | null> => {
+  if (!force) {
+    if (isCachedTokenUsable()) return cachedToken
+    clearApiToken()
+    if (!required && hasActiveSession()) return null
+  }
+
+  return mintApiToken(dispatch)
+}

--- a/admin-ui/app/redux/api/types/BackendApi.ts
+++ b/admin-ui/app/redux/api/types/BackendApi.ts
@@ -3,6 +3,8 @@ import type { JsonValue } from 'Routes/Apps/Gluu/types/common'
 
 export type ApiTokenResponse = {
   access_token: string
+  issuer?: string
+  scopes?: string[]
 }
 
 export type PutServerConfigPayload = {

--- a/admin-ui/app/redux/listeners/__tests__/licenseListener.test.ts
+++ b/admin-ui/app/redux/listeners/__tests__/licenseListener.test.ts
@@ -22,7 +22,7 @@ import { setApiToken } from 'Orval'
 import { fetchApiTokenWithDefaultScopes } from '../../api/backend-api'
 
 jest.mock('JansConfigApi')
-jest.mock('Orval', () => ({ setApiToken: jest.fn() }))
+jest.mock('Orval', () => ({ setApiToken: jest.fn(), getApiToken: jest.fn(() => null) }))
 jest.mock('../../api/backend-api')
 
 import '../licenseListener'

--- a/admin-ui/app/redux/listeners/__tests__/loginSequence.test.ts
+++ b/admin-ui/app/redux/listeners/__tests__/loginSequence.test.ts
@@ -2,7 +2,7 @@ jest.mock('../../api/axios', () => ({
   __esModule: true,
   default: { get: jest.fn(), put: jest.fn(), post: jest.fn(), delete: jest.fn() },
 }))
-jest.mock('Orval', () => ({ setApiToken: jest.fn() }))
+jest.mock('Orval', () => ({ setApiToken: jest.fn(), getApiToken: jest.fn(() => null) }))
 jest.mock('@/utils/logger', () => ({ logger: { error: jest.fn(), info: jest.fn() } }))
 
 import { configureStore } from '@reduxjs/toolkit'

--- a/admin-ui/app/redux/listeners/authListener.ts
+++ b/admin-ui/app/redux/listeners/authListener.ts
@@ -13,14 +13,13 @@ import {
 import { updateToast } from '../features/toastSlice'
 import {
   fetchServerConfiguration,
-  fetchApiTokenWithDefaultScopes,
   putServerConfiguration,
   createAdminUiSession as createAdminUiSessionApi,
 } from '../api/backend-api'
+import { clearApiToken, ensureApiToken } from '../api/apiToken'
 import { isFourZeroThreeError } from 'Utils/TokenController'
 import { logger } from '@/utils/logger'
 import { resolveApiErrorMessage } from '@/utils/apiErrorMessage'
-import { setApiToken } from 'Orval'
 import auditSessionExpired from '@/utils/auditSessionExpired'
 import type { Config } from '../features/types/authTypes'
 import type { PutConfigMeta } from '../features/types/authSliceTypes'
@@ -29,7 +28,6 @@ import type { AppDispatch } from '../hooks'
 import { startAppListening } from './index'
 
 type Throwable = Error | ApiErrorLike | string | number | boolean | object | null | undefined
-type ApiTokenResult = { access_token?: string; scopes?: string[]; issuer?: string }
 
 const asApiError = (error: Throwable): ApiErrorLike => {
   if (error === null || error === undefined) return { message: String(error), response: undefined }
@@ -45,20 +43,9 @@ const asApiError = (error: Throwable): ApiErrorLike => {
 
 const getApiTokenWithDefaultScopes = async (dispatch: AppDispatch): Promise<string | null> => {
   try {
-    const response = (await fetchApiTokenWithDefaultScopes()) as ApiTokenResult
-    if (response?.access_token) {
-      return response.access_token
-    }
-    return null
-  } catch (error) {
-    const err = asApiError(error as Throwable)
-    dispatch(
-      setBackendStatus({
-        active: false,
-        errorMessage: err?.response?.data?.responseMessage ?? null,
-        statusCode: err?.response?.status ?? null,
-      }),
-    )
+    const response = await ensureApiToken(dispatch, { required: true })
+    return response?.access_token ?? null
+  } catch {
     return null
   }
 }
@@ -131,7 +118,7 @@ startAppListening({
   effect: async (action, { dispatch }) => {
     try {
       if (action.payload) {
-        const response = (await fetchApiTokenWithDefaultScopes()) as ApiTokenResult
+        const response = await ensureApiToken(dispatch, { required: true })
         if (response) {
           dispatch(
             getAPIAccessTokenResponse({
@@ -141,7 +128,6 @@ startAppListening({
           )
 
           if (response.access_token) {
-            setApiToken(response.access_token)
             dispatch(
               createAdminUiSession({
                 ujwt: action.payload,
@@ -149,7 +135,7 @@ startAppListening({
               }),
             )
           } else {
-            setApiToken(null)
+            clearApiToken()
             logger.error('Failed to obtain API token for session creation')
             dispatch(
               createAdminUiSessionResponse({ success: false, error: 'Failed to obtain API token' }),
@@ -158,7 +144,7 @@ startAppListening({
         }
       }
     } catch (error) {
-      setApiToken(null)
+      clearApiToken()
       const err = asApiError(error as Throwable)
       logger.error('Problems getting API Access Token:', resolveApiErrorMessage(err))
       dispatch(

--- a/admin-ui/app/redux/listeners/licenseListener.ts
+++ b/admin-ui/app/redux/listeners/licenseListener.ts
@@ -8,8 +8,7 @@ import {
   getStat,
 } from 'JansConfigApi'
 import type { GenericResponse, GetStatParams } from 'JansConfigApi'
-import { setApiToken } from 'Orval'
-import { getOAuth2Config, setApiDefaultToken, setBackendStatus } from '../features/authSlice'
+import { getOAuth2Config } from '../features/authSlice'
 import { handleSessionExpired } from '../features/initSlice'
 import {
   checkLicenseConfigValidResponse,
@@ -27,8 +26,7 @@ import {
   generateTrialLicense,
 } from '../features/licenseSlice'
 import type { SSARequestPayload } from 'Redux/api/types/LicenseApi'
-import type { ApiTokenResponse } from '../api/types/BackendApi'
-import { fetchApiTokenWithDefaultScopes } from '../api/backend-api'
+import { ensureApiToken } from '../api/apiToken'
 import type { MauEntry } from '../types'
 import { getYearMonth } from '../../utils/Util'
 import { logger } from '@/utils/logger'
@@ -36,16 +34,6 @@ import { resolveApiErrorMessage } from '@/utils/apiErrorMessage'
 import type { ApiErrorLike } from '../types/audit'
 import type { AppDispatch } from '../hooks'
 import { startAppListening } from './index'
-
-const getBackendStatusFromError = (error: Error | ApiErrorLike) => {
-  const err = error as ApiErrorLike
-  const statusCode = typeof err?.response?.status === 'number' ? err.response.status : null
-  const errorMessage =
-    err?.response?.data?.responseMessage ??
-    err?.response?.data?.message ??
-    (err instanceof Error ? err.message : error != null ? String(error) : 'Network error')
-  return { active: false as const, errorMessage, statusCode }
-}
 
 // An expired session fails these calls with an auth status. That is a sign-in problem, not a
 // broken SSA config, so it must not fall through to the branch that renders the SSA upload screen.
@@ -64,30 +52,8 @@ const getLicenseErrorMessage = (error: Error | ApiErrorLike): string => {
   return error instanceof Error ? error.message : String(error)
 }
 
-const getAccessToken = async (dispatch: AppDispatch): Promise<ApiTokenResponse> => {
-  try {
-    const token = (await fetchApiTokenWithDefaultScopes()) as ApiTokenResponse
-    dispatch(setApiDefaultToken(token))
-    dispatch(setBackendStatus({ active: true, errorMessage: null, statusCode: null }))
-    return token
-  } catch (error) {
-    logger.error(
-      'Failed to fetch API token with default scopes',
-      error instanceof Error ? error : String(error),
-    )
-    dispatch(setBackendStatus(getBackendStatusFromError(error as Error | ApiErrorLike)))
-    throw error
-  }
-}
-
-const setupApiToken = async (dispatch: AppDispatch): Promise<ApiTokenResponse> => {
-  const token = await getAccessToken(dispatch)
-  setApiToken(token.access_token)
-  return token
-}
-
 const checkMauThreshold = async (dispatch: AppDispatch, mau_threshold: number): Promise<void> => {
-  await setupApiToken(dispatch)
+  await ensureApiToken(dispatch)
   try {
     const data = (await getStat({
       month: getYearMonth(new Date()),
@@ -114,7 +80,7 @@ const checkMauThreshold = async (dispatch: AppDispatch, mau_threshold: number): 
 
 const retrieveLicenseKey = async (dispatch: AppDispatch): Promise<void> => {
   try {
-    await setupApiToken(dispatch)
+    await ensureApiToken(dispatch)
     const response = (await retrieveLicense()) as GenericResponse | null
     const responseObj = response?.responseObject
     const licenseKey =
@@ -159,7 +125,7 @@ const retrieveLicenseKey = async (dispatch: AppDispatch): Promise<void> => {
 
 const generateTrialLicenseKey = async (dispatch: AppDispatch): Promise<void> => {
   try {
-    await setupApiToken(dispatch)
+    await ensureApiToken(dispatch)
     const response = (await getTrialLicense()) as GenericResponse | null
 
     const responseObj = response?.responseObject
@@ -199,7 +165,7 @@ const uploadNewSsaTokenWorker = async (
   payload: SSARequestPayload,
 ): Promise<void> => {
   try {
-    const token = await setupApiToken(dispatch)
+    const token = await ensureApiToken(dispatch)
     const response = (await adminuiPostSsa(payload.payload)) as GenericResponse | null
     if (!response?.success) {
       dispatch(
@@ -209,7 +175,7 @@ const uploadNewSsaTokenWorker = async (
       )
     }
     dispatch(checkLicenseConfigValidResponse(response?.success ?? false))
-    dispatch(getOAuth2Config(token))
+    dispatch(getOAuth2Config(token ?? undefined))
   } catch (err) {
     dispatch(checkLicenseConfigValidResponse(false))
     logger.error('Error uploading SSA token:', err instanceof Error ? err : String(err))
@@ -219,8 +185,8 @@ const uploadNewSsaTokenWorker = async (
 
 const checkAdminuiLicenseConfigWorker = async (dispatch: AppDispatch): Promise<void> => {
   try {
-    const token = await setupApiToken(dispatch)
-    dispatch(getOAuth2Config(token))
+    const token = await ensureApiToken(dispatch)
+    dispatch(getOAuth2Config(token ?? undefined))
     const response = (await checkAdminuiLicenseConfigApi()) as GenericResponse | null
     dispatch(checkLicenseConfigValidResponse(response?.success ?? false))
   } catch (error) {
@@ -235,7 +201,7 @@ const checkAdminuiLicenseConfigWorker = async (dispatch: AppDispatch): Promise<v
 
 const checkLicensePresentWorker = async (dispatch: AppDispatch): Promise<void> => {
   try {
-    await setupApiToken(dispatch)
+    await ensureApiToken(dispatch)
     const response = (await isLicenseActive()) as GenericResponse | null
     if (!response?.success) {
       await retrieveLicenseKey(dispatch)

--- a/admin-ui/app/redux/listeners/sessionListener.ts
+++ b/admin-ui/app/redux/listeners/sessionListener.ts
@@ -1,6 +1,8 @@
 import { startAppListening } from './index'
 import { auditLogoutLogs } from '../features/sessionSlice'
+import { logoutUser } from '../features/logoutSlice'
 import { postUserAction } from '../api/backend-api'
+import { clearApiToken } from '../api/apiToken'
 import type { UserActionPayload } from '../api/types/BackendApi'
 import { addAdditionalData } from 'Utils/TokenController'
 import { CREATE } from '@/audit/UserActionType'
@@ -35,5 +37,12 @@ startAppListening({
     } catch (e) {
       logger.error('Error:', e instanceof Error ? e : String(e))
     }
+  },
+})
+
+startAppListening({
+  actionCreator: logoutUser,
+  effect: () => {
+    clearApiToken()
   },
 })

--- a/admin-ui/app/routes/Apps/Gluu/__tests__/GluuNavBar.test.tsx
+++ b/admin-ui/app/routes/Apps/Gluu/__tests__/GluuNavBar.test.tsx
@@ -16,7 +16,12 @@ const createTestStore = (userinfo: UserInfo | null): Store =>
   })
 
 jest.mock('@/utils/hooks/useCedarlingLogToggle', () => ({
-  useCedarlingLogToggle: () => ({ enabled: false, toggle: jest.fn(), isSaving: false }),
+  useCedarlingLogToggle: () => ({
+    enabled: false,
+    toggle: jest.fn(),
+    isSaving: false,
+    isConfigReady: true,
+  }),
 }))
 
 const renderNavBar = (userinfo: UserInfo | null) => {

--- a/admin-ui/app/routes/components/Dropdowns/DropdownProfile.tsx
+++ b/admin-ui/app/routes/components/Dropdowns/DropdownProfile.tsx
@@ -14,7 +14,11 @@ const DropdownProfile = ({ trigger, renderTrigger, position = 'bottom' }: Dropdo
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const { navigateToRoute } = useAppNavigation()
-  const { enabled: cedarLogsEnabled, toggle: toggleCedarLogs } = useCedarlingLogToggle()
+  const {
+    enabled: cedarLogsEnabled,
+    toggle: toggleCedarLogs,
+    isConfigReady: cedarLogsReady,
+  } = useCedarlingLogToggle()
 
   const handleLogout = useCallback(() => {
     dispatch(auditLogoutLogs({ message: MANUAL_LOGOUT }))
@@ -46,12 +50,14 @@ const DropdownProfile = ({ trigger, renderTrigger, position = 'bottom' }: Dropdo
             <Switch
               size="small"
               checked={cedarLogsEnabled}
+              disabled={!cedarLogsReady}
               slotProps={{ input: { 'aria-label': t('fields.cedarlingLogs?') } }}
             />
           </Box>
         ),
         searchValue: t('fields.cedarlingLogs?'),
         keepOpen: true,
+        disabled: !cedarLogsReady,
         onClick: () => {
           toggleCedarLogs()
         },
@@ -64,7 +70,7 @@ const DropdownProfile = ({ trigger, renderTrigger, position = 'bottom' }: Dropdo
         },
       },
     ],
-    [t, navigateToRoute, handleLogout, cedarLogsEnabled, toggleCedarLogs],
+    [t, navigateToRoute, handleLogout, cedarLogsEnabled, toggleCedarLogs, cedarLogsReady],
   )
 
   return (

--- a/admin-ui/app/routes/components/Dropdowns/MobileProfileDropdown.tsx
+++ b/admin-ui/app/routes/components/Dropdowns/MobileProfileDropdown.tsx
@@ -91,7 +91,11 @@ const MobileProfileDropdown = ({ userInfo, renderTrigger }: MobileProfileDropdow
 
   const onChangeTheme = useThemePersistence(userInfo)
 
-  const { enabled: cedarLogsEnabled, toggle: toggleCedarLogs } = useCedarlingLogToggle()
+  const {
+    enabled: cedarLogsEnabled,
+    toggle: toggleCedarLogs,
+    isConfigReady: cedarLogsReady,
+  } = useCedarlingLogToggle()
 
   const handleProfile = useCallback(() => {
     setIsOpen(false)
@@ -233,6 +237,7 @@ const MobileProfileDropdown = ({ userInfo, renderTrigger }: MobileProfileDropdow
               size="small"
               checked={cedarLogsEnabled}
               onChange={toggleCedarLogs}
+              disabled={!cedarLogsReady}
               slotProps={{ input: { 'aria-label': t('fields.cedarlingLogs?') } }}
             />
           </div>

--- a/admin-ui/app/routes/components/Dropdowns/__tests__/DropdownProfile.test.tsx
+++ b/admin-ui/app/routes/components/Dropdowns/__tests__/DropdownProfile.test.tsx
@@ -14,6 +14,7 @@ jest.mock('@/utils/hooks/useCedarlingLogToggle', () => ({
     enabled: false,
     toggle: mockToggleCedarLogs,
     isSaving: false,
+    isConfigReady: true,
   }),
 }))
 

--- a/admin-ui/app/routes/components/Dropdowns/__tests__/MobileProfileDropdown.test.tsx
+++ b/admin-ui/app/routes/components/Dropdowns/__tests__/MobileProfileDropdown.test.tsx
@@ -17,6 +17,7 @@ jest.mock('@/utils/hooks/useCedarlingLogToggle', () => ({
     enabled: false,
     toggle: mockToggleCedarLogs,
     isSaving: false,
+    isConfigReady: true,
   }),
 }))
 

--- a/admin-ui/app/utils/hooks/__tests__/useCedarlingLogToggle.test.tsx
+++ b/admin-ui/app/utils/hooks/__tests__/useCedarlingLogToggle.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { configureStore } from '@reduxjs/toolkit'
+import authReducer from '@/redux/features/authSlice'
+import type { Config } from '@/redux/features/types/authTypes'
+import { useCedarlingLogToggle } from '../useCedarlingLogToggle'
+
+type MutationHandlers = {
+  onSuccess: (config: Config) => void
+  onError: (error: Error) => void
+}
+type MutateArgs = [{ data: Config }, MutationHandlers]
+
+const mockMutate = jest.fn<void, MutateArgs>()
+let mockIsPending = false
+
+jest.mock('JansConfigApi', () => ({
+  useEditAdminuiConf: () => ({
+    mutate: (...args: MutateArgs) => mockMutate(...args),
+    isPending: mockIsPending,
+  }),
+}))
+
+jest.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }))
+
+const buildStore = (config: Config) => {
+  const store = configureStore({ reducer: { authReducer } })
+  store.dispatch({ type: 'auth/getOAuth2ConfigResponse', payload: { config } })
+  return store
+}
+
+const renderToggle = (config: Config) => {
+  const store = buildStore(config)
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </Provider>
+  )
+  return { store, ...renderHook(() => useCedarlingLogToggle(), { wrapper }) }
+}
+
+describe('useCedarlingLogToggle reads the config redux already holds', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsPending = false
+  })
+
+  it('reports enabled when the stored log type is std_out', () => {
+    const { result } = renderToggle({ cedarlingLogType: 'std_out' })
+
+    expect(result.current.enabled).toBe(true)
+  })
+
+  it('reports disabled when the stored log type is off', () => {
+    const { result } = renderToggle({ cedarlingLogType: 'off' })
+
+    expect(result.current.enabled).toBe(false)
+  })
+
+  it('sends the other stored config fields back with the toggled log type', () => {
+    const { result } = renderToggle({
+      cedarlingLogType: 'off',
+      sessionTimeoutInMins: 30,
+      acrValues: 'basic',
+      additionalParameters: [{ key: 'a', value: 'b' }],
+    })
+
+    act(() => result.current.toggle())
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      {
+        data: {
+          sessionTimeoutInMins: 30,
+          acrValues: 'basic',
+          additionalParameters: [{ key: 'a', value: 'b' }],
+          cedarlingLogType: 'std_out',
+        },
+      },
+      expect.anything(),
+    )
+  })
+
+  it('shows the new state optimistically before the request settles', () => {
+    const { result } = renderToggle({ cedarlingLogType: 'off' })
+
+    act(() => result.current.toggle())
+
+    expect(result.current.enabled).toBe(true)
+  })
+
+  it('writes the saved config back into redux on success', async () => {
+    const { result, store } = renderToggle({ cedarlingLogType: 'off' })
+
+    act(() => result.current.toggle())
+
+    const [, handlers] = mockMutate.mock.calls[0]
+    act(() => handlers.onSuccess({ cedarlingLogType: 'std_out' }))
+
+    await waitFor(() =>
+      expect(store.getState().authReducer.config.cedarlingLogType).toBe('std_out'),
+    )
+    expect(result.current.enabled).toBe(true)
+  })
+
+  it('rolls the optimistic state back when the request fails', () => {
+    const { result } = renderToggle({ cedarlingLogType: 'off' })
+
+    act(() => result.current.toggle())
+    const [, handlers] = mockMutate.mock.calls[0]
+    act(() => handlers.onError(new Error('save boom')))
+
+    expect(result.current.enabled).toBe(false)
+  })
+
+  it('ignores a toggle while a save is already in flight', () => {
+    mockIsPending = true
+    const { result } = renderToggle({ cedarlingLogType: 'off' })
+
+    act(() => result.current.toggle())
+
+    expect(mockMutate).not.toHaveBeenCalled()
+  })
+})

--- a/admin-ui/app/utils/hooks/__tests__/useCedarlingLogToggle.test.tsx
+++ b/admin-ui/app/utils/hooks/__tests__/useCedarlingLogToggle.test.tsx
@@ -25,13 +25,15 @@ jest.mock('JansConfigApi', () => ({
 
 jest.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }))
 
-const buildStore = (config: Config) => {
+const buildStore = (config?: Config) => {
   const store = configureStore({ reducer: { authReducer } })
-  store.dispatch({ type: 'auth/getOAuth2ConfigResponse', payload: { config } })
+  if (config) {
+    store.dispatch({ type: 'auth/getOAuth2ConfigResponse', payload: { config } })
+  }
   return store
 }
 
-const renderToggle = (config: Config) => {
+const renderToggle = (config?: Config) => {
   const store = buildStore(config)
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -122,5 +124,32 @@ describe('useCedarlingLogToggle reads the config redux already holds', () => {
     act(() => result.current.toggle())
 
     expect(mockMutate).not.toHaveBeenCalled()
+  })
+})
+
+describe('useCedarlingLogToggle before redux holds a config', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsPending = false
+  })
+
+  it('reports the config as not ready before getOAuth2Config has populated it', () => {
+    const { result } = renderToggle()
+
+    expect(result.current.isConfigReady).toBe(false)
+  })
+
+  it('does not submit a configuration write while the stored config is still empty', () => {
+    const { result } = renderToggle()
+
+    act(() => result.current.toggle())
+
+    expect(mockMutate).not.toHaveBeenCalled()
+  })
+
+  it('reports the config as ready once getOAuth2Config has populated it', () => {
+    const { result } = renderToggle({ cedarlingLogType: 'off' })
+
+    expect(result.current.isConfigReady).toBe(true)
   })
 })

--- a/admin-ui/app/utils/hooks/useCedarlingLogToggle.ts
+++ b/admin-ui/app/utils/hooks/useCedarlingLogToggle.ts
@@ -12,6 +12,7 @@ type UseCedarlingLogToggle = {
   enabled: boolean
   toggle: () => void
   isSaving: boolean
+  isConfigReady: boolean
 }
 
 export const useCedarlingLogToggle = (): UseCedarlingLogToggle => {
@@ -30,8 +31,10 @@ export const useCedarlingLogToggle = (): UseCedarlingLogToggle => {
 
   const enabled = optimisticEnabled ?? serverEnabled
 
+  const isConfigReady = Boolean(config && Object.keys(config).length > 0)
+
   const toggle = useCallback(() => {
-    if (editConfigMutation.isPending) return
+    if (!isConfigReady || editConfigMutation.isPending) return
 
     const nextEnabled = !enabled
 
@@ -65,7 +68,7 @@ export const useCedarlingLogToggle = (): UseCedarlingLogToggle => {
         },
       },
     )
-  }, [config, enabled, editConfigMutation, dispatch, t])
+  }, [config, enabled, isConfigReady, editConfigMutation, dispatch, t])
 
-  return { enabled, toggle, isSaving: editConfigMutation.isPending }
+  return { enabled, toggle, isSaving: editConfigMutation.isPending, isConfigReady }
 }

--- a/admin-ui/app/utils/hooks/useCedarlingLogToggle.ts
+++ b/admin-ui/app/utils/hooks/useCedarlingLogToggle.ts
@@ -1,13 +1,7 @@
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useQueryClient } from '@tanstack/react-query'
-import {
-  useGetAdminuiConf,
-  useEditAdminuiConf,
-  getGetAdminuiConfQueryKey,
-  type AppConfigResponse,
-} from 'JansConfigApi'
-import { useAppDispatch } from '@/redux/hooks'
+import { useEditAdminuiConf, type AppConfigResponse } from 'JansConfigApi'
+import { useAppDispatch, useAppSelector } from '@/redux/hooks'
 import { updateToast } from '@/redux/features/toastSlice'
 import { getOAuth2ConfigResponse } from '@/redux/features/authSlice'
 import type { Config } from '@/redux/features/types/authTypes'
@@ -23,9 +17,8 @@ type UseCedarlingLogToggle = {
 export const useCedarlingLogToggle = (): UseCedarlingLogToggle => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
-  const queryClient = useQueryClient()
 
-  const { data: config } = useGetAdminuiConf()
+  const config = useAppSelector((state) => state.authReducer.config) as AppConfigResponse
   const editConfigMutation = useEditAdminuiConf()
 
   const [optimisticEnabled, setOptimisticEnabled] = useState<boolean | null>(null)
@@ -55,9 +48,7 @@ export const useCedarlingLogToggle = (): UseCedarlingLogToggle => {
       { data: updatePayload },
       {
         onSuccess: (updatedConfig) => {
-          queryClient.setQueryData(getGetAdminuiConfQueryKey(), updatedConfig)
           setOptimisticEnabled(null)
-          queryClient.invalidateQueries({ queryKey: getGetAdminuiConfQueryKey() })
           dispatch(getOAuth2ConfigResponse({ config: updatedConfig as Config }))
           dispatch(updateToast(true, 'success', t('fields.reloginToViewCedarlingChanges')))
         },
@@ -74,7 +65,7 @@ export const useCedarlingLogToggle = (): UseCedarlingLogToggle => {
         },
       },
     )
-  }, [config, enabled, editConfigMutation, queryClient, dispatch, t])
+  }, [config, enabled, editConfigMutation, dispatch, t])
 
   return { enabled, toggle, isSaving: editConfigMutation.isPending }
 }

--- a/admin-ui/orval/interceptors.ts
+++ b/admin-ui/orval/interceptors.ts
@@ -1,6 +1,7 @@
 import { AxiosHeaders } from 'axios'
-import { AXIOS_INSTANCE, setApiToken, getApiToken } from './axiosInstance'
-import { fetchApiTokenWithDefaultScopes, createAdminUiSession } from '@/redux/api/backend-api'
+import { AXIOS_INSTANCE, getApiToken } from './axiosInstance'
+import { createAdminUiSession } from '@/redux/api/backend-api'
+import { clearApiToken, ensureApiToken } from '@/redux/api/apiToken'
 import { auditLogoutLogs } from '@/redux/features/sessionSlice'
 import { SESSION_EXPIRED } from '@/audit/messages'
 import { logger } from '@/utils/logger'
@@ -38,14 +39,13 @@ export const installInterceptors = (getState: () => RootState, dispatch: AppDisp
     if (!sessionRecoveryPromise) {
       sessionRecoveryPromise = (async () => {
         try {
-          const response = await fetchApiTokenWithDefaultScopes()
+          const response = await ensureApiToken(dispatch, { force: true, required: true })
           const apiProtectionToken = response?.access_token
           if (!apiProtectionToken) {
             return false
           }
 
           await createAdminUiSession(userJwt, apiProtectionToken)
-          setApiToken(apiProtectionToken)
           return true
         } catch (error) {
           logger.error(
@@ -97,6 +97,7 @@ export const installInterceptors = (getState: () => RootState, dispatch: AppDisp
         !originalRequest._sessionRetryAttempted
       ) {
         originalRequest._sessionRetryAttempted = true
+        clearApiToken()
 
         const sessionRecovered = await recoverAdminUiSession()
         if (sessionRecovered) {

--- a/admin-ui/plugins/auth-server/components/ConfigApiProperties/types/configApiTypes.ts
+++ b/admin-ui/plugins/auth-server/components/ConfigApiProperties/types/configApiTypes.ts
@@ -1,6 +1,6 @@
 import type { JsonPatch } from 'JansConfigApi'
 
-export type CorsConfigurationFilter = {
+type CorsConfigurationFilter = {
   filterName?: string | null
   corsEnabled?: boolean | null
   corsAllowedOrigins?: string | null
@@ -11,17 +11,17 @@ export type CorsConfigurationFilter = {
   corsRequestDecorate?: boolean | null
 }
 
-export type AgamaConfiguration = {
+type AgamaConfiguration = {
   mandatoryAttributes?: string[] | null
   optionalAttributes?: string[] | null
 }
 
-export type AuditLogIgnoreObjectMapping = {
+type AuditLogIgnoreObjectMapping = {
   name: string
   text?: string[]
 }
 
-export type AuditLogConf = {
+type AuditLogConf = {
   enabled?: boolean | null
   logData?: boolean | null
   ignoreHttpMethod?: string[] | null
@@ -33,25 +33,25 @@ export type AuditLogConf = {
   auditLogDateFormat?: string | null
 }
 
-export type DataFormatConversionConf = {
+type DataFormatConversionConf = {
   enabled?: boolean | null
   ignoreHttpMethod?: string[] | null
 }
 
-export type Plugin = {
+type Plugin = {
   name?: string | null
   description?: string | null
   className?: string | null
 }
 
-export type AssetDirMapping = {
+type AssetDirMapping = {
   directory?: string | null
   type?: string[] | null
   description?: string | null
   jansServiceModule?: string[] | null
 }
 
-export type AssetMgtConfiguration = {
+type AssetMgtConfiguration = {
   assetMgtEnabled?: boolean | null
   assetServerUploadEnabled?: boolean | null
   fileExtensionValidationEnabled?: boolean | null
@@ -97,13 +97,11 @@ export type ApiAppConfiguration = {
 
 export type { JsonPatch }
 
-export type PatchConfigApiPropertiesData = JsonPatch[]
-
 export type ConfigApiAuditPayload = {
   requestBody: JsonPatch[]
 }
 
-export type ModifiedFieldsValue =
+type ModifiedFieldsValue =
   | string
   | number
   | boolean

--- a/admin-ui/plugins/auth-server/components/Keys/types/jwkTypes.ts
+++ b/admin-ui/plugins/auth-server/components/Keys/types/jwkTypes.ts
@@ -1,9 +1,9 @@
 import type { JSONWebKey, WebKeysConfiguration } from 'JansConfigApi'
 
 // Re-export orval types for convenience
-export type { JSONWebKey, WebKeysConfiguration }
+export type { JSONWebKey }
 
-export type JwkItemProps = {
+type JwkItemProps = {
   item: JSONWebKey
   index: number
 }

--- a/admin-ui/plugins/fido/components/Configuration/index.ts
+++ b/admin-ui/plugins/fido/components/Configuration/index.ts
@@ -1,4 +1,1 @@
 export { default } from './Fido'
-export { default as Fido } from './Fido'
-export { default as StaticConfiguration } from './components/StaticConfiguration'
-export { default as DynamicConfiguration } from './components/DynamicConfiguration'


### PR DESCRIPTION
### fix(admin-ui): prevent duplicate Config API requests on login (#3017)

#### Summary

- Prevented duplicate Config API requests during Admin UI login.
- Ensured the API protection token and Admin UI config are requested only once per login session.

---

#### Fix Summary

- Removed the duplicate `POST /app/admin-ui/oauth2/api-protection-token` request.
- Removed the duplicate `GET /admin-ui/config` request.
- Ensured the existing session cookie is reused instead of minting an unnecessary duplicate credential.
- Reduced unnecessary Config API traffic and login overhead.

---

#### Verification

- Verified a single Admin UI login sends only one `api-protection-token` request.
- Verified a single Admin UI login sends only one `/admin-ui/config` request.
- Verified no duplicate Config API requests are triggered during login.

---

#### 🔗 Ticket

Closes: #3017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved API protection token management with caching, renewal near expiry, forced refresh, and concurrent-request handling.
  - API tokens are now cleared on logout and refreshed automatically during session recovery.
  - Cedarling log settings now stay synchronized with application state while preserving unrelated configuration.

- **Bug Fixes**
  - Improved handling of token failures and unauthorized requests.
  - Prevented outdated configuration data from being used when toggling Cedarling logging.

- **Tests**
  - Added coverage for token caching, expiration, recovery, logout, and Cedarling setting updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->